### PR TITLE
fix: send only stdout delta in Bash terminal output to prevent replay

### DIFF
--- a/src/handlers/dispatch.ts
+++ b/src/handlers/dispatch.ts
@@ -132,31 +132,46 @@ function dispatchToolCallUpdate(
  * and the Python bridge's _dispatch_event). Zed correlates by terminal_id, so
  * the two notifications MUST be separate:
  *   ① terminal_output — pure data, no status/content. Sent on BOTH progress and
- *      result states (whenever there's data) so live output streams.
+ *      result states (whenever there's NEW data) so live output streams.
  *   ② terminal_exit — terminal state only: status + content[type:terminal] +
  *      _meta.terminal_exit (with exitCode) + rawOutput text fallback. Sent ONLY
  *      on completed/failed.
  *
  * Merging them into one notification causes Zed to clear the content once the
  * turn completes (the original bug); splitting keeps the output visible.
+ *
+ * DELTA DEDUP: zcode's `stdoutTail`/result `content` is a *snapshot* of the
+ * accumulated stdout tail, but ACP `terminal_output.data` is *append* semantics
+ * — each value is written to the terminal as new bytes. Without dedup, every
+ * progress event replays the whole tail, and the result event replays it again,
+ * so long-running commands show their output N times. We track the last-sent
+ * snapshot per callId and emit only the suffix beyond it.
  */
 async function dispatchTerminalUpdate(
-  _server: ZcodeAcpServer,
+  server: ZcodeAcpServer,
   cx: acp.AgentContext,
   acpSid: string,
   ev: Extract<InternalEvent, { kind: "ToolCallUpdate" }>,
   toolName: string,
 ): Promise<void> {
-  // ① terminal_output (pure data) — progress and result both emit it.
+  // ① terminal_output (pure data, append semantics) — progress and result both
+  //    emit it, but only the delta beyond the last-sent snapshot.
   let termData: unknown = ev.rawOutput ?? ev.rawResult;
   if (termData && typeof termData === "object" && !Array.isArray(termData)) {
     termData = (termData as Record<string, unknown>)["content"] ?? "";
   }
-  if (termData) {
+  const full = termData ? String(termData) : "";
+  const lastSent = server.terminalSentData.get(ev.callId) ?? "";
+  // Only the suffix past the previously-sent snapshot is new output. Guard
+  // against a non-monotonic snapshot (tail rotated) by falling back to the full
+  // value when the previous snapshot isn't a prefix of the current one.
+  const delta = lastSent && full.startsWith(lastSent) ? full.slice(lastSent.length) : full;
+  if (delta) {
+    server.terminalSentData.set(ev.callId, full);
     await sendSessionUpdate(cx, acpSid, {
       sessionUpdate: "tool_call_update",
       toolCallId: ev.callId,
-      _meta: { terminal_output: { terminal_id: ev.callId, data: String(termData) } },
+      _meta: { terminal_output: { terminal_id: ev.callId, data: delta } },
     });
   }
 
@@ -174,8 +189,14 @@ async function dispatchTerminalUpdate(
       },
     };
     // rawOutput gives Zed a text fallback outside the terminal render path.
+    // This carries the FULL output (not the delta) so a non-terminal render
+    // fallback shows everything once; the terminal_output stream already
+    // appended it above via the dedup delta.
     if (ev.output !== undefined) exitUpdate.rawOutput = ev.output;
     await sendSessionUpdate(cx, acpSid, exitUpdate);
+    // Terminal session ended — clear the snapshot so a future tool reusing this
+    // callId (shouldn't happen, but defensively) starts fresh.
+    server.terminalSentData.delete(ev.callId);
   }
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -65,6 +65,14 @@ export class ZcodeAcpServer {
   >();
   /** Per-session model cache for configOptions model dropdown. */
   readonly modelCache = new Map<string, string>();
+  /**
+   * Per-Bash-callId cumulative stdout snapshot already streamed via
+   * terminal_output. zcode's `stdoutTail` is a *snapshot* of the tail of the
+   * accumulated stdout, but ACP `terminal_output.data` is *append* semantics —
+   * so we must diff each new snapshot against the last-sent one and emit only
+   * the suffix to avoid replaying the whole output on every progress event.
+   */
+  readonly terminalSentData = new Map<string, string>();
   /** Monotonic id counter; base 10_000_000 to avoid collisions with zcode-originated ids. */
   private msgCounter = 10_000_000;
 

--- a/tests/dispatch.test.ts
+++ b/tests/dispatch.test.ts
@@ -101,7 +101,35 @@ describe("dispatchEvent", () => {
     expect((sent[0] as { status?: string }).status).toBeUndefined();
   });
 
-  it("Bash completed emits 2 notifications: terminal_output + terminal_exit", async () => {
+  it("Bash progress emits only the delta between cumulative stdout snapshots", async () => {
+    // zcode sends stdoutTail as a CUMULATIVE tail snapshot on every progress
+    // event. terminal_output.data is append semantics, so the bridge must diff
+    // consecutive snapshots and emit only the suffix — otherwise long-running
+    // commands show their output N times.
+    const { cx, sent } = mockContext();
+    const server = makeServer(true);
+    const base: Partial<Extract<InternalEvent, { kind: "ToolCallUpdate" }>> = {
+      kind: "ToolCallUpdate",
+      callId: "c1",
+      tool: "Bash",
+      status: "in_progress",
+    };
+    await dispatchEvent(server, cx, SID, { ...base, rawOutput: "line1\n" }, CHUNK);
+    await dispatchEvent(server, cx, SID, { ...base, rawOutput: "line1\nline2\n" }, CHUNK);
+    await dispatchEvent(server, cx, SID, { ...base, rawOutput: "line1\nline2\nline3\n" }, CHUNK);
+    expect(sent).toHaveLength(3);
+    expect(sent[0]).toMatchObject({
+      _meta: { terminal_output: { terminal_id: "c1", data: "line1\n" } },
+    });
+    expect(sent[1]).toMatchObject({
+      _meta: { terminal_output: { terminal_id: "c1", data: "line2\n" } },
+    });
+    expect(sent[2]).toMatchObject({
+      _meta: { terminal_output: { terminal_id: "c1", data: "line3\n" } },
+    });
+  });
+
+  it("Bash completed emits 2 notifications: terminal_output delta + terminal_exit", async () => {
     const { cx, sent } = mockContext();
     const server = makeServer(true);
     const ev: InternalEvent = {
@@ -131,6 +159,47 @@ describe("dispatchEvent", () => {
       },
       rawOutput: "done",
     });
+  });
+
+  it("Bash result after streamed progress emits only the unsent tail", async () => {
+    // Progress already streamed "line1\nline2\n"; the result carries the full
+    // "line1\nline2\nline3\n". Only "line3\n" should be appended.
+    const { cx, sent } = mockContext();
+    const server = makeServer(true);
+    const base: Partial<Extract<InternalEvent, { kind: "ToolCallUpdate" }>> = {
+      kind: "ToolCallUpdate",
+      callId: "c1",
+      tool: "Bash",
+    };
+    await dispatchEvent(
+      server,
+      cx,
+      SID,
+      { ...base, status: "in_progress", rawOutput: "line1\nline2\n" },
+      CHUNK,
+    );
+    await dispatchEvent(
+      server,
+      cx,
+      SID,
+      {
+        ...base,
+        status: "completed",
+        rawOutput: "line1\nline2\nline3\n",
+        output: "line1\nline2\nline3\n",
+        rawResult: { success: true, content: "line1\nline2\nline3\n", perf: { exitCode: 0 } },
+      },
+      CHUNK,
+    );
+    // progress (1) + terminal_output delta (1) + terminal_exit (1)
+    expect(sent).toHaveLength(3);
+    expect(sent[0]).toMatchObject({
+      _meta: { terminal_output: { data: "line1\nline2\n" } },
+    });
+    expect(sent[1]).toMatchObject({
+      _meta: { terminal_output: { data: "line3\n" } },
+    });
+    expect(sent[2]).toMatchObject({ status: "completed" });
   });
 
   it("Bash failed extracts exit code 1 when no perf.exitCode", async () => {


### PR DESCRIPTION
## Problem

Long-running Bash commands display duplicated output. The longer the command runs, the worse the duplication.

Root cause is a semantic mismatch:
- zcode's `stdoutTail` (progress events) and result `content` are **cumulative snapshots** — each carries the full tail of stdout so far.
- ACP's `terminal_output.data` is **append semantics** — the client writes each value as new bytes to the terminal.

`dispatchTerminalUpdate` passed the full snapshot into `data` every time, so N progress events replayed the output N times, and the final result event appended it once more.

## Fix

Add `terminalSentData: Map<callId, string>` on `ZcodeAcpServer` to track the last-sent snapshot per Bash call. `dispatchTerminalUpdate` now:
1. Diffs the new snapshot against the last-sent one and emits only the suffix delta (`full.slice(lastSent.length)`)
2. Falls back to full output when the snapshot isn't monotonic (tail rotation / prefix mismatch) to avoid data loss
3. Clears the callId entry on completed/failed

## Test

- Added regression tests: repeated cumulative snapshots emit only deltas; result after progress emits only the unsent tail
- All 154 tests pass
`