### PR TITLE
fix: preempt in-flight turn when a new prompt arrives without cancel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        # version is read from packageManager in package.json via corepack
+        with:
+          version: 10
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -281,6 +281,12 @@ export async function prompt(
   const intercepted = await handleSlashCommand(server, cx, params.sessionId, zcodeSid, text);
   if (intercepted) return intercepted;
 
+  // Preempt: if another turn is still running for this session (client sent a
+  // new prompt without cancelling), stop it and wait for it to fully exit
+  // before we subscribe/send. Without this, session/send hits the backend
+  // prompt-lock and the error path kills the old turn but loses the new msg.
+  await preemptInFlightTurn(server, zcodeSid, requestId);
+
   // Register the pending turn. This same object is mutated by cancel(); the
   // turn loop checks `.cancelled` on the SAME reference, so cancel propagates.
   const turn: PendingTurn = {
@@ -462,6 +468,55 @@ async function ensureTurnStopped(server: ZcodeAcpServer, zcodeSid: string): Prom
   }
   log(`  [stop] lock wait timed out (30s), lock may still be held`);
   return false;
+}
+
+/**
+ * If another prompt() is already running for this zcodeSid, treat the new
+ * prompt as an implicit cancel: stop the in-flight turn and wait for it to
+ * fully exit (lock released + listener unregistered + pendingTurns cleaned)
+ * before the new prompt subscribes and sends.
+ *
+ * Why wait for the map entry to disappear (not just the lock): registering
+ * a second EventStreamListener overwrites the first (Map.set in client.ts),
+ * so the old turn loop must have run its finally block before we subscribe.
+ * The map cleanup in that finally block is the synchronization point.
+ *
+ * Best-effort: never throws. On timeout, continues anyway — session/send
+ * will then hit the lock and take the existing error path.
+ */
+async function preemptInFlightTurn(
+  server: ZcodeAcpServer,
+  zcodeSid: string,
+  selfRequestId: number,
+): Promise<void> {
+  // Find any in-flight turn for this session that isn't this request.
+  let oldRequestId: number | undefined;
+  for (const [reqId, turn] of server.pendingTurns) {
+    if (turn.zcodeSid === zcodeSid && reqId !== selfRequestId) {
+      oldRequestId = reqId;
+      turn.cancelled = true; // signal the old turn loop to exit
+      break;
+    }
+  }
+  if (oldRequestId === undefined) return; // no in-flight turn, proceed
+
+  log(`  [preempt] in-flight turn ${oldRequestId} found, stopping it`);
+  // Stop the backend turn and wait for the prompt lock to release.
+  await ensureTurnStopped(server, zcodeSid);
+
+  // Wait for the old turn's prompt() to fully exit (its finally block deletes
+  // the pendingTurns entry). This is the synchronization point that guarantees
+  // its listener is unregistered before we register ours.
+  const PREEMPT_TIMEOUT_MS = 35_000; // slightly longer than ensureTurnStopped's 30s
+  const t0 = Date.now();
+  while (server.pendingTurns.has(oldRequestId)) {
+    if (Date.now() - t0 > PREEMPT_TIMEOUT_MS) {
+      log(`  [preempt] timed out waiting for old turn ${oldRequestId} to exit`);
+      return; // best-effort: continue anyway, session/send may fail
+    }
+    await sleep(200);
+  }
+  log(`  [preempt] old turn ${oldRequestId} exited, proceeding`);
 }
 
 // ---------- internals ----------


### PR DESCRIPTION
## Summary

Fixes a bug where sending a new message while a turn is still running (without pressing stop first) failed with "A prompt is already running", killing the old turn and losing the new message. Also fixes the CI pnpm setup that broke after the `packageManager` field was removed.

## Problem

**Scenario:** A turn is running (prompt-lock held). The user sends a new message directly, without pressing stop. The client issues a new `session/prompt` request.

**Root cause:** `prompt()` had no check for an in-flight turn on the same session. It went straight to `session/send`, which the backend rejected (`code 1308`, "prompt is running"). The error path then called `ensureTurnStopped`, which killed the running turn, and threw — so the old turn was interrupted AND the new message was lost. Worst-case outcome.

The ACP protocol does not define "new prompt preempts old prompt" (the defined interrupt primitive is `session/cancel`). But a robust server should treat this client behavior as an implicit cancel + new prompt, not reject it.

## Fix

Add a `preemptInFlightTurn` step at the `prompt()` entry (after slash interception, before registering the pending turn):

1. Scan `pendingTurns` for an in-flight turn matching the same `zcodeSid` (excluding self).
2. If found, mark `oldTurn.cancelled = true` (same propagation mechanism as `cancel()`).
3. Call `ensureTurnStopped` to stop the backend turn and wait for the prompt-lock to release.
4. **Poll until the old `PendingTurn` is removed from the map** — this is the synchronization point that guarantees the old turn's `finally` block has run (listener unregistered), so the new turn can safely subscribe without the listener being overwritten (`registerEventListener` uses `Map.set`).
5. Best-effort, never throws: 35s timeout, continues anyway if the old turn is stuck (in which case `session/send` will hit the lock and take the existing error path).

### Why wait for the map entry (not just the lock)

Registering a second `EventStreamListener` overwrites the first (`Map.set` in `client.ts`). If the new prompt subscribed before the old loop ran its `finally` block, the old loop would block forever and the new loop would steal its events. The `pendingTurns.delete` in the old loop's `finally` is the synchronization point.

## CI fix

The previous PR removed the `packageManager` field from `package.json`. CI's `pnpm/action-setup@v4` read the version from that field, so builds broke with `No pnpm version is specified`.

Fix: pin `version: 10` (a major-version