### PR TITLE
fix: stop dropping dragged-file attachments in session/prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,4 @@ coverage/
 
 # npm pack output
 *.tgz
-.zcode/plans/
+.zcode

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -552,24 +552,52 @@ async function preemptInFlightTurn(
 
 // ---------- internals ----------
 
-/** Concatenate text from ACP ContentBlocks into a prompt string. */
-function extractPromptText(blocks: acp.ContentBlock[] | undefined): string {
+/** Concatenate text from ACP ContentBlock[] into a prompt string.
+ *  Exported for unit testing (the resource_link path is easy to break). */
+export function extractPromptText(blocks: acp.ContentBlock[] | undefined): string {
   const parts: string[] = [];
   for (const block of blocks ?? []) {
+    // ACP ContentBlock is a discriminated union on `type`. The resource_link
+    // variant carries `name` + `uri` flat on the block itself (NOT nested under
+    // a `resource_link` key — see ACP schema $defs.ResourceLink). Accessing
+    // `block.resource_link` silently dropped every dragged-file attachment.
     const b = block as {
       type?: string;
       text?: string;
-      resource_link?: { name?: string; uri?: string };
+      name?: string;
+      uri?: string;
+      resource?: { text?: string; uri?: string };
     };
     if (b.type === "text" && b.text) {
       parts.push(b.text);
-    } else if (b.type === "resource_link" && b.resource_link) {
-      parts.push(
-        `[related resource: ${b.resource_link.name ?? b.resource_link.uri ?? ""}](${b.resource_link.uri ?? ""})`,
-      );
+    } else if (b.type === "resource_link" && b.uri) {
+      // Convert file:// URIs to absolute paths so the model treats them as
+      // readable filesystem locations rather than opaque hyperlinks. Fall
+      // back to the path when name is missing OR empty — the ACP schema
+      // requires `name`, but a non-compliant client still deserves useful
+      // prompt text rather than `[related resource: ](/path)`.
+      const path = b.uri.startsWith("file://") ? fileUriToPath(b.uri) : b.uri;
+      const label = b.name || path;
+      parts.push(`[related resource: ${label}](${path})`);
+    } else if (b.type === "resource" && b.resource) {
+      // Embedded resource (TextResourceContents). We don't advertise
+      // embeddedContext, but accept text payloads defensively in case a client
+      // sends them anyway.
+      const text = b.resource.text;
+      if (text) parts.push(text);
     }
   }
   return parts.join("\n").trim();
+}
+
+/** Convert a file:// URI to an absolute filesystem path. */
+function fileUriToPath(uri: string): string {
+  try {
+    return decodeURIComponent(new URL(uri).pathname);
+  } catch {
+    // Not a valid URL — return as-is (best-effort).
+    return uri;
+  }
 }
 
 /** Fetch session/messages from zcode. */

--- a/tests/extract-prompt.test.ts
+++ b/tests/extract-prompt.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Regression tests for extractPromptText (prompt block flattening).
+ *
+ * History: the resource_link branch accessed `block.resource_link.name` /
+ * `.uri`, but the ACP schema defines ResourceLink with `name` and `uri` FLAT
+ * on the block (`{type:"resource_link", name, uri}`) — there is no nested
+ * `resource_link` key. The wrong access meant every dragged-file attachment
+ * was silently dropped from the prompt sent to zcode. These tests lock the
+ * correct field access and the file:// → absolute-path rewrite so a model
+ * treats dragged files as filesystem locations rather than opaque hyperlinks.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { extractPromptText } from "../src/handlers/session.js";
+
+describe("extractPromptText", () => {
+  it("concatenates multiple text blocks with newlines", () => {
+    const out = extractPromptText([
+      { type: "text", text: "first" },
+      { type: "text", text: "second" },
+    ]);
+    expect(out).toBe("first\nsecond");
+  });
+
+  it("only trims the outermost whitespace, not per-block", () => {
+    // Matches the original join("\n").trim() behaviour — internal block
+    // whitespace survives. Locks the behaviour so a future "trim each block"
+    // change is a deliberate decision, not an accident.
+    const out = extractPromptText([
+      { type: "text", text: "  hello  " },
+      { type: "text", text: "  world  " },
+    ]);
+    expect(out).toBe("hello  \n  world");
+  });
+
+  it("returns empty string for no blocks / empty blocks", () => {
+    expect(extractPromptText(undefined)).toBe("");
+    expect(extractPromptText([])).toBe("");
+  });
+
+  describe("resource_link (dragged file)", () => {
+    it("emits a markdown link with name + absolute path for file:// URIs", () => {
+      const out = extractPromptText([
+        {
+          type: "resource_link",
+          name: "AGENTS.md",
+          uri: "file:///Users/william/Develop/tools/zcode-acp-server/.zcode/AGENTS.md",
+        },
+      ]);
+      // file:// is rewritten to the absolute path so the model treats it as a
+      // filesystem location, not an opaque hyperlink.
+      expect(out).toBe(
+        "[related resource: AGENTS.md]" +
+          "(/Users/william/Develop/tools/zcode-acp-server/.zcode/AGENTS.md)",
+      );
+    });
+
+    it("falls back to the uri when name is missing", () => {
+      const out = extractPromptText([
+        {
+          type: "resource_link",
+          name: "",
+          uri: "file:///tmp/x.txt",
+        } as never,
+      ]);
+      // Per the ACP schema `name` is required, but defensively fall back to
+      // the decoded path so a non-compliant client still produces usable text.
+      expect(out).toBe("[related resource: /tmp/x.txt](/tmp/x.txt)");
+    });
+
+    it("decodes percent-encoded bytes in file:// URIs", () => {
+      const out = extractPromptText([
+        {
+          type: "resource_link",
+          name: "my file",
+          uri: "file:///Users/some%20one/file%20name.txt",
+        },
+      ]);
+      expect(out).toBe("[related resource: my file](/Users/some one/file name.txt)");
+    });
+
+    it("keeps non-file:// URIs as-is (http, etc.)", () => {
+      const out = extractPromptText([
+        {
+          type: "resource_link",
+          name: "docs",
+          uri: "https://example.com/docs",
+        },
+      ]);
+      expect(out).toBe("[related resource: docs](https://example.com/docs)");
+    });
+
+    it("regression: the resource_link branch is actually entered", () => {
+      // The bug: the old code accessed `block.resource_link.uri`, which was
+      // always undefined because the ACP schema puts `uri` flat on the block.
+      // With the fix, the link MUST appear in the output (not be silently
+      // dropped).
+      const out = extractPromptText([
+        { type: "resource_link", name: "f", uri: "file:///x" },
+        { type: "text", text: "describe this" },
+      ]);
+      expect(out).toContain("/x");
+      expect(out).toContain("describe this");
+    });
+  });
+
+  describe("resource (embedded)", () => {
+    it("inlines embedded text resource contents", () => {
+      const out = extractPromptText([
+        {
+          type: "resource",
+          resource: { uri: "file:///x", text: "embedded body" },
+        },
+      ] as never);
+      expect(out).toBe("embedded body");
+    });
+
+    it("skips embedded resources without a text payload", () => {
+      const out = extractPromptText([
+        {
+          type: "resource",
+          resource: { uri: "file:///x", blob: "aGVsbG8=" },
+        },
+      ] as never);
+      expect(out).toBe("");
+    });
+  });
+});


### PR DESCRIPTION
## Root cause

`extractPromptText` (`src/handlers/session.ts`) read the resource_link fields via a non-existent nested path:

```ts
const b = block as { type?: string; text?: string; resource_link?: { name?: string; uri?: string } };
// ...
} else if (b.type === "resource_link" && b.resource_link) { ... }
```

But the ACP schema defines `ResourceLink` with `name` and `uri` **flat on the block** (`{type:"resource_link", name, uri}`) — there is no nested `resource_link` key. So `b.resource_link` was always `undefined`, the condition was always false, and **every dragged-file attachment was silently dropped** from the prompt text sent to zcode. The user only saw the accompanying text block, never the file path.

Confirmed by capturing the actual payload Zed sends (`~/Library/Logs/Zed/Zed.log`):

```json
[{"name":"AGENTS.md","uri":"file:///Users/william/Develop/tools/zcode-acp-server/.zcode/AGENTS.md","type":"resource_link"},
 {"text":" 再看一下","type":"text"}]
```

## Fix

- Read `name` / `uri` directly off the block (per ACP `ResourceLink` schema).
- Rewrite `file://` URIs to absolute paths (with percent-decoding) so the model treats them as filesystem locations rather than opaque hyperlinks.
- Fall back from empty `name` to the path (defensive against non-compliant clients).
- Accept embedded text resources defensively even though we advertise `embeddedContext=false` (a non-compliant client would otherwise lose the content entirely).
- Export `extractPromptText` (mirrors the existing `flattenTodos` pattern) and add a 10-case regression suite.

## Why this was silent for so long

Pure-text prompts (the common case) never hit the `resource_link` branch, so the bug only surfaced when the user dragged a file in. The accompanying text block usually made the prompt look fine, masking the missing attachment.

## Verification

- `pnpm typecheck` ✅
- `pnpm test` ✅ 282/282 passed (10 new)
- `pnpm lint` ✅ 0 errors
- `pnpm prettier --write` on the 2 changed source files ✅

## Out of scope

`.gitignore` widens `.zcode/plans/` to `.zcode` so the workspace-local `.zcode/AGENTS.md` (agent notes, not for git) stays out of the repo. Bundled here because it was touched in the same session.