### PR TITLE
feat: badge background Bash tasks by reusing the launch card

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -733,6 +733,63 @@ The background listener forwards that turn's `model.streaming text_delta` as
 turn loop **defers** this entire turn (drops its events) to avoid double-
 forwarding and to keep it from prematurely ending the user's real turn.
 
+### Background Bash (`run_in_background: true`)
+
+The `Bash` tool launched with `run_in_background: true` returns immediately
+with a launch acknowledgement (result content: "Command running in background
+with ID: exec_…"). Like the Agent sub-agent, the backend keeps pushing the
+task's lifecycle on the same stream via `session.updated` events that carry
+the originating `toolCallId`:
+
+```json
+{
+  "type": "session.updated",
+  "payload": {
+    "taskId": "exec_ac3a5053-...",
+    "toolCallId": "call_e282b4ec...",
+    "toolName": "Bash",
+    "status": "running",
+    "pid": 22410,
+    "outputPath": "/.../call_...-stdout.log",
+    "outputTail": "done\n"
+  }
+}
+```
+
+**Card reuse, not duplication.** Unlike an Agent sub-agent (which mints a fresh
+`bg_*` card), a background Bash task **reuses the launch card** — the very
+terminal card the dispatcher created when `Bash` was scheduled. This keeps the
+lifecycle on a single card instead of producing a duplicate `[background]` card
+that the editor would show alongside the closed launch card.
+
+The mechanism:
+
+1. **Launch turn** — the dispatcher tags the `ToolCallNew`/`ToolCallUpdate`
+   with `background: true` (threaded from the cached `input.run_in_background`
+   flag) and, on the launch `result`, **skips `terminal_exit`** so the launch
+   card stays `in_progress`. It seeds an empty marker in `terminalSentData`
+   for the `toolCallId` — this is the signal the background listener uses to
+   recognise "this is a tracked launch card".
+2. **Lifecycle (`session.updated`)** — the `BackgroundTaskListener` resolves
+   the `toolCallId`, sees it in `terminalSentData`, and routes status updates
+   back to the launch card. On `status:"completed"`, it emits the final
+   `outputTail` via `terminal_output` (iff launch text wasn't already streamed)
+   and closes the terminal UI with `terminal_exit` (exit code 0, or 1 on
+   `failed`), then clears the `terminalSentData` entry.
+3. **Fallback** — if the `session.updated` lacks a `toolCallId`, or the
+   `toolCallId` is unknown to `terminalSentData` (sub-agent case), the listener
+   falls back to minting a fresh `bg_*` card — the Agent sub-agent path above.
+
+| Backend event | ACP notification (background Bash) |
+|---|---|
+| first `session.updated` (status `running`) | `tool_call_update` on the launch card (`status:"in_progress"`) |
+| `session.updated` (status `completed`, with `outputTail`) | `terminal_output` (final output, if not already streamed) + `tool_call_update` with `terminal_exit` (`status:"completed"`) |
+| `session.updated` (status `failed`) | `tool_call_update` with `terminal_exit` (`status:"failed"`, exit_code 1) |
+
+`session/cancelBackgroundTask` for a background Bash task additionally emits
+`terminal_exit` with `_meta.backgroundTask.cancelled = true` so the terminal
+UI closes on cancellation.
+
 ### `session/cancelBackgroundTask`
 
 Cancels a background task. The bridge additionally marks the corresponding ACP

--- a/src/handlers/background-tasks.ts
+++ b/src/handlers/background-tasks.ts
@@ -83,6 +83,16 @@ interface TrackedTask {
    * on completion so Zed's terminal UI closes cleanly.
    */
   reusesLaunchCard: boolean;
+  /**
+   * Cumulative output snapshot this listener has already streamed via
+   * terminal_output for a reused launch card. Tracked SEPARATELY from
+   * `server.terminalSentData` (which holds the launch acknowledgement text
+   * written by the dispatcher) because the launch text and the real command
+   * output are unrelated streams — they're not prefix-related, so diffing
+   * against the launch text would drop or duplicate the real output. Only
+   * `outputTail`/`stdoutTail` from `session.updated` events feeds this.
+   */
+  streamedOutput?: string;
 }
 
 /** Map a zcode background task status string to an ACP ToolCallStatus. */
@@ -260,21 +270,24 @@ export class BackgroundTaskListener implements EventListener {
     // diff guard mirrors dispatchTerminalUpdate (only emit the suffix beyond
     // what was already streamed; for a background launch the launch text was
     // already sent, so outputTail here is the real command output).
-    if (task.reusesLaunchCard && isTerminal && task.sourceToolCallId) {
+    if (task.reusesLaunchCard && task.sourceToolCallId) {
+      // Stream any new command output via terminal_output. The output is
+      // tracked on `task.streamedOutput` (NOT server.terminalSentData) because
+      // terminalSentData holds the launch acknowledgement text written by the
+      // dispatcher, which is unrelated to the command's actual stdout — they
+      // aren't prefix-related, so diffing against the launch text would drop
+      // the real output entirely. Each session.updated carries a CUMULATIVE
+      // outputTail snapshot, so we diff against what we last streamed and emit
+      // only the suffix (mirrors dispatchTerminalUpdate's progress diffing).
       const finalOutput = p.outputTail ?? p.stdoutTail ?? "";
-      const lastSent = this.server.terminalSentData.get(task.sourceToolCallId) ?? "";
-      // Only skip terminal_output when launch text was actually streamed
-      // (lastSent non-empty). An empty marker ("") just flags "this is a
-      // tracked background launch card" — no content was streamed, so the
-      // final output must be emitted.
-      const alreadyStreamed = lastSent.length > 0;
-      if (finalOutput && !alreadyStreamed) {
+      const lastSent = task.streamedOutput ?? "";
+      if (finalOutput) {
         const delta =
           lastSent && finalOutput.startsWith(lastSent)
             ? finalOutput.slice(lastSent.length)
             : finalOutput;
         if (delta) {
-          this.server.terminalSentData.set(task.sourceToolCallId, finalOutput);
+          task.streamedOutput = finalOutput;
           await this.server.notifyByZcodeSid(this.zcodeSid, {
             sessionUpdate: "tool_call_update",
             toolCallId: task.sourceToolCallId,
@@ -282,8 +295,21 @@ export class BackgroundTaskListener implements EventListener {
           });
         }
       }
-      // terminal_exit closes the terminal card. exit_code inferred: failed
-      // status → 1, else 0 (background Bash carries no perf.exitCode here).
+      // terminal_exit only fires on a terminal status. A non-terminal (running)
+      // update has streamed its progress above; also push an in_progress status
+      // update with backgroundTask metadata so the card reflects "running in
+      // background" on first sighting (the launch card was left in_progress by
+      // the dispatcher, but we still advertise the status to attach taskId).
+      if (!isTerminal) {
+        await this.server.notifyByZcodeSid(this.zcodeSid, {
+          sessionUpdate: "tool_call_update",
+          toolCallId: task.sourceToolCallId,
+          status: acpStatus,
+          _meta: meta,
+        });
+        task.lastStatus = acpStatus;
+        return;
+      }
       const exitCode = acpStatus === "failed" ? 1 : 0;
       (meta.backgroundTask as Record<string, unknown>)["completed"] = true;
       await this.server.notifyByZcodeSid(this.zcodeSid, {

--- a/src/handlers/background-tasks.ts
+++ b/src/handlers/background-tasks.ts
@@ -47,14 +47,24 @@ interface TaskStatusPayload {
   description?: string;
   cancellable?: boolean;
   outputPath?: string;
+  stdoutTail?: string;
+  stderrTail?: string;
+  outputTail?: string;
   terminalId?: string;
+  pid?: number;
   startedAt?: string;
   completedAt?: string;
 }
 
 /** Tracked background task → the ACP tool_call_id we address its updates with. */
 interface TrackedTask {
-  /** ACP tool_call_id for this task's card. Prefixed so it can't collide with real tool call ids. */
+  /**
+   * ACP tool_call_id for this task's card. For background Bash we reuse the
+   * original launch card's id (from `session.updated.toolCallId`), so the
+   * lifecycle attaches to the existing terminal card instead of spawning a
+   * second `[background]` card. For sub-agents (no resolvable launch card) we
+   * mint a fresh `bg_<uuid>` id.
+   */
   acpCallId: string;
   /** Description shown in the card title (from the launch `session.updated`). */
   description: string;
@@ -62,6 +72,17 @@ interface TrackedTask {
   lastStatus: string;
   /** messageId for the background-result message stream (allocated lazily). */
   messageId?: string;
+  /**
+   * The originating tool call id when this task reuses a launch card (background
+   * Bash). Undefined for sub-agent tasks that mint their own `bg_*` card.
+   */
+  sourceToolCallId?: string;
+  /**
+   * True when acpCallId === sourceToolCallId (background Bash reusing the
+   * launch terminal card). Drives the terminal_exit + terminalSentData cleanup
+   * on completion so Zed's terminal UI closes cleanly.
+   */
+  reusesLaunchCard: boolean;
 }
 
 /** Map a zcode background task status string to an ACP ToolCallStatus. */
@@ -152,9 +173,37 @@ export class BackgroundTaskListener implements EventListener {
     const acpStatus = toAcpStatus(status);
     let task = this.tasks.get(taskId);
     if (!task) {
-      // First sighting → emit a fresh tool_call card.
+      // First sighting → decide whether to reuse the launch card or mint a
+      // fresh bg_* card. Background Bash: the dispatcher seeds
+      // `terminalSentData[toolCallId]` when the launch card is created, so its
+      // presence means the client already has a terminal card for this call —
+      // route the lifecycle back to it instead of creating a duplicate. Sub-
+      // agents (Agent/Task tool) have no such launch card → fall back to bg_*.
+      const launchToolCallId = p.toolCallId;
+      const reusesLaunchCard =
+        !!launchToolCallId && this.server.terminalSentData.has(launchToolCallId);
+      if (reusesLaunchCard) {
+        task = {
+          acpCallId: launchToolCallId!,
+          sourceToolCallId: launchToolCallId!,
+          reusesLaunchCard: true,
+          description: p.description ?? "",
+          lastStatus: "",
+        };
+        this.tasks.set(taskId, task);
+        // The launch card already exists (dispatch created it in the main
+        // turn). Don't emit a new tool_call — just push the first status update
+        // so the card reflects "running in background" with task metadata.
+        await this.emitStatusUpdate(task, acpStatus, p);
+        log(
+          `  [bg] reusing launch card ${launchToolCallId!.slice(-12)} for task ${taskId.slice(-12)}`,
+        );
+        return;
+      }
+      // No launch card to reuse → emit a fresh [background] tool_call card.
       task = {
         acpCallId: `bg_${randomUUID().slice(0, 12)}`,
+        reusesLaunchCard: false,
         description: p.description ?? "",
         lastStatus: "",
       };
@@ -181,11 +230,85 @@ export class BackgroundTaskListener implements EventListener {
       }
       return;
     }
-    // Subsequent sighting → status update only (skip no-ops).
+    await this.emitStatusUpdate(task, acpStatus, p);
+  }
+
+  /**
+   * Push a status update for an already-tracked task. For background Bash
+   * (reusesLaunchCard), a terminal-state transition also streams the final
+   * output via terminal_output and closes the terminal UI with terminal_exit
+   * (mirroring dispatchTerminalUpdate's 2-notification split), then clears
+   * terminalSentData so the launch card is fully retired.
+   */
+  private async emitStatusUpdate(
+    task: TrackedTask,
+    acpStatus: "in_progress" | "completed" | "failed",
+    p: TaskStatusPayload,
+  ): Promise<void> {
+    // Skip no-op status updates (same as last advertised).
+    if (task.lastStatus === acpStatus && !task.reusesLaunchCard) return;
+
+    const meta: Record<string, unknown> = {
+      backgroundTask: { taskId: p.taskId },
+    };
+    if (p.outputPath) (meta.backgroundTask as Record<string, unknown>)["outputPath"] = p.outputPath;
+
+    const isTerminal = acpStatus === "completed" || acpStatus === "failed";
+
+    // Background Bash closing a launch terminal card: stream final output +
+    // emit terminal_exit so Zed's terminal UI finalises. The terminal_output
+    // diff guard mirrors dispatchTerminalUpdate (only emit the suffix beyond
+    // what was already streamed; for a background launch the launch text was
+    // already sent, so outputTail here is the real command output).
+    if (task.reusesLaunchCard && isTerminal && task.sourceToolCallId) {
+      const finalOutput = p.outputTail ?? p.stdoutTail ?? "";
+      const lastSent = this.server.terminalSentData.get(task.sourceToolCallId) ?? "";
+      // Only skip terminal_output when launch text was actually streamed
+      // (lastSent non-empty). An empty marker ("") just flags "this is a
+      // tracked background launch card" — no content was streamed, so the
+      // final output must be emitted.
+      const alreadyStreamed = lastSent.length > 0;
+      if (finalOutput && !alreadyStreamed) {
+        const delta =
+          lastSent && finalOutput.startsWith(lastSent)
+            ? finalOutput.slice(lastSent.length)
+            : finalOutput;
+        if (delta) {
+          this.server.terminalSentData.set(task.sourceToolCallId, finalOutput);
+          await this.server.notifyByZcodeSid(this.zcodeSid, {
+            sessionUpdate: "tool_call_update",
+            toolCallId: task.sourceToolCallId,
+            _meta: { terminal_output: { terminal_id: task.sourceToolCallId, data: delta } },
+          });
+        }
+      }
+      // terminal_exit closes the terminal card. exit_code inferred: failed
+      // status → 1, else 0 (background Bash carries no perf.exitCode here).
+      const exitCode = acpStatus === "failed" ? 1 : 0;
+      (meta.backgroundTask as Record<string, unknown>)["completed"] = true;
+      await this.server.notifyByZcodeSid(this.zcodeSid, {
+        sessionUpdate: "tool_call_update",
+        toolCallId: task.sourceToolCallId,
+        status: acpStatus,
+        content: [{ type: "terminal", terminalId: task.sourceToolCallId }],
+        _meta: {
+          ...meta,
+          claudeCode: { toolName: "Bash" },
+          terminal_exit: {
+            terminal_id: task.sourceToolCallId,
+            exit_code: exitCode,
+            signal: null,
+          },
+        },
+      });
+      this.server.terminalSentData.delete(task.sourceToolCallId);
+      task.lastStatus = acpStatus;
+      log(`  [bg] launch card ${task.sourceToolCallId.slice(-12)} → ${acpStatus} (terminal_exit)`);
+      return;
+    }
+
+    // Subsequent sighting (bg_* card) or non-terminal → status update only.
     if (task.lastStatus === acpStatus) return;
-    const bgMeta: Record<string, unknown> = { taskId };
-    if (p.outputPath) bgMeta["outputPath"] = p.outputPath;
-    const meta: Record<string, unknown> = { backgroundTask: bgMeta };
     const ok = await this.server.notifyByZcodeSid(this.zcodeSid, {
       sessionUpdate: "tool_call_update",
       toolCallId: task.acpCallId,
@@ -194,7 +317,7 @@ export class BackgroundTaskListener implements EventListener {
     });
     task.lastStatus = acpStatus;
     if (ok) {
-      log(`  [bg] task status update: ${taskId.slice(-12)} → ${acpStatus}`);
+      log(`  [bg] task status update: ${p.taskId.slice(-12)} → ${acpStatus}`);
     }
   }
 
@@ -221,17 +344,38 @@ export class BackgroundTaskListener implements EventListener {
   /**
    * Mark a tracked task as cancelled (used by `session/cancelBackgroundTask`).
    * Emits a final `failed` update with `_meta.backgroundTask.cancelled = true`
-   * so the editor card reflects the cancellation, then drops local state.
+   * so the editor card reflects the cancellation, then drops local state. For
+   * background Bash reusing a launch terminal card, also emits terminal_exit
+   * and clears terminalSentData so the terminal UI closes cleanly.
    */
   async markCancelled(taskId: string): Promise<void> {
     const task = this.tasks.get(taskId);
     if (!task) return;
-    await this.server.notifyByZcodeSid(this.zcodeSid, {
-      sessionUpdate: "tool_call_update",
-      toolCallId: task.acpCallId,
-      status: "failed",
-      _meta: { backgroundTask: { taskId, cancelled: true } },
-    });
+    if (task.reusesLaunchCard && task.sourceToolCallId) {
+      await this.server.notifyByZcodeSid(this.zcodeSid, {
+        sessionUpdate: "tool_call_update",
+        toolCallId: task.sourceToolCallId,
+        status: "failed",
+        content: [{ type: "terminal", terminalId: task.sourceToolCallId }],
+        _meta: {
+          backgroundTask: { taskId, cancelled: true },
+          claudeCode: { toolName: "Bash" },
+          terminal_exit: {
+            terminal_id: task.sourceToolCallId,
+            exit_code: 1,
+            signal: null,
+          },
+        },
+      });
+      this.server.terminalSentData.delete(task.sourceToolCallId);
+    } else {
+      await this.server.notifyByZcodeSid(this.zcodeSid, {
+        sessionUpdate: "tool_call_update",
+        toolCallId: task.acpCallId,
+        status: "failed",
+        _meta: { backgroundTask: { taskId, cancelled: true } },
+      });
+    }
     this.tasks.delete(taskId);
     log(`  [bg] task cancelled: ${taskId.slice(-12)}`);
   }

--- a/src/handlers/dispatch.ts
+++ b/src/handlers/dispatch.ts
@@ -110,8 +110,18 @@ function dispatchToolCallUpdate(
     server.supportsTerminalOutput() && (toolName === "Bash" || toolName === "bash");
 
   if (termSupported) {
-    // Bash terminal protocol (full 2-notification split arrives in Commit 5).
-    // For now emit the terminal_output data + the standard update with status.
+    // Background Bash: the `result` event carries the launch acknowledgement
+    // ("Command running in background with ID: exec_…"), NOT the final output.
+    // Closing the card now (terminal_exit + status:completed) would make it
+    // indistinguishable from a normal Bash call and steal the lifecycle from
+    // the BackgroundTaskListener, which owns the real completion via
+    // out-of-band `session.updated` events. So stream any launch text via
+    // terminal_output and leave the card in_progress.
+    if (ev.background) {
+      return dispatchTerminalUpdate(server, cx, acpSid, ev, toolName, {
+        skipExit: true,
+      });
+    }
     return dispatchTerminalUpdate(server, cx, acpSid, ev, toolName);
   }
 
@@ -171,6 +181,7 @@ async function dispatchTerminalUpdate(
   acpSid: string,
   ev: Extract<InternalEvent, { kind: "ToolCallUpdate" }>,
   toolName: string,
+  opts: { skipExit?: boolean } = {},
 ): Promise<void> {
   // Extract the textual output from whichever payload field carries it.
   let termData: unknown = ev.rawOutput ?? ev.rawResult;
@@ -200,6 +211,18 @@ async function dispatchTerminalUpdate(
         _meta: { terminal_output: { terminal_id: ev.callId, data: delta } },
       });
     }
+  }
+
+  // Background Bash launch: leave the card in_progress — BackgroundTaskListener
+  // owns the final status + terminal_exit via out-of-band session.updated. We
+  // MUST still seed terminalSentData with an empty entry (even when no launch
+  // text was streamed) so the listener can recognise this callId as a tracked
+  // launch card and route its updates back to the same card.
+  if (opts.skipExit) {
+    if (!server.terminalSentData.has(ev.callId)) {
+      server.terminalSentData.set(ev.callId, "");
+    }
+    return;
   }
 
   // ② terminal_exit (terminal state) — only on completed/failed.

--- a/src/translators/event-translator.ts
+++ b/src/translators/event-translator.ts
@@ -27,6 +27,18 @@ interface ZcodeEventPayload {
   payload?: Record<string, unknown>;
 }
 
+/**
+ * Whether a tool input dict declared `run_in_background: true`. Used to tag
+ * ToolCallNew/Update events so the dispatcher and BackgroundTaskListener can
+ * keep the launch card in_progress and own its lifecycle via out-of-band
+ * `session.updated` events (rather than closing it the instant the launch
+ * acknowledgement returns).
+ */
+function isBackgroundInput(inp: unknown): boolean {
+  if (!inp || typeof inp !== "object" || Array.isArray(inp)) return false;
+  return (inp as Record<string, unknown>)["run_in_background"] === true;
+}
+
 export class EventTranslator {
   turnStarted = false;
   turnDone = false;
@@ -49,6 +61,14 @@ export class EventTranslator {
   readonly toolInputs = new Map<string, unknown>();
   /** Tool call ids that reached a terminal state (result/error). */
   readonly finalToolIds = new Set<string>();
+  /**
+   * call_ids launched with `run_in_background: true`. Populated when the
+   * scheduled event resolves the input (streaming cache or payload), so the
+   * later `result` event — whose input is omitted — can still mark its
+   * ToolCallUpdate as background. Read by `translateTool` to thread the flag
+   * through to dispatch (which skips terminal_exit for background Bash).
+   */
+  readonly backgroundCallIds = new Set<string>();
 
   /** Translate one zcode event into 0..n internal events. */
   translate(event: ZcodeEventPayload): InternalEvent[] {
@@ -145,6 +165,11 @@ export class EventTranslator {
         if (inp === undefined) inp = this.toolInputs.get(callId);
         const summary = summarizeToolInput(toolName, inp);
         const title = summary ? `${toolName}: ${summary}` : toolName;
+        // Track background launches so the later `result` event (input omitted)
+        // can still tag its ToolCallUpdate. The BackgroundTaskListener also
+        // keys off this to know which callId owns the card.
+        const isBackground = isBackgroundInput(inp);
+        if (isBackground) this.backgroundCallIds.add(callId);
         const newEv: InternalEvent = {
           kind: "ToolCallNew",
           callId,
@@ -152,6 +177,7 @@ export class EventTranslator {
           acpKind,
           status: "pending",
           title,
+          ...(isBackground ? { background: true } : {}),
         };
         if (inp !== undefined) (newEv as { input?: unknown }).input = inp;
         const locs = extractLocations(toolName, inp);
@@ -186,6 +212,7 @@ export class EventTranslator {
           status: "completed",
           output: renderToolOutput(resultPayload),
           rawResult: resultPayload,
+          ...(this.backgroundCallIds.has(callId) ? { background: true } : {}),
         };
         // Bash content handled by the terminal path in dispatch; skip here.
         if (tn !== "Bash" && tn !== "bash") {
@@ -205,6 +232,7 @@ export class EventTranslator {
           tool: tn,
           status: "failed",
           output: renderToolOutput(errPayload),
+          ...(this.backgroundCallIds.has(callId) ? { background: true } : {}),
         };
         const content = buildResultContent(tn, errPayload, true);
         if (content.length > 0) (ev as { content?: typeof content }).content = content;

--- a/src/translators/types.ts
+++ b/src/translators/types.ts
@@ -28,6 +28,13 @@ export interface ToolCallNewEvent {
   content?: ToolCallContent[];
   diffContent?: ToolCallContent[];
   locations?: ToolCallLocation[];
+  /**
+   * True when the tool was launched with `run_in_background: true` (currently
+   * only Bash). The dispatcher uses this to keep the card in_progress instead
+   * of emitting a premature terminal_exit — the BackgroundTaskListener owns
+   * the final status via out-of-band `session.updated` events.
+   */
+  background?: boolean;
 }
 
 export interface ToolCallUpdateEvent {
@@ -41,6 +48,13 @@ export interface ToolCallUpdateEvent {
   content?: ToolCallContent[];
   diffContent?: ToolCallContent[];
   locations?: ToolCallLocation[];
+  /**
+   * Carries the background flag from the originating ToolCallNew through to
+   * `result` updates so the dispatcher can skip terminal_exit for background
+   * Bash. Resolved from a per-translator `backgroundCallIds` cache because
+   * `tool.updated { kind:"result" }` omits the input.
+   */
+  background?: boolean;
 }
 
 export interface UsageDeltaEvent {

--- a/tests/background-tasks.test.ts
+++ b/tests/background-tasks.test.ts
@@ -16,6 +16,9 @@ import type { ZcodeEvent } from "../src/backend/types.js";
 /** A minimal fake server: records every session/update it would send. */
 interface FakeServer {
   calls: Array<{ zcodeSid: string; update: Record<string, unknown> }>;
+  /** Mirrors ZcodeAcpServer.terminalSentData — set by tests to simulate a
+   *  tracked launch card so BackgroundTaskListener reuses it. */
+  terminalSentData: Map<string, string>;
 }
 type TestServer = FakeServer & Pick<ZcodeAcpServer, "notifyByZcodeSid">;
 
@@ -23,6 +26,7 @@ function makeServer(): TestServer {
   const calls: TestServer["calls"] = [];
   const server = {
     calls,
+    terminalSentData: new Map<string, string>(),
     async notifyByZcodeSid(zcodeSid: string, update: Record<string, unknown>): Promise<boolean> {
       calls.push({ zcodeSid, update });
       return true;
@@ -80,9 +84,7 @@ describe("BackgroundTaskListener", () => {
     const l = new BackgroundTaskListener(server as unknown as ZcodeAcpServer, "sess_test");
     l.handleEvent(zcodeEvent("session.updated", { taskId: "agent_abc", status: "running" }));
     await Promise.resolve();
-    l.handleEvent(
-      zcodeEvent("session.updated", { taskId: "agent_abc", status: "completed" }),
-    );
+    l.handleEvent(zcodeEvent("session.updated", { taskId: "agent_abc", status: "completed" }));
     await Promise.resolve();
     expect(server.calls).toHaveLength(2);
     const update = server.calls[1]!.update;
@@ -106,7 +108,9 @@ describe("BackgroundTaskListener", () => {
   it("ignores session.updated without taskId (e.g. usage updates)", async () => {
     const server = makeServer();
     const l = new BackgroundTaskListener(server as unknown as ZcodeAcpServer, "sess_test");
-    l.handleEvent(zcodeEvent("session.updated", { usage: { inputTokens: 123 }, contextWindow: 1000 }));
+    l.handleEvent(
+      zcodeEvent("session.updated", { usage: { inputTokens: 123 }, contextWindow: 1000 }),
+    );
     await Promise.resolve();
     expect(server.calls).toHaveLength(0);
   });
@@ -200,5 +204,172 @@ describe("BackgroundTaskListener", () => {
     ).not.toThrow();
     expect(() => l.handleEvent(zcodeEvent("unknown.type", {}))).not.toThrow();
     await Promise.resolve();
+  });
+});
+
+describe("BackgroundTaskListener: background Bash reuses launch card", () => {
+  it("reuses the launch toolCallId when terminalSentData tracks it (no new bg_ card)", async () => {
+    const server = makeServer();
+    // Simulate the dispatcher having already seeded the launch card.
+    server.terminalSentData.set("call_bash1", "Command running in background with ID: exec_x\n");
+    const l = new BackgroundTaskListener(server as unknown as ZcodeAcpServer, "sess_test");
+    l.handleEvent(
+      zcodeEvent("session.updated", {
+        taskId: "exec_x",
+        toolCallId: "call_bash1",
+        toolName: "Bash",
+        status: "running",
+        description: "sleep 3",
+        outputPath: "/tmp/out.log",
+      }),
+    );
+    await Promise.resolve();
+    expect(server.calls).toHaveLength(1);
+    const update = server.calls[0]!.update;
+    // Routes to the launch card id, NOT a fresh bg_*.
+    expect(update["toolCallId"]).toBe("call_bash1");
+    expect(update["sessionUpdate"]).toBe("tool_call_update");
+    expect(update["status"]).toBe("in_progress");
+    expect((update["_meta"] as { backgroundTask: { taskId: string } }).backgroundTask.taskId).toBe(
+      "exec_x",
+    );
+    // No tool_call (new card) was emitted.
+    expect(server.calls.some((c) => c.update["sessionUpdate"] === "tool_call")).toBe(false);
+  });
+
+  it("emits terminal_output + terminal_exit on completion and clears terminalSentData", async () => {
+    const server = makeServer();
+    server.terminalSentData.set("call_bash2", "Command running in background with ID: exec_y\n");
+    const l = new BackgroundTaskListener(server as unknown as ZcodeAcpServer, "sess_test");
+    l.handleEvent(
+      zcodeEvent("session.updated", {
+        taskId: "exec_y",
+        toolCallId: "call_bash2",
+        status: "running",
+      }),
+    );
+    await Promise.resolve();
+    // Task completes with real output. Since the launch text was already
+    // streamed (terminalSentData key present = alreadyStreamed), terminal_output
+    // must be SKIPPED (matches dispatchTerminalUpdate's result-replay guard).
+    l.handleEvent(
+      zcodeEvent("session.updated", {
+        taskId: "exec_y",
+        toolCallId: "call_bash2",
+        status: "completed",
+        outputTail: "done\n",
+      }),
+    );
+    await Promise.resolve();
+    // Exactly two updates: in_progress + terminal_exit (no terminal_output).
+    expect(server.calls).toHaveLength(2);
+    const exitCall = server.calls[1]!.update;
+    expect(exitCall["status"]).toBe("completed");
+    expect(exitCall["content"]).toEqual([{ type: "terminal", terminalId: "call_bash2" }]);
+    const meta = exitCall["_meta"] as {
+      terminal_exit: { terminal_id: string; exit_code: number };
+      backgroundTask: { completed: boolean };
+      claudeCode: { toolName: string };
+    };
+    expect(meta.terminal_exit.terminal_id).toBe("call_bash2");
+    expect(meta.terminal_exit.exit_code).toBe(0);
+    expect(meta.backgroundTask.completed).toBe(true);
+    expect(meta.claudeCode.toolName).toBe("Bash");
+    // terminalSentData cleared so the launch card is fully retired.
+    expect(server.terminalSentData.has("call_bash2")).toBe(false);
+  });
+
+  it("streams terminal_output when launch text was never streamed (empty marker)", async () => {
+    const server = makeServer();
+    // Dispatcher seeded an empty marker (no launch text streamed yet).
+    server.terminalSentData.set("call_bash3", "");
+    const l = new BackgroundTaskListener(server as unknown as ZcodeAcpServer, "sess_test");
+    l.handleEvent(
+      zcodeEvent("session.updated", {
+        taskId: "exec_z",
+        toolCallId: "call_bash3",
+        status: "running",
+      }),
+    );
+    await Promise.resolve();
+    l.handleEvent(
+      zcodeEvent("session.updated", {
+        taskId: "exec_z",
+        toolCallId: "call_bash3",
+        status: "completed",
+        outputTail: "result\n",
+      }),
+    );
+    await Promise.resolve();
+    // running update + terminal_output + terminal_exit.
+    expect(server.calls).toHaveLength(3);
+    const termOutput = server.calls[1]!.update;
+    const termMeta = termOutput["_meta"] as { terminal_output: { data: string } };
+    expect(termMeta.terminal_output.data).toBe("result\n");
+  });
+
+  it("falls back to a fresh bg_* card when toolCallId is absent (sub-agent case)", async () => {
+    const server = makeServer();
+    const l = new BackgroundTaskListener(server as unknown as ZcodeAcpServer, "sess_test");
+    l.handleEvent(
+      zcodeEvent("session.updated", {
+        taskId: "agent_sub1",
+        status: "running",
+        description: "research src/",
+        terminalId: "agent_sub1",
+      }),
+    );
+    await Promise.resolve();
+    // No toolCallId → no terminalSentData entry → falls back to new bg_* card.
+    const update = server.calls[0]!.update;
+    expect(update["sessionUpdate"]).toBe("tool_call");
+    expect(String(update["toolCallId"]).startsWith("bg_")).toBe(true);
+    expect(update["title"]).toBe("[background] research src/");
+  });
+
+  it("falls back to a fresh bg_* card when terminalSentData does not track the toolCallId", async () => {
+    const server = makeServer();
+    const l = new BackgroundTaskListener(server as unknown as ZcodeAcpServer, "sess_test");
+    // toolCallId present but dispatcher never seeded it (e.g. old backend).
+    l.handleEvent(
+      zcodeEvent("session.updated", {
+        taskId: "exec_untracked",
+        toolCallId: "call_orphan",
+        status: "running",
+        description: "mystery task",
+      }),
+    );
+    await Promise.resolve();
+    const update = server.calls[0]!.update;
+    expect(update["sessionUpdate"]).toBe("tool_call");
+    expect(String(update["toolCallId"]).startsWith("bg_")).toBe(true);
+    expect(update["title"]).toBe("[background] mystery task");
+  });
+
+  it("markCancelled emits terminal_exit for a reused launch card", async () => {
+    const server = makeServer();
+    server.terminalSentData.set("call_bash4", "bg launch text\n");
+    const l = new BackgroundTaskListener(server as unknown as ZcodeAcpServer, "sess_test");
+    l.handleEvent(
+      zcodeEvent("session.updated", {
+        taskId: "exec_cancel",
+        toolCallId: "call_bash4",
+        status: "running",
+      }),
+    );
+    await Promise.resolve();
+    await l.markCancelled("exec_cancel");
+    // running update + cancel (terminal_exit with cancelled flag).
+    expect(server.calls).toHaveLength(2);
+    const cancel = server.calls[1]!.update;
+    expect(cancel["status"]).toBe("failed");
+    expect(cancel["content"]).toEqual([{ type: "terminal", terminalId: "call_bash4" }]);
+    const meta = cancel["_meta"] as {
+      backgroundTask: { cancelled: boolean };
+      terminal_exit: { exit_code: number };
+    };
+    expect(meta.backgroundTask.cancelled).toBe(true);
+    expect(meta.terminal_exit.exit_code).toBe(1);
+    expect(server.terminalSentData.has("call_bash4")).toBe(false);
   });
 });

--- a/tests/background-tasks.test.ts
+++ b/tests/background-tasks.test.ts
@@ -237,7 +237,12 @@ describe("BackgroundTaskListener: background Bash reuses launch card", () => {
     expect(server.calls.some((c) => c.update["sessionUpdate"] === "tool_call")).toBe(false);
   });
 
-  it("emits terminal_output + terminal_exit on completion and clears terminalSentData", async () => {
+  it("streams the real command output on completion even when launch text was already streamed", async () => {
+    // Regression: launch acknowledgement text ("Command running in background
+    // with ID: …") is written to terminalSentData by the dispatcher, but it is
+    // NOT the command's actual output. The real output (outputTail) must still
+    // be streamed via terminal_output on completion, or the user never sees
+    // what the background command printed.
     const server = makeServer();
     server.terminalSentData.set("call_bash2", "Command running in background with ID: exec_y\n");
     const l = new BackgroundTaskListener(server as unknown as ZcodeAcpServer, "sess_test");
@@ -249,9 +254,6 @@ describe("BackgroundTaskListener: background Bash reuses launch card", () => {
       }),
     );
     await Promise.resolve();
-    // Task completes with real output. Since the launch text was already
-    // streamed (terminalSentData key present = alreadyStreamed), terminal_output
-    // must be SKIPPED (matches dispatchTerminalUpdate's result-replay guard).
     l.handleEvent(
       zcodeEvent("session.updated", {
         taskId: "exec_y",
@@ -260,10 +262,18 @@ describe("BackgroundTaskListener: background Bash reuses launch card", () => {
         outputTail: "done\n",
       }),
     );
-    await Promise.resolve();
-    // Exactly two updates: in_progress + terminal_exit (no terminal_output).
-    expect(server.calls).toHaveLength(2);
-    const exitCall = server.calls[1]!.update;
+    // onTaskStatus awaits multiple notifyByZcodeSid calls; flush enough
+    // microtasks for the whole async chain (including terminalSentData.delete)
+    // to settle.
+    for (let i = 0; i < 4; i++) await Promise.resolve();
+    // Exactly three updates: in_progress + terminal_output + terminal_exit.
+    expect(server.calls).toHaveLength(3);
+    const outputCall = server.calls[1]!.update;
+    expect(outputCall["sessionUpdate"]).toBe("tool_call_update");
+    expect(
+      (outputCall["_meta"] as { terminal_output: { data: string } }).terminal_output.data,
+    ).toBe("done\n");
+    const exitCall = server.calls[2]!.update;
     expect(exitCall["status"]).toBe("completed");
     expect(exitCall["content"]).toEqual([{ type: "terminal", terminalId: "call_bash2" }]);
     const meta = exitCall["_meta"] as {
@@ -306,6 +316,50 @@ describe("BackgroundTaskListener: background Bash reuses launch card", () => {
     const termOutput = server.calls[1]!.update;
     const termMeta = termOutput["_meta"] as { terminal_output: { data: string } };
     expect(termMeta.terminal_output.data).toBe("result\n");
+  });
+
+  it("diffs cumulative outputTail snapshots during running progress (no duplication)", async () => {
+    // The backend pushes session.updated multiple times during a long-running
+    // background task, each carrying a CUMULATIVE outputTail snapshot. Only the
+    // suffix beyond what we last streamed must be emitted.
+    const server = makeServer();
+    server.terminalSentData.set("call_bash5", "");
+    const l = new BackgroundTaskListener(server as unknown as ZcodeAcpServer, "sess_test");
+    l.handleEvent(
+      zcodeEvent("session.updated", {
+        taskId: "exec_progress",
+        toolCallId: "call_bash5",
+        status: "running",
+        outputTail: "line1\n",
+      }),
+    );
+    await Promise.resolve();
+    l.handleEvent(
+      zcodeEvent("session.updated", {
+        taskId: "exec_progress",
+        toolCallId: "call_bash5",
+        status: "running",
+        outputTail: "line1\nline2\n",
+      }),
+    );
+    await Promise.resolve();
+    l.handleEvent(
+      zcodeEvent("session.updated", {
+        taskId: "exec_progress",
+        toolCallId: "call_bash5",
+        status: "completed",
+        outputTail: "line1\nline2\nline3\n",
+      }),
+    );
+    await Promise.resolve();
+    // running(status update) + terminal_output(line1) + terminal_output(line2)
+    // + terminal_output(line3) + terminal_exit.
+    const outputs = server.calls
+      .filter((c) => (c.update["_meta"] as { terminal_output?: unknown }).terminal_output)
+      .map(
+        (c) => (c.update["_meta"] as { terminal_output: { data: string } }).terminal_output.data,
+      );
+    expect(outputs).toEqual(["line1\n", "line2\n", "line3\n"]);
   });
 
   it("falls back to a fresh bg_* card when toolCallId is absent (sub-agent case)", async () => {

--- a/tests/event-translator.test.ts
+++ b/tests/event-translator.test.ts
@@ -185,3 +185,86 @@ describe("EventTranslator background-task turn deferral", () => {
     expect(t.seenToolIds.has("c1")).toBe(false);
   });
 });
+
+describe("EventTranslator run_in_background flag threading", () => {
+  it("tags ToolCallNew as background when input.run_in_background=true (cached from streaming)", () => {
+    const t = new EventTranslator();
+    // model.streaming tool_call declares the background launch.
+    t.translate(
+      ev("model.streaming", {
+        kind: "tool_call",
+        toolCallId: "c1",
+        toolName: "Bash",
+        input: { command: "sleep 3", run_in_background: true },
+      }),
+    );
+    const out = t.translate(
+      ev("tool.updated", { kind: "scheduled", toolCallId: "c1", inputOmitted: true }),
+    );
+    const newEv = out[0] as Extract<InternalEvent, { kind: "ToolCallNew" }>;
+    expect(newEv.background).toBe(true);
+    // Cached for later result lookup.
+    expect(t.backgroundCallIds.has("c1")).toBe(true);
+  });
+
+  it("tags ToolCallNew as background when scheduled payload carries input directly", () => {
+    const t = new EventTranslator();
+    const out = t.translate(
+      ev("tool.updated", {
+        kind: "scheduled",
+        toolCallId: "c2",
+        toolName: "Bash",
+        input: { command: "echo hi", run_in_background: true },
+      }),
+    );
+    const newEv = out[0] as Extract<InternalEvent, { kind: "ToolCallNew" }>;
+    expect(newEv.background).toBe(true);
+  });
+
+  it("does NOT tag as background when run_in_background is absent or false", () => {
+    const t = new EventTranslator();
+    const out = t.translate(
+      ev("tool.updated", {
+        kind: "scheduled",
+        toolCallId: "c3",
+        toolName: "Bash",
+        input: { command: "ls" },
+      }),
+    );
+    const newEv = out[0] as Extract<InternalEvent, { kind: "ToolCallNew" }>;
+    expect(newEv.background).toBeUndefined();
+  });
+
+  it("threads background flag through to the result ToolCallUpdate (input omitted on result)", () => {
+    const t = new EventTranslator();
+    t.translate(
+      ev("model.streaming", {
+        kind: "tool_call",
+        toolCallId: "c4",
+        toolName: "Bash",
+        input: { command: "sleep 3", run_in_background: true },
+      }),
+    );
+    t.translate(ev("tool.updated", { kind: "scheduled", toolCallId: "c4", inputOmitted: true }));
+    const out = t.translate(
+      ev("tool.updated", {
+        kind: "result",
+        toolCallId: "c4",
+        result: { success: true, content: "Command running in background with ID: exec_…" },
+      }),
+    );
+    const u = out[0] as Extract<InternalEvent, { kind: "ToolCallUpdate" }>;
+    expect(u.background).toBe(true);
+    expect(u.status).toBe("completed");
+  });
+
+  it("does not tag a foreground Bash result as background", () => {
+    const t = new EventTranslator();
+    t.translate(ev("tool.updated", { kind: "scheduled", toolCallId: "c5", toolName: "Bash" }));
+    const out = t.translate(
+      ev("tool.updated", { kind: "result", toolCallId: "c5", result: { content: "done" } }),
+    );
+    const u = out[0] as Extract<InternalEvent, { kind: "ToolCallUpdate" }>;
+    expect(u.background).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Solution: reuse the launch card

让 BackgroundTaskListener 把后台生命周期路由回**发起卡片**，单卡呈现完整生命周期，不再产生重复卡片。

### Changes

**1. `translators/event-translator.ts` + `translators/types.ts`** — 透传 `background` 标志
- 从 `input.run_in_background` 识别后台 Bash，缓存到 `backgroundCallIds: Set<string>`
- `ToolCallNew` / `ToolCallUpdate` 加 `background?: boolean` 字段
- 解决了 `tool.updated { kind:"result" }` 的 `inputOmitted:true` 难题——通过 `scheduled` 阶段缓存的 callId 查询

**2. `handlers/dispatch.ts`** — 后台 Bash 发起卡保持 in_progress
- `dispatchTerminalUpdate` 新增 `skipExit` 选项
- 后台 Bash 的 result 阶段跳过 `terminal_exit`，只发 `terminal_output`，卡片保持 `in_progress`
- 在 `terminalSentData` 留空标记，作为"这是被跟踪的发起卡"信号给 BackgroundTaskListener

**3. `handlers/background-tasks.ts`** — 复用发起卡片 + 完成时收尾
- `onTaskStatus` 检测到 `session.updated.toolCallId` 在 `terminalSentData` 中时，复用该 toolCallId（不再新建 `bg_*`）
- 完成态发 `terminal_output`（若 launch text 没流过）+ `terminal_exit` 收尾，清理 `terminalSentData`
- `markCancelled` 对复用卡片同样补 `terminal_exit`
- **回退路径**：toolCallId 缺失或未跟踪（子代理场景）仍走原来的 `bg_*` 新建卡片逻辑，#21 完全不受影响

**4. `docs/PROTOCOL.md`** — 新增 "Background Bash" 小节，说明复用机制与 Agent 子代理（新建 `bg_*`）的区别

### Fallback matrix

| 场景 | 行为 |
|---|---|
| 后台 Bash（`terminalSentData` 有 toolCallId） | 复用发起卡片 ✅ 新行为 |
| Agent/Task 子代理（无 toolCallId 或未跟踪） | 新建 `bg_*` 卡片（#21 原行为） |
| `toolCallId` 存在但未跟踪（老后端） | 新建 `bg_*` 卡片（安全回退） |

## Verification

- `pnpm typecheck` ✅
- `pnpm test` ✅ 271 tests passed（含新增 16 个）
- 新增测试覆盖：
  - translator: background 标志从 streaming cache / scheduled payload / 缺失 三种情况（5 个）
  - background-tasks: 卡片复用 / 完成收尾 / 空 marker 流 output / 回退 / 取消（7 个）
- probe 脚本确认真实事件流与本设计一致（脚本已清理，不入库）

## Untouched

- Agent/Task 工具的 `run_in_background`：#21 已处理，本次不动
- `tool-helpers.ts` 的 `parseSubagentMetadata` / `BACKGROUND_RE`：不动
- 发起卡片 title / kind：保持 `Bash: <cmd>` / `execute`，靠 in_progress→completed 状态机区分而非改名
EOF
