### PR TITLE
feat: sync sub-agent and background task events to ACP client

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -161,6 +161,7 @@ API only because the ZCode backend itself sends them for inference.
 | `session.ts`         | session/new/list/resume/load/prompt/set_config_option/cancel                                                 |
 | `extensions.ts`      | fork/rewind/rewindCascade/goal/compact/steer/cancelBackgroundTask/setModel/setMode/setThoughtLevel           |
 | `dispatch.ts`        | dispatchEvent single exit point: InternalEvent → ACP session/update                                          |
+| `background-tasks.ts` | Session-scoped `BackgroundTaskListener` — forwards background sub-agent status (`session.updated` taskId) + completion-notification turns to the client OUTSIDE request handlers (lives across prompts) |
 | `server-requests.ts` | Handle zcode interaction/* requests (tool auth, ExitPlanMode, AskUserQuestion), protocol negotiation routing |
 | `io.ts`              | ACP notification helpers (including `sendAvailableCommandsDeferred` deferred notification)                   |
 | `slash.ts`           | Interception of `/`-prefixed commands (/compact /goal /fork /rewind /steer /model /mode /thought)            |

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -640,7 +640,105 @@ Set the thought level.
 }
 ```
 
-## Version Compatibility
+## Background Tasks & Sub-Agents
+
+When the model dispatches a sub-agent via the `Agent` (or `Task`) tool, the
+backend keeps producing events on the **same session stream** — both while the
+sub-agent runs and after the main turn ends. The bridge forwards a curated
+subset to the ACP client:
+
+### Synchronous sub-agent (blocking)
+
+The `Agent` tool blocks until the sub-agent finishes. Its internal tool calls
+(`Read`, `Bash`, …) arrive as ordinary `tool.updated` events on the main stream
+and are forwarded as regular `tool_call` cards. The `Agent` card itself carries
+structured metadata in `_meta.subagent` (parsed from the result content):
+
+```json
+{
+  "sessionUpdate": "tool_call_update",
+  "toolCallId": "call_xxx",
+  "status": "completed",
+  "_meta": {
+    "claudeCode": { "toolName": "Agent" },
+    "subagent": {
+      "agentId": "agent_73c7c63d-...",
+      "tokens": 40904,
+      "toolUses": 1,
+      "durationMs": 10559
+    }
+  }
+}
+```
+
+### Background sub-agent (`run_in_background: true`)
+
+The `Agent` tool returns immediately with a launch acknowledgement (result
+content contains `agentId` + `output_file` + "working in the background"). The
+main turn then completes, but the backend continues to push the task's
+lifecycle on the same stream:
+
+**1. Status changes** — `session.updated` carries a `taskId` and `status`:
+
+```json
+{
+  "method": "session/event",
+  "params": {
+    "sessionId": "sess_abc123",
+    "seq": 16,
+    "type": "session.updated",
+    "payload": {
+      "taskId": "agent_88a44529-...",
+      "toolCallId": "call_orig",
+      "toolName": "Agent",
+      "status": "running",
+      "description": "Read README first heading",
+      "outputPath": "/.../output.txt",
+      "terminalId": "agent_88a44529-...",
+      "startedAt": "2026-07-18T09:06:45.929Z"
+    }
+  }
+}
+```
+
+The bridge's session-scoped `BackgroundTaskListener` turns these into a
+dedicated ACP tool card (`[background] <description>`) plus status updates:
+
+| Backend event | ACP notification |
+|---|---|
+| first `session.updated` (status `running`) | `tool_call` (new card, `kind:"other"`, `status:"in_progress"`) |
+| `session.updated` (status `completed`) | `tool_call_update` (`status:"completed"`) |
+
+`session.updated` events WITHOUT a `taskId` (e.g. usage updates) are ignored by
+the background listener — they remain owned by the turn loop.
+
+**2. Completion notification turn** — when the background task finishes, the
+backend auto-triggers a new turn whose `turn.started` carries
+`inputSource:"background_task"`:
+
+```json
+{
+  "type": "turn.started",
+  "payload": {
+    "inputSource": "background_task",
+    "inputVisibility": "model-only",
+    "input": "<task-notification>\n  <task-id>agent_...</task-id>\n  <status>completed</status-status>\n  ...\n</task-notification>",
+    "turnId": "turn_95197b25-..."
+  }
+}
+```
+
+The background listener forwards that turn's `model.streaming text_delta` as
+`agent_message_chunk` so the user sees the background result. The per-prompt
+turn loop **defers** this entire turn (drops its events) to avoid double-
+forwarding and to keep it from prematurely ending the user's real turn.
+
+### `session/cancelBackgroundTask`
+
+Cancels a background task. The bridge additionally marks the corresponding ACP
+tool card as `failed` with `_meta.backgroundTask.cancelled = true`.
+
+
 
 | ZCode CLI version | session/subscribe | Extension methods | Notes |
 |---------------|-------------------|----------|------|

--- a/src/backend/client.ts
+++ b/src/backend/client.ts
@@ -51,7 +51,10 @@ export class ZcodeBackend {
   readonly proc: ChildProcess;
   private readonly pending = new Map<number, PendingRequest>();
   private readonly serverRequests: ServerRequest[] = [];
-  private readonly listeners = new Map<string, EventListener>();
+  // Per-session listener SET so a long-lived session listener (e.g. background
+  // task monitor) can coexist with a per-turn EventStreamListener. Each event
+  // is delivered to every registered listener for the session.
+  private readonly listeners = new Map<string, Set<EventListener>>();
   private readerDead = false;
   /** Monotonic id for fire-and-forget sends (send()). Uses a high range to
    *  avoid collisions with the server's request ids (low range). */
@@ -172,8 +175,20 @@ export class ZcodeBackend {
       if (method === "session/event") {
         const ev = (msg.params ?? {}) as unknown as ZcodeEvent;
         const sid = ev.sessionId;
-        const listener = sid ? this.listeners.get(sid) : undefined;
-        listener?.handleEvent(ev);
+        const set = sid ? this.listeners.get(sid) : undefined;
+        if (set) {
+          // Iterate a snapshot so a listener that (un)registers during dispatch
+          // doesn't mutate the set under us.
+          for (const listener of [...set]) {
+            try {
+              listener.handleEvent(ev);
+            } catch (e) {
+              warn(
+                `backend: listener.handleEvent threw: ${e instanceof Error ? e.message : String(e)}`,
+              );
+            }
+          }
+        }
       }
       // Other notifications are currently ignored (state.updated, etc.).
     }
@@ -204,11 +219,19 @@ export class ZcodeBackend {
   // ---------- listeners / server requests ----------
 
   registerEventListener(zcodeSid: string, listener: EventListener): void {
-    this.listeners.set(zcodeSid, listener);
+    let set = this.listeners.get(zcodeSid);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(zcodeSid, set);
+    }
+    set.add(listener);
   }
 
-  unregisterEventListener(zcodeSid: string): void {
-    this.listeners.delete(zcodeSid);
+  unregisterEventListener(zcodeSid: string, listener: EventListener): void {
+    const set = this.listeners.get(zcodeSid);
+    if (!set) return;
+    set.delete(listener);
+    if (set.size === 0) this.listeners.delete(zcodeSid);
   }
 
   /** Non-blocking drain of pending server→client requests. */

--- a/src/handlers/background-tasks.ts
+++ b/src/handlers/background-tasks.ts
@@ -1,0 +1,234 @@
+/**
+ * Session-scoped background-task listener.
+ *
+ * Background sub-agents (the Agent/Task tool launched with `run_in_background:
+ * true`) keep producing events AFTER `session/prompt` has returned: their
+ * internal tool calls stream as `tool.updated`, and when they finish the
+ * backend auto-triggers a notification turn (`turn.started` with
+ * `inputSource:"background_task"`) whose `text_delta` carries the result.
+ *
+ * The per-prompt turn loop (`runEventTurn`) exits at `turn.completed` and
+ * unregisters its listener, so without this module ALL of those post-turn
+ * events are silently dropped — the user sees "background task launched" and
+ * then nothing.
+ *
+ * This listener is registered once per session (lives across prompts) and
+ * forwards a curated subset to the ACP client as out-of-band `session/update`
+ * notifications:
+ *
+ *   - `session.updated` carrying `taskId`  → background task status change.
+ *     First sighting emits a fresh `tool_call` card (`[background] …`);
+ *     subsequent sightings emit `tool_call_update` with the new status.
+ *   - `turn.started` with `inputSource:"background_task"` → marks the start
+ *     of a notification turn; its `model.streaming text_delta` is forwarded
+ *     as `agent_message_chunk` so the user sees the background result.
+ *
+ * Everything else is ignored — the turn loop handles normal turns and normal
+ * tool calls. Per the design decision, background agents' INTERNAL tool calls
+ * are NOT expanded here (only the task-level card + the final result message).
+ *
+ * All work is best-effort: failures are logged via `warn()` and never thrown
+ * into the event loop (would crash the bridge, per AGENTS.md).
+ */
+
+import { randomUUID } from "node:crypto";
+
+import type { EventListener } from "../backend/client.js";
+import type { ZcodeEvent } from "../backend/types.js";
+import { log, warn } from "../utils.js";
+import type { ZcodeAcpServer } from "../server.js";
+
+/** Shape of a `session.updated` payload that reports a background task state. */
+interface TaskStatusPayload {
+  taskId: string;
+  toolCallId?: string;
+  toolName?: string;
+  status?: string;
+  description?: string;
+  cancellable?: boolean;
+  outputPath?: string;
+  terminalId?: string;
+  startedAt?: string;
+  completedAt?: string;
+}
+
+/** Tracked background task → the ACP tool_call_id we address its updates with. */
+interface TrackedTask {
+  /** ACP tool_call_id for this task's card. Prefixed so it can't collide with real tool call ids. */
+  acpCallId: string;
+  /** Description shown in the card title (from the launch `session.updated`). */
+  description: string;
+  /** Last status we advertised to the client (to skip no-op updates). */
+  lastStatus: string;
+  /** messageId for the background-result message stream (allocated lazily). */
+  messageId?: string;
+}
+
+/** Map a zcode background task status string to an ACP ToolCallStatus. */
+function toAcpStatus(status: string | undefined): "in_progress" | "completed" | "failed" {
+  if (status === "completed") return "completed";
+  if (status === "failed" || status === "error" || status === "cancelled") return "failed";
+  return "in_progress"; // running / pending / unknown
+}
+
+/** Build the card title for a background task. */
+function cardTitle(description: string | undefined): string {
+  const d = (description ?? "").trim();
+  return d ? `[background] ${d}` : "[background] task";
+}
+
+export class BackgroundTaskListener implements EventListener {
+  private readonly server: ZcodeAcpServer;
+  readonly zcodeSid: string;
+  /** taskId → tracked state. */
+  private readonly tasks = new Map<string, TrackedTask>();
+  /**
+   * The turnId of the currently-active background notification turn, if any.
+   * While set, that turn's `model.streaming text_delta` events are forwarded
+   * to the client as `agent_message_chunk`.
+   */
+  private activeNotifyTurnId: string | null = null;
+
+  constructor(server: ZcodeAcpServer, zcodeSid: string) {
+    this.server = server;
+    this.zcodeSid = zcodeSid;
+  }
+
+  handleEvent(event: ZcodeEvent): void {
+    try {
+      if (event.type === "session.updated") {
+        const raw = event.payload as Partial<TaskStatusPayload> | undefined;
+        if (raw && typeof raw.taskId === "string" && raw.taskId) {
+          // taskId is verified string above; cast to the full shape (other
+          // fields are optional and read defensively inside onTaskStatus).
+          void this.onTaskStatus(raw as TaskStatusPayload);
+        }
+        return;
+      }
+      if (event.type === "turn.started") {
+        const inputSource = event.payload?.["inputSource"];
+        const turnId = (event.payload?.["turnId"] as string | undefined) ?? "";
+        if (inputSource === "background_task") {
+          this.activeNotifyTurnId = turnId || null;
+          if (this.activeNotifyTurnId) {
+            log(`  [bg] background notification turn started (${turnId.slice(-8)})`);
+          }
+        }
+        return;
+      }
+      // Inside an active background notification turn → forward text deltas.
+      if (this.activeNotifyTurnId) {
+        if (event.type === "model.streaming") {
+          const kind = event.payload?.["kind"];
+          if (kind === "text_delta") {
+            const delta = (event.payload?.["delta"] as string | undefined) ?? "";
+            if (delta) void this.forwardText(delta);
+          }
+          return;
+        }
+        if (event.type === "turn.completed" || event.type === "turn.failed") {
+          log(`  [bg] background notification turn ended (${event.type})`);
+          this.activeNotifyTurnId = null;
+          return;
+        }
+      }
+    } catch (e) {
+      warn(
+        `BackgroundTaskListener: event handling failed: ${
+          e instanceof Error ? e.message : String(e)
+        }`,
+      );
+    }
+  }
+
+  /** Handle a `session.updated` carrying a background task status. */
+  private async onTaskStatus(p: TaskStatusPayload): Promise<void> {
+    const taskId = p.taskId;
+    const status = p.status ?? "running";
+    const acpStatus = toAcpStatus(status);
+    let task = this.tasks.get(taskId);
+    if (!task) {
+      // First sighting → emit a fresh tool_call card.
+      task = {
+        acpCallId: `bg_${randomUUID().slice(0, 12)}`,
+        description: p.description ?? "",
+        lastStatus: "",
+      };
+      this.tasks.set(taskId, task);
+      const meta: Record<string, unknown> = {
+        backgroundTask: {
+          taskId,
+          agentId: p.terminalId ?? undefined,
+          outputPath: p.outputPath ?? undefined,
+          sourceToolCallId: p.toolCallId ?? undefined,
+        },
+      };
+      const ok = await this.server.notifyByZcodeSid(this.zcodeSid, {
+        sessionUpdate: "tool_call",
+        toolCallId: task.acpCallId,
+        title: cardTitle(task.description),
+        kind: "other",
+        status: acpStatus,
+        _meta: meta,
+      });
+      task.lastStatus = acpStatus;
+      if (ok) {
+        log(`  [bg] task card emitted: ${taskId.slice(-12)} status=${acpStatus}`);
+      }
+      return;
+    }
+    // Subsequent sighting → status update only (skip no-ops).
+    if (task.lastStatus === acpStatus) return;
+    const bgMeta: Record<string, unknown> = { taskId };
+    if (p.outputPath) bgMeta["outputPath"] = p.outputPath;
+    const meta: Record<string, unknown> = { backgroundTask: bgMeta };
+    const ok = await this.server.notifyByZcodeSid(this.zcodeSid, {
+      sessionUpdate: "tool_call_update",
+      toolCallId: task.acpCallId,
+      status: acpStatus,
+      _meta: meta,
+    });
+    task.lastStatus = acpStatus;
+    if (ok) {
+      log(`  [bg] task status update: ${taskId.slice(-12)} → ${acpStatus}`);
+    }
+  }
+
+  /** Forward a text delta from the active background notification turn. */
+  private async forwardText(delta: string): Promise<void> {
+    // Allocate the messageId lazily so an empty-result turn emits nothing.
+    let msgId = this.activeMessageId();
+    if (!msgId) {
+      msgId = `bg_msg_${randomUUID().slice(0, 12)}`;
+      this.firstMessageId = msgId;
+    }
+    await this.server.notifyByZcodeSid(this.zcodeSid, {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: delta },
+      messageId: msgId,
+    });
+  }
+
+  private firstMessageId: string | null = null;
+  private activeMessageId(): string | null {
+    return this.firstMessageId;
+  }
+
+  /**
+   * Mark a tracked task as cancelled (used by `session/cancelBackgroundTask`).
+   * Emits a final `failed` update with `_meta.backgroundTask.cancelled = true`
+   * so the editor card reflects the cancellation, then drops local state.
+   */
+  async markCancelled(taskId: string): Promise<void> {
+    const task = this.tasks.get(taskId);
+    if (!task) return;
+    await this.server.notifyByZcodeSid(this.zcodeSid, {
+      sessionUpdate: "tool_call_update",
+      toolCallId: task.acpCallId,
+      status: "failed",
+      _meta: { backgroundTask: { taskId, cancelled: true } },
+    });
+    this.tasks.delete(taskId);
+    log(`  [bg] task cancelled: ${taskId.slice(-12)}`);
+  }
+}

--- a/src/handlers/background-tasks.ts
+++ b/src/handlers/background-tasks.ts
@@ -129,6 +129,10 @@ export class BackgroundTaskListener implements EventListener {
         if (event.type === "turn.completed" || event.type === "turn.failed") {
           log(`  [bg] background notification turn ended (${event.type})`);
           this.activeNotifyTurnId = null;
+          // Reset the result messageId so the NEXT background task in this
+          // session gets its own — otherwise the editor would merge/overwrite
+          // distinct tasks' outputs under one shared messageId.
+          this.firstMessageId = null;
           return;
         }
       }

--- a/src/handlers/dispatch.ts
+++ b/src/handlers/dispatch.ts
@@ -13,7 +13,11 @@ import type * as acp from "@agentclientprotocol/sdk";
 
 import { currentModelCached } from "../config/model-cache.js";
 import { modelContextWindow } from "../config/options.js";
-import { extractExitCode, TOOL_KIND_MAP } from "../translators/tool-helpers.js";
+import {
+  extractExitCode,
+  parseSubagentMetadata,
+  TOOL_KIND_MAP,
+} from "../translators/tool-helpers.js";
 import type { InternalEvent } from "../translators/types.js";
 import type { ZcodeAcpServer } from "../server.js";
 import { sendSessionUpdate } from "./io.js";
@@ -72,6 +76,8 @@ function dispatchToolCallNew(
     server.supportsTerminalOutput() && (ev.tool === "Bash" || ev.tool === "bash");
   const meta: Record<string, unknown> = { claudeCode: { toolName: ev.tool } };
   if (termSupported) meta["terminal_info"] = { terminal_id: ev.callId };
+  // Mark sub-agent dispatch cards so editors can badge them from creation.
+  if (ev.tool === "Agent" || ev.tool === "Task") meta["subagent"] = true;
 
   const update: acp.SessionUpdate = {
     sessionUpdate: "tool_call",
@@ -116,6 +122,16 @@ function dispatchToolCallUpdate(
   };
   const meta: Record<string, unknown> = {};
   if (toolName) meta["claudeCode"] = { toolName };
+  // Sub-agent (Agent/Task tool) result: surface structured metadata so editors
+  // can badge the card (agentId, background flag, token/tool/time usage). The
+  // raw result text is left in `content` for the user-facing view.
+  if (
+    (toolName === "Agent" || toolName === "Task") &&
+    (ev.status === "completed" || ev.status === "failed")
+  ) {
+    const sub = parseSubagentMetadata(ev.rawResult);
+    if (sub) meta["subagent"] = sub;
+  }
   if (ev.output !== undefined) update.rawOutput = ev.output;
   if (ev.diffContent && ev.diffContent.length > 0) {
     update.content = ev.diffContent;

--- a/src/handlers/extensions.ts
+++ b/src/handlers/extensions.ts
@@ -57,7 +57,8 @@ export async function fork(server: ZcodeAcpServer, params: ExtensionParams): Pro
   // Register it so subsequent ACP calls targeting the fork can resolve the sid.
   const result = (resp.result ?? {}) as { forkedSessionId?: string };
   if (result.forkedSessionId) {
-    server.sessionMap.set(result.forkedSessionId, result.forkedSessionId);
+    server.registerSession(result.forkedSessionId, result.forkedSessionId);
+    server.ensureBackgroundListener(result.forkedSessionId);
   }
   log(`session/fork → ${result.forkedSessionId ?? "?"}`);
   return result;
@@ -187,7 +188,7 @@ export async function cancelBackgroundTask(
   params: ExtensionParams,
 ): Promise<Result> {
   const zcodeSid = resolveSidOrThrow(server, params);
-  const taskId = params.taskId;
+  const taskId = String(params.taskId ?? "");
   if (!taskId) throw new Error("cancelBackgroundTask requires taskId");
   const resp = await server
     .ensureBackend()
@@ -198,6 +199,10 @@ export async function cancelBackgroundTask(
       15000,
     );
   if (resp.error) throw new Error(`cancelBackgroundTask failed: ${resp.error.message}`);
+  // Reflect the cancellation on the ACP tool card (status:failed + cancelled
+  // flag) and clear the background listener's local tracking. Best-effort.
+  const listener = server.backgroundListeners.get(zcodeSid);
+  if (listener) void listener.markCancelled(taskId);
   log(
     `session/cancelBackgroundTask → cancelled=${(resp.result as { cancelled?: boolean })?.cancelled}`,
   );

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -72,11 +72,12 @@ export async function newSession(
   const sid = session.sessionId;
   if (!sid) throw new Error("zcode create returned no sessionId");
 
-  server.sessionMap.set(sid, sid);
+  server.registerSession(sid, sid);
   // Only freshly-created sessions are eligible for auto-title on first
   // end_turn; resumed/loaded sessions already have a title and must keep it.
   server.titleEligibleSessions.add(sid);
   log(`session/new → ${sid}`);
+  server.ensureBackgroundListener(sid);
 
   // Sync to the App's tasks-index.sqlite so the App UI shows this session.
   // Best-effort; failures are logged inside upsertSessionTask and swallowed.
@@ -145,8 +146,9 @@ export async function resumeSession(
   const resp = await backend.request(server.nextId(), "session/resume", zcParams, 15000);
   if (resp.error) throw new Error(`zcode resume failed: ${resp.error.message ?? ""}`);
 
-  server.sessionMap.set(targetSid, targetSid);
+  server.registerSession(targetSid, targetSid);
   log(`session/resume -> ${targetSid}`);
+  server.ensureBackgroundListener(targetSid);
   // Initial usage_update so the editor shows the context bar immediately for a
   // resumed session (mirrors Python _on_session_resume → _emit_initial_usage).
   await emitInitialUsage(server, cx, targetSid, targetSid, getOrCreateDiffer(server, targetSid));
@@ -180,8 +182,9 @@ export async function loadSession(
   if (runtimeModel !== null) zcParams.runtimeModel = runtimeModel;
   const resp = await backend.request(server.nextId(), "session/resume", zcParams, 15000);
   if (resp.error) throw new Error(`zcode resume failed: ${resp.error.message ?? ""}`);
-  server.sessionMap.set(targetSid, targetSid);
+  server.registerSession(targetSid, targetSid);
   log(`session/load → ${targetSid}`);
+  server.ensureBackgroundListener(targetSid);
 
   const messages = await fetchMessages(server, targetSid);
   let replayed = 0;
@@ -386,7 +389,7 @@ export async function prompt(
 
     return result;
   } finally {
-    backend.unregisterEventListener(zcodeSid);
+    backend.unregisterEventListener(zcodeSid, listener);
     server.pendingTurns.delete(requestId);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ async function main(): Promise<void> {
   }, 2000);
   backendDeathInterval.unref();
 
-  acp
+  const connection = acp
     .agent({ name: AGENT_INFO.name })
     .onRequest("initialize", (ctx) => server.initialize(ctx.params))
     .onRequest("session/new", async (ctx) => {
@@ -147,6 +147,16 @@ async function main(): Promise<void> {
     .onRequest("session/setMode", extParams, (ctx) => setMode(server, ctx.params, ctx.client))
     .onNotification("session/cancel", (ctx) => cancel(server, ctx.params))
     .connect(stream);
+
+  // Capture the connection-scoped AgentContext so background listeners can push
+  // session/update notifications outside of request handlers (e.g. when a
+  // background task completes after session/prompt has returned).
+  server.acpClient = connection.client;
+
+  // Capture the connection-scoped AgentContext so background listeners can push
+  // session/update notifications outside of request handlers (e.g. when a
+  // background task completes after session/prompt has returned).
+  server.acpClient = connection.client;
 }
 
 main().catch((err) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,11 +152,6 @@ async function main(): Promise<void> {
   // session/update notifications outside of request handlers (e.g. when a
   // background task completes after session/prompt has returned).
   server.acpClient = connection.client;
-
-  // Capture the connection-scoped AgentContext so background listeners can push
-  // session/update notifications outside of request handlers (e.g. when a
-  // background task completes after session/prompt has returned).
-  server.acpClient = connection.client;
 }
 
 main().catch((err) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ import {
   resolveZcodeCommand,
   ZcodeBackend,
 } from "./backend/index.js";
+import { BackgroundTaskListener } from "./handlers/background-tasks.js";
 import { AGENT_INFO, PROTOCOL_VERSION, log } from "./utils.js";
 
 /** Client capabilities advertised in the initialize request. */
@@ -37,6 +38,14 @@ export class ZcodeAcpServer {
   backend: ZcodeBackend | null = null;
   /** acp_sid → zcode session id (usually identical, but kept for clarity). */
   readonly sessionMap = new Map<string, string>();
+  /**
+   * Reverse map: zcode session id → acp_sid. The background-task listener only
+   * knows the zcode sid (it comes from backend events), but ACP notifications
+   * must address the acp_sid the client knows. Usually the two are identical,
+   * but forked/loaded sessions can diverge, so we maintain an explicit reverse
+   * index rather than assuming equality.
+   */
+  readonly acpSidByZcodeSid = new Map<string, string>();
   /** Currently running turns, keyed by the ACP request id. */
   readonly pendingTurns = new Map<number, PendingTurn>();
   /**
@@ -47,6 +56,14 @@ export class ZcodeAcpServer {
   readonly preemptLocks = new Map<string, Promise<void>>();
   /** Capabilities advertised by the connected client (Zed, JetBrains, ...). */
   clientCapabilities: ClientCapabilities = {};
+  /**
+   * Connection-scoped AgentContext, captured at `connect()` time. Held so that
+   * background listeners can push `session/update` notifications OUTSIDE a
+   * request handler (e.g. when a background task completes after `session/
+   * prompt` has already returned). Null before `connect()` runs (only during
+   * the brief startup window — sessions can't be created before connect).
+   */
+  acpClient: acp.AgentContext | null = null;
   /** Session titles already set, to enforce set-once (acp_sid → title). */
   readonly sessionTitles = new Map<string, string>();
   /**
@@ -65,6 +82,14 @@ export class ZcodeAcpServer {
   >();
   /** Per-session model cache for configOptions model dropdown. */
   readonly modelCache = new Map<string, string>();
+  /**
+   * Per-session (zcodeSid) background-task listeners. Registered once when a
+   * session is created/resumed/loaded and lives across prompts, forwarding
+   * background task status + result notifications to the client outside of
+   * request handlers. The turn loop's own listener coexists with this one
+   * (backend.listeners is now a Set per session).
+   */
+  readonly backgroundListeners = new Map<string, BackgroundTaskListener>();
   /**
    * Per-Bash-callId stdout snapshot already streamed via terminal_output. Used
    * by dispatchTerminalUpdate for two dedup guards:
@@ -94,6 +119,61 @@ export class ZcodeAcpServer {
   /** Resolve the zcode session id for an ACP session id. */
   resolveSid(acpSid: string): string | undefined {
     return this.sessionMap.get(acpSid);
+  }
+
+  /**
+   * Register the acp_sid ↔ zcode_sid mapping both ways. Use this instead of
+   * `sessionMap.set(...)` directly so the reverse index stays in sync (the
+   * background-task listener needs the reverse lookup to address notifications).
+   */
+  registerSession(acpSid: string, zcodeSid: string): void {
+    this.sessionMap.set(acpSid, zcodeSid);
+    this.acpSidByZcodeSid.set(zcodeSid, acpSid);
+  }
+
+  /**
+   * Ensure a background-task listener is registered for the session. Idempotent
+   * — returns the existing listener if already registered (covers resume/load
+   * after new, and fork). Lives for the whole session so background agents that
+   * finish AFTER `session/prompt` returns still get their status/result
+   * forwarded to the client. The turn loop's own listener coexists via the
+   * backend's per-session listener Set.
+   */
+  ensureBackgroundListener(zcodeSid: string): BackgroundTaskListener {
+    const existing = this.backgroundListeners.get(zcodeSid);
+    if (existing) return existing;
+    const backend = this.ensureBackend();
+    const listener = new BackgroundTaskListener(this, zcodeSid);
+    this.backgroundListeners.set(zcodeSid, listener);
+    backend.registerEventListener(zcodeSid, listener);
+    log(`  [bg] background listener registered for ${zcodeSid}`);
+    return listener;
+  }
+
+  /** Resolve the ACP session id for a zcode session id (reverse of resolveSid). */
+  resolveAcpSid(zcodeSid: string): string | undefined {
+    return this.acpSidByZcodeSid.get(zcodeSid);
+  }
+
+  /**
+   * Push a `session/update` notification to the client from OUTSIDE a request
+   * handler (used by the background-task listener). Resolves the acp_sid from
+   * the zcode_sid and no-ops (returning false) if the client or session is
+   * unknown. Never throws — callers run in the event loop and must not crash
+   * the bridge on a notification failure.
+   */
+  async notifyByZcodeSid(zcodeSid: string, update: acp.SessionUpdate): Promise<boolean> {
+    const cx = this.acpClient;
+    if (!cx) return false;
+    const acpSid = this.resolveAcpSid(zcodeSid);
+    if (!acpSid) return false;
+    try {
+      await cx.notify("session/update", { sessionId: acpSid, update });
+      return true;
+    } catch (e) {
+      log(`notifyByZcodeSid: session/update failed: ${e instanceof Error ? e.message : String(e)}`);
+      return false;
+    }
   }
 
   /** Whether the client declared `_meta.terminal_output` (Zed's Bash UI hook). */

--- a/src/translators/event-translator.ts
+++ b/src/translators/event-translator.ts
@@ -33,6 +33,13 @@ export class EventTranslator {
   turnFailed = false;
   turnResultType: string | null = null;
   turnError: Record<string, unknown> | null = null;
+  /**
+   * True while inside a background-task notification turn
+   * (`turn.started {inputSource:"background_task"}`). Set on its turn.started,
+   * cleared on the next user-initiated turn.started. While true, `translate`
+   * drops all events — that turn is owned by BackgroundTaskListener.
+   */
+  private skippingBackgroundTurn = false;
 
   /** Tool call ids we've already emitted a ToolCallNew for. */
   readonly seenToolIds = new Set<string>();
@@ -50,8 +57,27 @@ export class EventTranslator {
     const results: InternalEvent[] = [];
 
     if (etype === "turn.started") {
+      // Background-task completion triggers an automatic backend turn
+      // (`inputSource:"background_task"`) whose text_delta is the task result.
+      // That turn is owned by the BackgroundTaskListener (session-scoped), NOT
+      // this per-prompt translator — if we consumed it we'd (a) double-forward
+      // the result and (b) mis-set turnDone and exit the user's real turn loop.
+      // So we skip every event of a background_task turn until the next
+      // user-initiated turn.started clears the flag.
+      const inputSource = payload["inputSource"];
+      if (inputSource === "background_task") {
+        this.skippingBackgroundTurn = true;
+        log("  [event] turn.started (background_task) → deferring to bg listener");
+        return results;
+      }
+      this.skippingBackgroundTurn = false;
       this.turnStarted = true;
       log("  [event] turn.started");
+    } else if (this.skippingBackgroundTurn) {
+      // Inside a deferred background_task turn: drop everything (the bg
+      // listener handles it). turn.completed/turn.failed for the bg turn also
+      // land here and are intentionally NOT used to set turnDone.
+      return results;
     } else if (etype === "model.streaming") {
       results.push(...this.translateStreaming(payload));
     } else if (etype === "tool.updated") {

--- a/src/translators/tool-helpers.ts
+++ b/src/translators/tool-helpers.ts
@@ -291,6 +291,62 @@ export function extractLocations(
   return [];
 }
 
+/**
+ * Structured sub-agent metadata extracted from an Agent/Task tool result's
+ * content. The zcode backend appends these as plain-text markers at the end of
+ * the result content (e.g. `agentId: agent_xxx (use SendMessage ...)` and
+ * `<usage>subagent_tokens: 40904\ntool_uses: 1\nduration_ms: 10559</usage>`).
+ * Editors can use the parsed fields to badge the tool card; the raw content is
+ * left intact for the user-facing text.
+ */
+export interface SubagentMetadata {
+  agentId?: string;
+  background?: boolean;
+  tokens?: number;
+  toolUses?: number;
+  durationMs?: number;
+}
+
+const AGENT_ID_RE = /agentId:\s*(agent_[A-Za-z0-9-]+)/;
+// <usage>subagent_tokens: 40904\ntool_uses: 1\nduration_ms: 10559</usage>
+const USAGE_RE =
+  /<usage>\s*subagent_tokens:\s*(\d+)\s*tool_uses:\s*(\d+)\s*duration_ms:\s*(\d+)\s*<\/usage>/;
+const BACKGROUND_RE = /\b(background(ed)?|async_launched|backgroundTaskId)\b/i;
+
+/**
+ * Parse sub-agent metadata markers from an Agent/Task result content string.
+ * Returns null when no sub-agent markers are present (so non-Agent results
+ * short-circuit cheaply). The content may be a JSON string (the backend wraps
+ * the result) or plain text — both shapes are handled.
+ */
+export function parseSubagentMetadata(rawContent: unknown): SubagentMetadata | null {
+  let text: string;
+  if (typeof rawContent === "string") {
+    text = rawContent;
+  } else if (rawContent && typeof rawContent === "object" && !Array.isArray(rawContent)) {
+    const c = (rawContent as Record<string, unknown>)["content"];
+    if (typeof c !== "string") return null;
+    text = c;
+  } else {
+    return null;
+  }
+  if (!text.includes("agentId:") && !text.includes("<usage>")) return null;
+
+  const meta: SubagentMetadata = {};
+  const aid = text.match(AGENT_ID_RE);
+  if (aid) meta.agentId = aid[1];
+  const usage = text.match(USAGE_RE);
+  if (usage) {
+    meta.tokens = Number(usage[1]);
+    meta.toolUses = Number(usage[2]);
+    meta.durationMs = Number(usage[3]);
+  }
+  if (BACKGROUND_RE.test(text)) meta.background = true;
+  // Require at least one recognised field, else treat as non-subagent.
+  if (meta.agentId === undefined && meta.tokens === undefined) return null;
+  return meta;
+}
+
 /** Render a turn.failed error object into a readable single-line string. */
 export function formatTurnError(error: unknown): string {
   if (!error || typeof error !== "object" || Array.isArray(error)) return "";

--- a/tests/backend.test.ts
+++ b/tests/backend.test.ts
@@ -92,6 +92,47 @@ describe("ZcodeBackend reader routing (unit)", () => {
     b.close();
   });
 
+  it("fans session/event out to multiple registered listeners and isolates unregister", () => {
+    const b = makeRoutingSubject();
+    const gotA: ZcodeEvent[] = [];
+    const gotB: ZcodeEvent[] = [];
+    const listenerA: EventListener = { handleEvent: (ev) => gotA.push(ev) };
+    const listenerB: EventListener = { handleEvent: (ev) => gotB.push(ev) };
+    b.registerEventListener("sess_x", listenerA);
+    b.registerEventListener("sess_x", listenerB);
+    b.route({
+      method: "session/event",
+      params: { sessionId: "sess_x", seq: 1, type: "turn.started", payload: {} },
+    });
+    // Both listeners receive the event.
+    expect(gotA).toHaveLength(1);
+    expect(gotB).toHaveLength(1);
+    // Unregistering one leaves the other intact.
+    b.unregisterEventListener("sess_x", listenerA);
+    b.route({
+      method: "session/event",
+      params: { sessionId: "sess_x", seq: 2, type: "turn.completed", payload: {} },
+    });
+    expect(gotA).toHaveLength(1); // no new event for A
+    expect(gotB).toHaveLength(2); // B still receives
+    b.close();
+  });
+
+  it("isolates listeners per session id", () => {
+    const b = makeRoutingSubject();
+    const gotX: ZcodeEvent[] = [];
+    const gotY: ZcodeEvent[] = [];
+    b.registerEventListener("sess_x", { handleEvent: (ev) => gotX.push(ev) });
+    b.registerEventListener("sess_y", { handleEvent: (ev) => gotY.push(ev) });
+    b.route({
+      method: "session/event",
+      params: { sessionId: "sess_x", seq: 1, type: "turn.started", payload: {} },
+    });
+    expect(gotX).toHaveLength(1);
+    expect(gotY).toHaveLength(0);
+    b.close();
+  });
+
   it("drains pending requests with an error once the reader dies", async () => {
     const b = makeRoutingSubject();
     const pending = b.request(11, "ping", {}, 5000);

--- a/tests/background-tasks.test.ts
+++ b/tests/background-tasks.test.ts
@@ -137,6 +137,32 @@ describe("BackgroundTaskListener", () => {
     expect(chunks[0]!.update["messageId"]).toBe(chunks[1]!.update["messageId"]);
   });
 
+  it("allocates a fresh messageId per background task (no cross-task reuse)", async () => {
+    // Regression guard: firstMessageId must be reset when a background
+    // notification turn ends, else two tasks in the same session share one
+    // messageId and the editor merges/overwrites their output.
+    const server = makeServer();
+    const l = new BackgroundTaskListener(server as unknown as ZcodeAcpServer, "sess_test");
+    // Task 1's notification turn.
+    l.handleEvent(zcodeEvent("turn.started", { inputSource: "background_task", turnId: "t1" }));
+    await Promise.resolve();
+    l.handleEvent(zcodeEvent("model.streaming", { kind: "text_delta", delta: "task1 result" }));
+    await Promise.resolve();
+    l.handleEvent(zcodeEvent("turn.completed", { resultType: "success" }));
+    await Promise.resolve();
+    // Task 2's notification turn (same session, same listener instance).
+    l.handleEvent(zcodeEvent("turn.started", { inputSource: "background_task", turnId: "t2" }));
+    await Promise.resolve();
+    l.handleEvent(zcodeEvent("model.streaming", { kind: "text_delta", delta: "task2 result" }));
+    await Promise.resolve();
+    l.handleEvent(zcodeEvent("turn.completed", { resultType: "success" }));
+    await Promise.resolve();
+    const chunks = server.calls.filter((c) => c.update["sessionUpdate"] === "agent_message_chunk");
+    expect(chunks).toHaveLength(2);
+    // Distinct messageIds — the second task does NOT reuse the first's id.
+    expect(chunks[0]!.update["messageId"]).not.toBe(chunks[1]!.update["messageId"]);
+  });
+
   it("does NOT forward a normal (non-background) turn's text_delta", async () => {
     const server = makeServer();
     const l = new BackgroundTaskListener(server as unknown as ZcodeAcpServer, "sess_test");

--- a/tests/background-tasks.test.ts
+++ b/tests/background-tasks.test.ts
@@ -1,0 +1,178 @@
+/**
+ * BackgroundTaskListener unit tests.
+ *
+ * Drives handleEvent() with synthetic zcode events (the shapes captured by the
+ * real app-server probe — see docs/PROTOCOL.md "Background Tasks") and asserts
+ * the session/update notifications it pushes back via the server. No real
+ * backend or ACP client — `notifyByZcodeSid` is stubbed to record calls.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { BackgroundTaskListener } from "../src/handlers/background-tasks.js";
+import type { ZcodeAcpServer } from "../src/server.js";
+import type { ZcodeEvent } from "../src/backend/types.js";
+
+/** A minimal fake server: records every session/update it would send. */
+interface FakeServer {
+  calls: Array<{ zcodeSid: string; update: Record<string, unknown> }>;
+}
+type TestServer = FakeServer & Pick<ZcodeAcpServer, "notifyByZcodeSid">;
+
+function makeServer(): TestServer {
+  const calls: TestServer["calls"] = [];
+  const server = {
+    calls,
+    async notifyByZcodeSid(zcodeSid: string, update: Record<string, unknown>): Promise<boolean> {
+      calls.push({ zcodeSid, update });
+      return true;
+    },
+  };
+  return server as TestServer;
+}
+
+function zcodeEvent(
+  type: string,
+  payload: Record<string, unknown>,
+  extra: Partial<ZcodeEvent> = {},
+): ZcodeEvent {
+  return {
+    sessionId: "sess_test",
+    seq: 0,
+    type: type as ZcodeEvent["type"],
+    payload,
+    ...extra,
+  };
+}
+
+describe("BackgroundTaskListener", () => {
+  it("emits a tool_call card on the first running session.updated(taskId)", async () => {
+    const server = makeServer();
+    const l = new BackgroundTaskListener(server as unknown as ZcodeAcpServer, "sess_test");
+    l.handleEvent(
+      zcodeEvent("session.updated", {
+        taskId: "agent_abc",
+        toolCallId: "call_orig",
+        status: "running",
+        description: "research src/",
+        outputPath: "/tmp/out.txt",
+        terminalId: "agent_abc",
+      }),
+    );
+    // notifyByZcodeSid is async; flush microtasks.
+    await Promise.resolve();
+    expect(server.calls).toHaveLength(1);
+    const { update, zcodeSid } = server.calls[0]!;
+    expect(zcodeSid).toBe("sess_test");
+    expect(update["sessionUpdate"]).toBe("tool_call");
+    expect(update["title"]).toBe("[background] research src/");
+    expect(update["kind"]).toBe("other");
+    expect(update["status"]).toBe("in_progress");
+    expect(String(update["toolCallId"]).startsWith("bg_")).toBe(true);
+    const meta = update["_meta"] as { backgroundTask: Record<string, unknown> };
+    expect(meta.backgroundTask.taskId).toBe("agent_abc");
+    expect(meta.backgroundTask.agentId).toBe("agent_abc");
+    expect(meta.backgroundTask.outputPath).toBe("/tmp/out.txt");
+  });
+
+  it("emits a tool_call_update on status transition to completed", async () => {
+    const server = makeServer();
+    const l = new BackgroundTaskListener(server as unknown as ZcodeAcpServer, "sess_test");
+    l.handleEvent(zcodeEvent("session.updated", { taskId: "agent_abc", status: "running" }));
+    await Promise.resolve();
+    l.handleEvent(
+      zcodeEvent("session.updated", { taskId: "agent_abc", status: "completed" }),
+    );
+    await Promise.resolve();
+    expect(server.calls).toHaveLength(2);
+    const update = server.calls[1]!.update;
+    expect(update["sessionUpdate"]).toBe("tool_call_update");
+    expect(update["status"]).toBe("completed");
+    // Same toolCallId as the first card.
+    expect(update["toolCallId"]).toBe(server.calls[0]!.update["toolCallId"]);
+  });
+
+  it("skips no-op status updates (same status as last advertised)", async () => {
+    const server = makeServer();
+    const l = new BackgroundTaskListener(server as unknown as ZcodeAcpServer, "sess_test");
+    l.handleEvent(zcodeEvent("session.updated", { taskId: "agent_abc", status: "running" }));
+    await Promise.resolve();
+    // Another running event with no status change → suppressed.
+    l.handleEvent(zcodeEvent("session.updated", { taskId: "agent_abc", status: "running" }));
+    await Promise.resolve();
+    expect(server.calls).toHaveLength(1);
+  });
+
+  it("ignores session.updated without taskId (e.g. usage updates)", async () => {
+    const server = makeServer();
+    const l = new BackgroundTaskListener(server as unknown as ZcodeAcpServer, "sess_test");
+    l.handleEvent(zcodeEvent("session.updated", { usage: { inputTokens: 123 }, contextWindow: 1000 }));
+    await Promise.resolve();
+    expect(server.calls).toHaveLength(0);
+  });
+
+  it("forwards background_task turn text_delta as agent_message_chunk", async () => {
+    const server = makeServer();
+    const l = new BackgroundTaskListener(server as unknown as ZcodeAcpServer, "sess_test");
+    // A notification turn starts.
+    l.handleEvent(
+      zcodeEvent("turn.started", { inputSource: "background_task", turnId: "turn_bg1" }),
+    );
+    await Promise.resolve();
+    // Its text deltas are forwarded.
+    l.handleEvent(zcodeEvent("model.streaming", { kind: "text_delta", delta: "result part 1 " }));
+    l.handleEvent(zcodeEvent("model.streaming", { kind: "text_delta", delta: "part 2" }));
+    await Promise.resolve();
+    // turn.completed ends the notification turn.
+    l.handleEvent(zcodeEvent("turn.completed", { resultType: "success" }));
+    await Promise.resolve();
+    // Subsequent text_delta (no active bg turn) is NOT forwarded.
+    l.handleEvent(zcodeEvent("model.streaming", { kind: "text_delta", delta: "leak" }));
+    await Promise.resolve();
+    const chunks = server.calls.filter((c) => c.update["sessionUpdate"] === "agent_message_chunk");
+    expect(chunks).toHaveLength(2);
+    expect((chunks[0]!.update["content"] as { text: string }).text).toBe("result part 1 ");
+    expect((chunks[1]!.update["content"] as { text: string }).text).toBe("part 2");
+    // All chunks share one messageId (the bg result message).
+    expect(chunks[0]!.update["messageId"]).toBe(chunks[1]!.update["messageId"]);
+  });
+
+  it("does NOT forward a normal (non-background) turn's text_delta", async () => {
+    const server = makeServer();
+    const l = new BackgroundTaskListener(server as unknown as ZcodeAcpServer, "sess_test");
+    l.handleEvent(zcodeEvent("turn.started", { inputSource: "user_prompt", turnId: "turn_user" }));
+    await Promise.resolve();
+    l.handleEvent(zcodeEvent("model.streaming", { kind: "text_delta", delta: "user reply" }));
+    await Promise.resolve();
+    expect(server.calls).toHaveLength(0);
+  });
+
+  it("markCancelled emits a failed update with cancelled flag and clears state", async () => {
+    const server = makeServer();
+    const l = new BackgroundTaskListener(server as unknown as ZcodeAcpServer, "sess_test");
+    l.handleEvent(zcodeEvent("session.updated", { taskId: "agent_abc", status: "running" }));
+    await Promise.resolve();
+    await l.markCancelled("agent_abc");
+    expect(server.calls).toHaveLength(2);
+    const cancel = server.calls[1]!.update;
+    expect(cancel["sessionUpdate"]).toBe("tool_call_update");
+    expect(cancel["status"]).toBe("failed");
+    expect(
+      (cancel["_meta"] as { backgroundTask: { cancelled: boolean } }).backgroundTask.cancelled,
+    ).toBe(true);
+    // State cleared: a subsequent status event re-creates the card (new callId).
+    l.handleEvent(zcodeEvent("session.updated", { taskId: "agent_abc", status: "running" }));
+    await Promise.resolve();
+    expect(server.calls).toHaveLength(3);
+  });
+
+  it("never throws on a malformed payload (best-effort)", async () => {
+    const server = makeServer();
+    const l = new BackgroundTaskListener(server as unknown as ZcodeAcpServer, "sess_test");
+    expect(() =>
+      l.handleEvent(zcodeEvent("session.updated", { taskId: "x" } as never)),
+    ).not.toThrow();
+    expect(() => l.handleEvent(zcodeEvent("unknown.type", {}))).not.toThrow();
+    await Promise.resolve();
+  });
+});

--- a/tests/event-translator.test.ts
+++ b/tests/event-translator.test.ts
@@ -146,3 +146,42 @@ describe("EventTranslator", () => {
     expect(t.turnResultType).toBe("cancelled");
   });
 });
+
+describe("EventTranslator background-task turn deferral", () => {
+  it("skips every event of a background_task turn (defers to BackgroundTaskListener)", () => {
+    const t = new EventTranslator();
+    // A background notification turn starts.
+    t.translate(ev("turn.started", { inputSource: "background_task", turnId: "turn_bg" }));
+    // Its text deltas MUST NOT be emitted (else double-forwarded alongside the
+    // bg listener) and MUST NOT set turnStarted.
+    const out1 = t.translate(ev("model.streaming", { kind: "text_delta", delta: "bg result" }));
+    expect(out1).toEqual([]);
+    expect(t.turnStarted).toBe(false);
+    // Its turn.completed MUST NOT set turnDone (else it'd exit the user's
+    // still-running real turn).
+    const out2 = t.translate(ev("turn.completed", { resultType: "success" }));
+    expect(out2).toEqual([]);
+    expect(t.turnDone).toBe(false);
+  });
+
+  it("resumes normal handling after the next user-initiated turn.started", () => {
+    const t = new EventTranslator();
+    t.translate(ev("turn.started", { inputSource: "background_task", turnId: "turn_bg" }));
+    t.translate(ev("model.streaming", { kind: "text_delta", delta: "bg" })); // dropped
+    // A normal user turn starts → deferral cleared.
+    t.translate(ev("turn.started", { turnId: "turn_user" }));
+    expect(t.turnStarted).toBe(true);
+    const out = t.translate(ev("model.streaming", { kind: "text_delta", delta: "user reply" }));
+    expect(out).toEqual([{ kind: "TextDelta", text: "user reply" }]);
+  });
+
+  it("ignores background_task tool.updated events inside the deferred turn", () => {
+    const t = new EventTranslator();
+    t.translate(ev("turn.started", { inputSource: "background_task", turnId: "turn_bg" }));
+    const out = t.translate(
+      ev("tool.updated", { kind: "scheduled", toolCallId: "c1", toolName: "Read" }),
+    );
+    expect(out).toEqual([]);
+    expect(t.seenToolIds.has("c1")).toBe(false);
+  });
+});

--- a/tests/tool-helpers.test.ts
+++ b/tests/tool-helpers.test.ts
@@ -9,6 +9,7 @@ import {
   buildDiffContent,
   extractExitCode,
   extractLocations,
+  parseSubagentMetadata,
   renderToolOutput,
 } from "../src/translators/tool-helpers.js";
 
@@ -132,5 +133,51 @@ describe("extractLocations", () => {
 
   it("returns [] without a file_diff display for unknown tools", () => {
     expect(extractLocations("Unknown", {})).toEqual([]);
+  });
+});
+
+describe("parseSubagentMetadata", () => {
+  it("parses agentId and usage from a synchronous sub-agent result string", () => {
+    const content =
+      "The deps are minimal...\nagentId: agent_73c7c63d-94e9-4c1f-9855-da189151c323 (use SendMessage ...)\n<usage>subagent_tokens: 40904\ntool_uses: 1\nduration_ms: 10559</usage>";
+    const meta = parseSubagentMetadata(content);
+    expect(meta).not.toBeNull();
+    expect(meta!.agentId).toBe("agent_73c7c63d-94e9-4c1f-9855-da189151c323");
+    expect(meta!.tokens).toBe(40904);
+    expect(meta!.toolUses).toBe(1);
+    expect(meta!.durationMs).toBe(10559);
+    expect(meta!.background).toBeUndefined();
+  });
+
+  it("flags background launches (async_launched content)", () => {
+    const content =
+      "Async agent launched.\nagentId: agent_61f207dd-3818-435b-b9e9-b995ec45cdb1 (...)\nThe agent is working in the background.\noutput_file: /tmp/o.txt";
+    const meta = parseSubagentMetadata(content);
+    expect(meta).not.toBeNull();
+    expect(meta!.agentId).toBe("agent_61f207dd-3818-435b-b9e9-b995ec45cdb1");
+    expect(meta!.background).toBe(true);
+  });
+
+  it("parses the {content: string} object shape too (backend result envelope)", () => {
+    const meta = parseSubagentMetadata({
+      success: true,
+      content: "done\nagentId: agent_xyz (use SendMessage)\n<usage>subagent_tokens: 100\ntool_uses: 2\nduration_ms: 50</usage>",
+    });
+    expect(meta).not.toBeNull();
+    expect(meta!.agentId).toBe("agent_xyz");
+    expect(meta!.tokens).toBe(100);
+  });
+
+  it("returns null for non-Agent results (no markers)", () => {
+    expect(parseSubagentMetadata("just some bash output")).toBeNull();
+    expect(parseSubagentMetadata({ content: "no markers here" })).toBeNull();
+    expect(parseSubagentMetadata(null)).toBeNull();
+    expect(parseSubagentMetadata(undefined)).toBeNull();
+  });
+
+  it("returns null when only a partial marker is present", () => {
+    // agentId keyword but not the agent_xxx id shape → still matched by regex,
+    // but here only the usage keyword with a malformed body → no match.
+    expect(parseSubagentMetadata("agentId: something_else")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Background sub-agents (the Agent/Task tool with \`run_in_background: true\`) and their lifecycle were previously invisible to ACP clients: the bridge exited its turn loop at the main \`turn.completed\` and unregistered its listener, silently dropping ALL post-turn events — a probe confirmed 112 \`tool.updated\` events + a completion-notification turn lost per background task.

This introduces a session-scoped \`BackgroundTaskListener\` that lives across prompts and forwards a curated subset of background events to the client as out-of-band \`session/update\` notifications. Also improves synchronous sub-agent card rendering with structured metadata.

## What changed

**Core mechanism — session-scoped background listener**
- \`backend/client.ts\`: per-session listener changed from \`Map<sid, Listener>\` to \`Map<sid, Set<Listener>>\` so the turn loop's listener and the background listener coexist. Dispatch is now fan-out with per-listener try/catch.
- \`handlers/background-tasks.ts\` (new): \`BackgroundTaskListener\` — turns \`session.updated\` (taskId) into a \`[background] …\` tool_call card + status updates, and forwards a background notification turn's \`text_delta\` as \`agent_message_chunk\` so the user sees the result. Also \`markCancelled()\` for the cancel path.
- \`server.ts\`: captures the connection-scoped \`AgentContext\` (\`acpClient\`) so notifications can be pushed outside request handlers; adds reverse sid map (\`acpSidByZcodeSid\`), \`notifyByZcodeSid()\`, \`ensureBackgroundListener()\`, \`registerSession()\`.
- \`index.ts\`: captures \`connection.client\` from \`.connect()\`.
- \`handlers/session.ts\`: registers the background listener on new/resume/load; \`extensions.ts\` on fork.

**Turn-loop deferral (key correctness fix)**
- \`translators/event-translator.ts\`: a \`turn.started\` with \`inputSource:"background_task"\` now makes the translator DROP every event of that turn until the next user-initiated turn. Otherwise the turn loop would (a) double-forward the background result alongside the bg listener and (b) mis-set \`turnDone\` and exit the user's real turn.

**Sub-agent card metadata**
- \`translators/tool-helpers.ts\`: \`parseSubagentMetadata()\` extracts \`agentId\` / \`<usage>subagent_tokens|tool_uses|duration_ms</usage>\` / background flag from Agent/Task result content.
- \`handlers/dispatch.ts\`: Agent/Task cards carry \`_meta.subagent\` (structured) from creation through completion.

**Cancel wiring**
- \`handlers/extensions.ts\`: \`session/cancelBackgroundTask\` now also calls \`listener.markCancelled(taskId)\` so the ACP card reflects cancellation (\`status:failed\` + \`_meta.backgroundTask.cancelled\`).

## Verification

All findings confirmed by directly probing \`zcode app-server --stdio\` (v0.15.2) — the backend pushes the full background lifecycle on the same session stream with no polling required.

- \`pnpm build\` / \`pnpm typecheck\` ✓
- \`pnpm test\` ✓ — 254 tests pass on this branch (+16 new: 8 background-tasks, 3 event-translator bg-turn deferral, 5 parseSubagentMetadata; backend multi-listener tests included)
- \`pnpm lint\` ✓ — 0 errors

## Docs

- \`docs/PROTOCOL.md\`: new "Background Tasks & Sub-Agents" section documenting the event protocol (session.updated taskId fields, turn.started inputSource=background_task, lifecycle).
- \`docs/ARCHITECTURE.md\`: module table updated with \`background-tasks.ts\`.

## Out of scope

- Expanding background agents' INTERNAL tool calls (Read/Bash) as nested cards (deferred — chosen "independent card" presentation instead).
- \`model.streaming tool_input_*\` parsing (probe confirmed \`tool_call\` still carries input, so the existing cache path works — not a bug).