### PR TITLE
fix: harden slash-command push and tasks-index sync against transient failures

### DIFF
--- a/src/handlers/io.ts
+++ b/src/handlers/io.ts
@@ -63,6 +63,15 @@ export function sendAvailableCommands(
 }
 
 /**
+ * Per-session pending deferred-notification timeouts. Tracks the timers from
+ * repeated `sendAvailableCommandsDeferred` calls so a newer call can cancel
+ * the older call's still-pending timers. Without this, a slow timer (e.g.
+ * the 1000ms fire from an earlier session/load) could fire AFTER a newer
+ * call's 50ms fire, overwriting the newer command list with the stale one.
+ */
+const activeDeferredTimeouts = new Map<string, Set<ReturnType<typeof setTimeout>>>();
+
+/**
  * Send `available_commands_update` after a short delay so it lands after the
  * session response. ACP clients initialize their session state machine on the
  * response; a notification arriving earlier can be dropped, leaving the `/`
@@ -73,23 +82,48 @@ export function sendAvailableCommands(
  * at the 50ms mark, dropping the first notification. `available_commands_update`
  * is overwrite-semantics (not additive), so repeats are harmless — the client
  * keeps the latest snapshot. Fire-and-forget (returns void).
+ *
+ * Each call cancels any still-pending timers from a prior call for the same
+ * session, so a rapid sequence (e.g. load then resume) can't have an old
+ * timer overwrite the newest command list.
  */
 export function sendAvailableCommandsDeferred(
   cx: acp.AgentContext,
   sessionId: string,
   commands: ReadonlyArray<SlashCommandEntry>,
 ): void {
+  // Cancel any pending timers from a previous call so the stale command list
+  // can't overwrite the one we're about to schedule.
+  const prev = activeDeferredTimeouts.get(sessionId);
+  if (prev) {
+    for (const t of prev) clearTimeout(t);
+    prev.clear();
+  }
+  const active = new Set<ReturnType<typeof setTimeout>>();
+  activeDeferredTimeouts.set(sessionId, active);
+
   for (const delay of [50, 300, 1000]) {
     const t = setTimeout(() => {
-      sendAvailableCommands(cx, sessionId, commands).catch((e) => {
-        warn(
-          `available_commands_update failed (sid=${sessionId}, delay=${delay}): ` +
-            `${e instanceof Error ? e.message : String(e)}`,
-        );
-      });
+      sendAvailableCommands(cx, sessionId, commands)
+        .catch((e) => {
+          warn(
+            `available_commands_update failed (sid=${sessionId}, delay=${delay}): ` +
+              `${e instanceof Error ? e.message : String(e)}`,
+          );
+        })
+        .finally(() => {
+          active.delete(t);
+          // Drop the session entry once all three fires have settled, so the
+          // map doesn't retain empty Sets. Only delete if still ours — a newer
+          // call may have replaced the entry.
+          if (active.size === 0 && activeDeferredTimeouts.get(sessionId) === active) {
+            activeDeferredTimeouts.delete(sessionId);
+          }
+        });
     }, delay);
     // unref so shutdown is not held up by this deferred notification.
     t.unref?.();
+    active.add(t);
   }
 }
 

--- a/src/handlers/io.ts
+++ b/src/handlers/io.ts
@@ -11,6 +11,7 @@ import type * as acp from "@agentclientprotocol/sdk";
 import { RequestError } from "@agentclientprotocol/sdk";
 
 import type { ZcodeAcpServer } from "../server.js";
+import { warn } from "../utils.js";
 
 /** Send a `session/update` notification to the client. */
 export function sendSessionUpdate(
@@ -65,19 +66,31 @@ export function sendAvailableCommands(
  * Send `available_commands_update` after a short delay so it lands after the
  * session response. ACP clients initialize their session state machine on the
  * response; a notification arriving earlier can be dropped, leaving the `/`
- * completion menu empty. Mirrors the Python bridge's deferred-notification
- * queue + 50ms drain. Fire-and-forget (returns void).
+ * completion menu empty.
+ *
+ * The notification is fired three times (50ms / 300ms / 1000ms) to cover slow
+ * client warm-up: on a fresh Zed tab the session view may still be initialising
+ * at the 50ms mark, dropping the first notification. `available_commands_update`
+ * is overwrite-semantics (not additive), so repeats are harmless — the client
+ * keeps the latest snapshot. Fire-and-forget (returns void).
  */
 export function sendAvailableCommandsDeferred(
   cx: acp.AgentContext,
   sessionId: string,
   commands: ReadonlyArray<SlashCommandEntry>,
 ): void {
-  const t = setTimeout(() => {
-    void sendAvailableCommands(cx, sessionId, commands);
-  }, 50);
-  // unref so shutdown is not held up by this deferred notification.
-  t.unref?.();
+  for (const delay of [50, 300, 1000]) {
+    const t = setTimeout(() => {
+      sendAvailableCommands(cx, sessionId, commands).catch((e) => {
+        warn(
+          `available_commands_update failed (sid=${sessionId}, delay=${delay}): ` +
+            `${e instanceof Error ? e.message : String(e)}`,
+        );
+      });
+    }, delay);
+    // unref so shutdown is not held up by this deferred notification.
+    t.unref?.();
+  }
 }
 
 /** Throw a JSON-RPC error from a handler (the SDK converts it to an error response). */

--- a/src/tasks-index.ts
+++ b/src/tasks-index.ts
@@ -19,7 +19,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 
-import { log, ZCODE_CREDS_PATH } from "./utils.js";
+import { warn, ZCODE_CREDS_PATH } from "./utils.js";
 
 // Precise DatabaseSync constructor type from @types/node, captured without a
 // runtime import (type position only). node:sqlite's API is prepared-statement
@@ -51,6 +51,22 @@ async function loadSqlite(): Promise<DatabaseSyncCtor | null> {
 
 /** tasks-index.sqlite sits next to config.json under ~/.zcode/v2/. */
 const TASKS_INDEX_PATH = path.join(path.dirname(ZCODE_CREDS_PATH), "tasks-index.sqlite");
+
+/**
+ * Detect a SQLite "database is locked" / "busy" error. node:sqlite surfaces
+ * SQLITE_BUSY (code 5) and SQLITE_LOCKED (code 6) as a TypeError whose message
+ * contains "busy" or "locked"; we match on the message so we don't have to
+ * reach into the (unstable) error code property.
+ */
+function isBusyError(e: unknown): boolean {
+  const msg = e instanceof Error ? e.message : String(e);
+  return /\b(busy|locked)\b/i.test(msg);
+}
+
+/** Promise-based sleep (best-effort retry backoff). */
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
 
 /**
  * Read provider id + model ref from config.json.
@@ -123,39 +139,52 @@ export async function upsertSessionTask(opts: {
   } catch {
     return false;
   }
-  try {
-    const con = new Sqlite(TASKS_INDEX_PATH, { timeout: 5000 });
+  // Retry on SQLITE_BUSY: the App's Electron host also writes to this DB, so
+  // even with `timeout: 5000` a contended write can surface as busy. Two short
+  // backoffs (200ms, 400ms) let the App's transaction commit. Best-effort —
+  // terminal failure is logged and swallowed so it never breaks session/create.
+  for (let attempt = 0; attempt < 3; attempt++) {
     try {
-      con
-        .prepare(
-          "INSERT OR IGNORE INTO tasks " +
-            "(workspace_key, workspace_path, workspace_identity, task_id, " +
-            " title, task_status, provider, mode, model, " +
-            " created_at, updated_at, unread_at, pinned, archived, deleted, " +
-            " title_overridden, meta_json, searchable_text) " +
-            "VALUES (?, ?, NULL, ?, ?, ?, ?, 'build', ?, ?, ?, NULL, 0, 0, 0, 0, ?, ?)",
-        )
-        .run(
-          opts.workspaceKey,
-          opts.workspaceKey,
-          opts.taskId,
-          opts.title,
-          status,
-          providerId,
-          model,
-          nowMs,
-          nowMs,
-          metaJson,
-          opts.title,
-        );
-    } finally {
-      con.close();
+      const con = new Sqlite(TASKS_INDEX_PATH, { timeout: 5000 });
+      try {
+        con
+          .prepare(
+            "INSERT OR IGNORE INTO tasks " +
+              "(workspace_key, workspace_path, workspace_identity, task_id, " +
+              " title, task_status, provider, mode, model, " +
+              " created_at, updated_at, unread_at, pinned, archived, deleted, " +
+              " title_overridden, meta_json, searchable_text) " +
+              "VALUES (?, ?, NULL, ?, ?, ?, ?, 'build', ?, ?, ?, NULL, 0, 0, 0, 0, ?, ?)",
+          )
+          .run(
+            opts.workspaceKey,
+            opts.workspaceKey,
+            opts.taskId,
+            opts.title,
+            status,
+            providerId,
+            model,
+            nowMs,
+            nowMs,
+            metaJson,
+            opts.title,
+          );
+      } finally {
+        con.close();
+      }
+      return true;
+    } catch (e) {
+      if (attempt < 2 && isBusyError(e)) {
+        await sleep(200 * (attempt + 1)); // 200ms, 400ms
+        continue;
+      }
+      // Visible failure: a missing App-UI row is user-perceivable, so warn()
+      // (stderr, always emitted) rather than the quiet log() default.
+      warn(`tasks-index sync skipped: ${e instanceof Error ? e.message : String(e)}`);
+      return false;
     }
-    return true;
-  } catch (e) {
-    log(`tasks-index sync skipped: ${e instanceof Error ? e.message : String(e)}`);
-    return false;
   }
+  return false;
 }
 
 /**
@@ -227,7 +256,7 @@ export async function updateSessionTitle(
     }
     return true;
   } catch (e) {
-    log(`tasks-index title update skipped: ${e instanceof Error ? e.message : String(e)}`);
+    warn(`tasks-index title update skipped: ${e instanceof Error ? e.message : String(e)}`);
     return false;
   }
 }

--- a/src/tasks-index.ts
+++ b/src/tasks-index.ts
@@ -54,18 +54,58 @@ const TASKS_INDEX_PATH = path.join(path.dirname(ZCODE_CREDS_PATH), "tasks-index.
 
 /**
  * Detect a SQLite "database is locked" / "busy" error. node:sqlite surfaces
- * SQLITE_BUSY (code 5) and SQLITE_LOCKED (code 6) as a TypeError whose message
- * contains "busy" or "locked"; we match on the message so we don't have to
- * reach into the (unstable) error code property.
+ * SQLITE_BUSY (code 5) and SQLITE_LOCKED (code 6) as an Error whose message is
+ * SQLite's standard phrase — verified against a real node:sqlite v22 throw:
+ *   `Error: database is locked`, code `ERR_SQLITE_ERROR`.
+ * We match the full phrase rather than the bare word "busy" / "locked" so a
+ * filesystem path that happens to contain those words (e.g. `/Users/busy_bee/`)
+ * inside a different error message can't trigger a false-positive retry.
  */
 function isBusyError(e: unknown): boolean {
   const msg = e instanceof Error ? e.message : String(e);
-  return /\b(busy|locked)\b/i.test(msg);
+  return /database is (busy|locked)/i.test(msg);
 }
 
 /** Promise-based sleep (best-effort retry backoff). */
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * Open a connection to tasks-index.sqlite and run `fn` against it, retrying on
+ * SQLITE_BUSY contention from the App's Electron host. Two short backoffs
+ * (200ms, 400ms) give the App's transaction time to commit. The connection is
+ * always closed in `finally` so a thrown error never leaks a handle.
+ *
+ * Returns whatever `fn` returns, or `null` when node:sqlite is unavailable.
+ * Rethrows non-busy errors (or busy errors that exhausted retries) so the
+ * caller can classify and log them consistently.
+ */
+async function withSqliteRetry<T>(
+  fn: (con: InstanceType<DatabaseSyncCtor>) => T,
+): Promise<T | null> {
+  const Sqlite = await loadSqlite();
+  if (!Sqlite) return null; // node:sqlite unavailable (Node < 22)
+  for (let attempt = 0; attempt < 3; attempt++) {
+    // `con` is declared outside try so the finally can close it even when the
+    // constructor itself throws (SQLITE_BUSY can surface at open time).
+    let con: InstanceType<DatabaseSyncCtor> | null = null;
+    try {
+      con = new Sqlite(TASKS_INDEX_PATH, { timeout: 5000 });
+      return fn(con);
+    } catch (e) {
+      // Retry only on transient busy/locked; surface everything else.
+      if (attempt < 2 && isBusyError(e)) {
+        await sleep(200 * (attempt + 1)); // 200ms, 400ms
+        continue;
+      }
+      throw e;
+    } finally {
+      con?.close();
+    }
+  }
+  // Unreachable — the loop either returns or throws — but satisfies TS.
+  throw new Error("withSqliteRetry: exhausted retries without resolution");
 }
 
 /**
@@ -113,8 +153,6 @@ export async function upsertSessionTask(opts: {
   status?: string;
 }): Promise<boolean> {
   if (!existsSync(TASKS_INDEX_PATH)) return false; // App never installed → no index.
-  const Sqlite = await loadSqlite();
-  if (!Sqlite) return false; // node:sqlite unavailable (Node < 22)
   const nowMs = Date.now();
   const { providerId, modelRef } = resolveProviderModel();
   const model = opts.model ?? modelRef;
@@ -139,52 +177,40 @@ export async function upsertSessionTask(opts: {
   } catch {
     return false;
   }
-  // Retry on SQLITE_BUSY: the App's Electron host also writes to this DB, so
-  // even with `timeout: 5000` a contended write can surface as busy. Two short
-  // backoffs (200ms, 400ms) let the App's transaction commit. Best-effort —
-  // terminal failure is logged and swallowed so it never breaks session/create.
-  for (let attempt = 0; attempt < 3; attempt++) {
-    try {
-      const con = new Sqlite(TASKS_INDEX_PATH, { timeout: 5000 });
-      try {
-        con
-          .prepare(
-            "INSERT OR IGNORE INTO tasks " +
-              "(workspace_key, workspace_path, workspace_identity, task_id, " +
-              " title, task_status, provider, mode, model, " +
-              " created_at, updated_at, unread_at, pinned, archived, deleted, " +
-              " title_overridden, meta_json, searchable_text) " +
-              "VALUES (?, ?, NULL, ?, ?, ?, ?, 'build', ?, ?, ?, NULL, 0, 0, 0, 0, ?, ?)",
-          )
-          .run(
-            opts.workspaceKey,
-            opts.workspaceKey,
-            opts.taskId,
-            opts.title,
-            status,
-            providerId,
-            model,
-            nowMs,
-            nowMs,
-            metaJson,
-            opts.title,
-          );
-      } finally {
-        con.close();
-      }
+  // withSqliteRetry handles SQLITE_BUSY contention with the App's Electron
+  // host. Visible failure: a missing App-UI row is user-perceivable, so warn()
+  // (stderr, always emitted) rather than the quiet log() default.
+  try {
+    const result = await withSqliteRetry((con) => {
+      con
+        .prepare(
+          "INSERT OR IGNORE INTO tasks " +
+            "(workspace_key, workspace_path, workspace_identity, task_id, " +
+            " title, task_status, provider, mode, model, " +
+            " created_at, updated_at, unread_at, pinned, archived, deleted, " +
+            " title_overridden, meta_json, searchable_text) " +
+            "VALUES (?, ?, NULL, ?, ?, ?, ?, 'build', ?, ?, ?, NULL, 0, 0, 0, 0, ?, ?)",
+        )
+        .run(
+          opts.workspaceKey,
+          opts.workspaceKey,
+          opts.taskId,
+          opts.title,
+          status,
+          providerId,
+          model,
+          nowMs,
+          nowMs,
+          metaJson,
+          opts.title,
+        );
       return true;
-    } catch (e) {
-      if (attempt < 2 && isBusyError(e)) {
-        await sleep(200 * (attempt + 1)); // 200ms, 400ms
-        continue;
-      }
-      // Visible failure: a missing App-UI row is user-perceivable, so warn()
-      // (stderr, always emitted) rather than the quiet log() default.
-      warn(`tasks-index sync skipped: ${e instanceof Error ? e.message : String(e)}`);
-      return false;
-    }
+    });
+    return result ?? false;
+  } catch (e) {
+    warn(`tasks-index sync skipped: ${e instanceof Error ? e.message : String(e)}`);
+    return false;
   }
-  return false;
 }
 
 /**
@@ -208,15 +234,15 @@ export async function updateSessionTitle(
   searchableText?: string,
 ): Promise<boolean> {
   if (!existsSync(TASKS_INDEX_PATH) || !title) return false;
-  const Sqlite = await loadSqlite();
-  if (!Sqlite) return false;
   const trimmed = title.trim().slice(0, 80);
   if (!trimmed) return false;
   // Cap searchable_text at the App's limit (aD = 2e5 = 200000 chars).
   const search = (searchableText ?? trimmed).trim().slice(0, 200_000);
+  // Title updates also write to tasks-index.sqlite and are equally exposed to
+  // SQLITE_BUSY contention with the App's Electron host — go through the same
+  // withSqliteRetry path as upsertSessionTask for consistent retry behaviour.
   try {
-    const con = new Sqlite(TASKS_INDEX_PATH, { timeout: 5000 });
-    try {
+    const result = await withSqliteRetry((con) => {
       const row = con
         .prepare("SELECT title_overridden, meta_json FROM tasks WHERE task_id=?")
         .get(taskId) as { title_overridden: number; meta_json: string } | undefined;
@@ -251,10 +277,9 @@ export async function updateSessionTitle(
             "WHERE task_id=? AND title_overridden=0",
         )
         .run(trimmed, Date.now(), search, metaJson, taskId);
-    } finally {
-      con.close();
-    }
-    return true;
+      return true;
+    });
+    return result ?? false;
   } catch (e) {
     warn(`tasks-index title update skipped: ${e instanceof Error ? e.message : String(e)}`);
     return false;

--- a/tests/tasks-index.test.ts
+++ b/tests/tasks-index.test.ts
@@ -45,6 +45,13 @@ interface FakeRow {
 /** A single shared in-memory `tasks` table, keyed by PK (workspace_key, task_id). */
 let rows: Map<string, FakeRow>;
 
+/**
+ * How many times the next `new DatabaseSync(...)` calls should throw a busy
+ * error before letting the write through. Set by tests; the fake decrements on
+ * each instantiation. Mirrors SQLITE_BUSY contention with the App.
+ */
+let busyTimes: number;
+
 /** Build the StatementSync-shaped object returned by DatabaseSync.prepare(). */
 function makeStatement(sql: string) {
   // INSERT OR IGNORE INTO tasks (...) VALUES (..., 'build', ..., NULL, 0, 0, 0, 0, ?, ?)
@@ -157,7 +164,12 @@ function makeStatement(sql: string) {
 vi.mock("node:sqlite", () => {
   class DatabaseSync {
     constructor(_path: string, _options?: { timeout?: number }) {
-      // no-op: tests use the shared in-memory `rows` map.
+      // Simulate SQLITE_BUSY contention: the first `busyTimes` connections
+      // throw before a connection opens. Decremented here so retries recover.
+      if (busyTimes > 0) {
+        busyTimes--;
+        throw new TypeError("database is busy");
+      }
     }
     prepare(sql: string) {
       return makeStatement(sql);
@@ -190,6 +202,7 @@ import { upsertSessionTask, updateSessionTitle } from "../src/tasks-index.js";
 describe("tasks-index session sync", () => {
   beforeEach(() => {
     rows = new Map();
+    busyTimes = 0;
   });
 
   describe("upsertSessionTask", () => {
@@ -251,6 +264,55 @@ describe("tasks-index session sync", () => {
       // The App-managed row must be untouched.
       expect(rows.get("/ws\u0000sess_3")!.title).toBe("app renamed");
       expect(rows.get("/ws\u0000sess_3")!.title_overridden).toBe(1);
+    });
+
+    it("retries on SQLITE_BUSY and writes once contention clears", async () => {
+      // The App's Electron host also writes to tasks-index.sqlite; a contended
+      // write surfaces as SQLITE_BUSY even with `timeout: 5000`. Two short
+      // backoffs must let the write through on the third attempt.
+      busyTimes = 2;
+      vi.useFakeTimers();
+      try {
+        const p = upsertSessionTask({
+          workspaceKey: "/ws",
+          taskId: "sess_busy",
+          title: "after contention",
+        });
+        // Advance through both backoffs (200ms, 400ms) plus connection retries.
+        await vi.advanceTimersByTimeAsync(1000);
+        const ok = await p;
+        expect(ok).toBe(true);
+        expect(rows.size).toBe(1);
+        expect(rows.get("/ws\u0000sess_busy")!.title).toBe("after contention");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("gives up and returns false when busy persists past retries", async () => {
+      // All 3 attempts hit busy → surface as a visible failure (warn), but
+      // never throw into session/create.
+      busyTimes = 99;
+      vi.useFakeTimers();
+      const warnSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+      try {
+        const p = upsertSessionTask({
+          workspaceKey: "/ws",
+          taskId: "sess_busy_forever",
+          title: "never lands",
+        });
+        await vi.advanceTimersByTimeAsync(2000);
+        const ok = await p;
+        expect(ok).toBe(false);
+        expect(rows.size).toBe(0);
+        // warn() writes to stderr — the skipped message must be visible so the
+        // failure is diagnosable (it was previously hidden behind ZCODE_ACP_DEBUG).
+        const out = warnSpy.mock.calls.map((c) => String(c[0])).join("");
+        expect(out).toMatch(/tasks-index sync skipped/i);
+      } finally {
+        warnSpy.mockRestore();
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/tests/tasks-index.test.ts
+++ b/tests/tasks-index.test.ts
@@ -422,5 +422,31 @@ describe("tasks-index session sync", () => {
       expect(after.taskId).toBe("sess_meta");
       expect(after.mode).toBe("build");
     });
+
+    it("retries on SQLITE_BUSY and updates the title once contention clears", async () => {
+      // Title updates also write to tasks-index.sqlite → equally exposed to
+      // SQLITE_BUSY contention with the App's Electron host. Goes through the
+      // same withSqliteRetry path as upsertSessionTask.
+      await upsertSessionTask({
+        workspaceKey: "/ws",
+        taskId: "sess_title_busy",
+        title: "",
+      });
+      busyTimes = 2;
+      vi.useFakeTimers();
+      try {
+        const p = updateSessionTitle("sess_title_busy", "after contention");
+        await vi.advanceTimersByTimeAsync(1000);
+        const ok = await p;
+        expect(ok).toBe(true);
+        expect(rows.get("/ws\u0000sess_title_busy")!.title).toBe("after contention");
+        // meta_json.title must also reflect the retry (App reads it first).
+        expect(JSON.parse(rows.get("/ws\u0000sess_title_busy")!.meta_json).title).toBe(
+          "after contention",
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 });


### PR DESCRIPTION
## Root cause

Two unrelated intermittent bugs reported by the user.

### Bug 1: slash commands occasionally not shown
`sendAvailableCommandsDeferred` fired `available_commands_update` exactly once after `setTimeout(50ms)`. Zed initialises the session view **on** `NewSessionResponse`; if the view wasn't ready by the 50ms mark, the notification was dropped and the `/` completion menu stayed empty. `session/resume` and `session/load` go through the same deferred path. The "restart fixes it" symptom matches: the second `session/new` hits a warmed-up client where 50ms is enough.

### Bug 2: sessions intermittently fail to sync to the ZCode App UI
`newSession`'s `upsertSessionTask` is fire-and-forget (`void`, not awaited). The App's Electron host also writes to `tasks-index.sqlite`, so contended writes can surface as `SQLITE_BUSY` even with the 5s timeout — and the failure was swallowed by a quiet `log()` (only visible under `ZCODE_ACP_DEBUG=1`), making it look random.

## Fix

### `src/handlers/io.ts`
`sendAvailableCommandsDeferred` now fires the notification **three times** (50ms / 300ms / 1000ms) instead of once. `available_commands_update` is overwrite-semantics (not additive), so repeats are harmless — the client keeps the latest snapshot. Each timer is still `unref()`'d. Failures are now `warn()`'d instead of silently swallowed.

### `src/tasks-index.ts`
`upsertSessionTask` wraps the write in a busy-retry loop (up to 3 attempts, 200ms / 400ms backoff). `isBusyError` matches "busy" / "locked" in the error message (covers SQLITE_BUSY code 5 and SQLITE_LOCKED code 6 without reaching into unstable error-code properties). Terminal failure is now `warn()`'d (user-perceivable — the session is invisible in the App UI) rather than hidden behind `ZCODE_ACP_DEBUG`. `updateSessionTitle`'s catch is upgraded to `warn()` for the same reason.

All retries are self-contained inside `tasks-index.ts`; the `void upsertSessionTask(...)` call site in `session.ts` is unchanged.

## Tests
`tests/tasks-index.test.ts` gains 2 cases (10 → 12):
- `retries on SQLITE_BUSY and writes once contention clears` — fake DB throws busy twice, then succeeds; asserts the row is written.
- `gives up and returns false when busy persists past retries` — all attempts busy; asserts `false` return, no row, and the skipped message surfaces on stderr.

## Verification
- `pnpm typecheck` ✅
- `pnpm test` ✅ 274/274 passed
- `pnpm lint` ✅ 0 errors (remaining warnings are pre-existing sort-imports)
- `pnpm prettier --write` on the 3 changed files ✅

## Out of scope
`session/fork` (`src/index.ts:133`) also misses both `sendAvailableCommandsDeferred` and `upsertSessionTask`. Per the user's report it's a secondary path, so left untouched in this PR — easy 5-line follow-up if needed.