### PR TITLE
feat: support custom model providers and fix model switching for new backend

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -59,18 +59,33 @@
 **Symptom:**
 
 ```
-session/subscribe failed (ZCode CLI 0.14.8+ required)
+session/subscribe failed: <backend error message> [(code <N>)]
 ```
+
+The error message carries the backend's real failure reason. It is **no longer**
+a hardcoded version string — read the message text to identify the root cause.
+
+**Common causes:**
+
+| Message fragment                 | Cause                                                                      |
+| -------------------------------- | -------------------------------------------------------------------------- |
+| `reader exited (backend dead)`   | The zcode subprocess crashed/exited. Restart the editor session.           |
+| `timeout`                        | The 10s subscribe deadline elapsed — usually a hung or overloaded backend. |
+| `pipe broken`                    | The stdin pipe to the zcode subprocess broke (process died mid-write).     |
+| `method not found (code -32601)` | The CLI genuinely is too old (< 0.14.8). Upgrade.                          |
+| session-level business error     | The target session no longer exists or was evicted.                        |
 
 **Troubleshooting steps:**
 
-1. Confirm ZCode CLI >= 0.14.8:
+1. **Read the error message** — the fragment identifies the cause (table above).
+
+2. If the message indicates `method not found`, confirm ZCode CLI >= 0.14.8:
 
    ```bash
    zcode --version
    ```
 
-2. If the version is correct but it still fails, check whether the zcode
+3. If the version is correct but it still fails, check whether the zcode
    app-server supports subscribe:
 
    ```bash
@@ -80,7 +95,7 @@ session/subscribe failed (ZCode CLI 0.14.8+ required)
    { "id": 1, "method": "session/subscribe", "params": { "sessionId": "test", "deliveryKind": "desktop-continuous", "includeSnapshot": true, "afterSeq": 0 } }
    ```
 
-3. Check whether other zcode processes are running:
+4. Check whether other zcode processes are running:
    ```bash
    ps aux | grep zcode
    killall -9 zcode  # caution: this kills all zcode processes

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -70,7 +70,7 @@ a hardcoded version string — read the message text to identify the root cause.
 | Message fragment                 | Cause                                                                      |
 | -------------------------------- | -------------------------------------------------------------------------- |
 | `reader exited (backend dead)`   | The zcode subprocess crashed/exited. Restart the editor session.           |
-| `timeout`                        | The 10s subscribe deadline elapsed — usually a hung or overloaded backend. |
+| `timeout`                        | The per-attempt 10s subscribe deadline elapsed. The bridge retries transient timeouts up to 3× (the backend can be briefly busy finalising a cancelled turn after a preempt / `session/stop`); if all retries fail, the backend was unresponsive for ~30s. |
 | `pipe broken`                    | The stdin pipe to the zcode subprocess broke (process died mid-write).     |
 | `method not found (code -32601)` | The CLI genuinely is too old (< 0.14.8). Upgrade.                          |
 | session-level business error     | The target session no longer exists or was evicted.                        |

--- a/src/backend/listener.ts
+++ b/src/backend/listener.ts
@@ -12,7 +12,14 @@
  */
 
 import type { ZcodeBackend } from "./client.js";
-import type { ZcodeEvent, ZcodeProjection, ZcodeSnapshot, ZcodeSubscribeResult } from "./types.js";
+import type {
+  ZcodeEvent,
+  ZcodeProjection,
+  ZcodeResponse,
+  ZcodeSnapshot,
+  ZcodeSubscribeResult,
+} from "./types.js";
+import { log } from "../utils.js";
 
 /** ID generator function (the server's `_next_id`). */
 export type NextId = () => number;
@@ -42,11 +49,13 @@ export class EventStreamListener {
   /**
    * Subscribe and capture the initial snapshot + eventSeq watermark.
    *
-   * Returns the snapshot (with projection/messages) or null on failure. ZCode
-   * CLI 0.14.8+ always supports this; null means an old/ broken backend and
-   * the caller should surface an error (polling fallback was removed).
+   * Returns the snapshot (with projection/messages). Throws on failure,
+   * surfacing the backend's real error message (reader dead, timeout, pipe
+   * broken, method not found on old CLI, or a session-level business error) so
+   * the caller can distinguish root causes instead of seeing a single
+   * misleading "version too old" string.
    */
-  async subscribe(nextId: NextId): Promise<ZcodeSnapshot | null> {
+  async subscribe(nextId: NextId): Promise<ZcodeSnapshot> {
     const resp = await this.backend.request(
       nextId(),
       "session/subscribe",
@@ -59,12 +68,12 @@ export class EventStreamListener {
       10000,
     );
     if (resp.error) {
-      return null;
+      throw new Error(formatSubscribeError(resp));
     }
     const result = (resp.result ?? {}) as ZcodeSubscribeResult;
     this.lastSeq = result.eventSeq ?? 0;
     this.subscribed = true;
-    return result.snapshot ?? null;
+    return result.snapshot ?? { projection: undefined, messages: [] };
   }
 
   /** Called by the backend reader when a `session/event` arrives. */
@@ -128,6 +137,9 @@ export class EventStreamListener {
       10000,
     );
     if (resp.error) {
+      log(
+        `resubscribe failed (non-fatal, stall recovery degrades to polling): ${formatSubscribeError(resp)}`,
+      );
       return false;
     }
     const result = (resp.result ?? {}) as ZcodeSubscribeResult;
@@ -165,4 +177,16 @@ export class TurnMonitor {
     const result = (resp.result ?? {}) as { projection?: ZcodeProjection };
     return result.projection ?? null;
   }
+}
+
+/**
+ * Format a `session/subscribe` failure into a readable message that carries
+ * the backend's real error so the caller can distinguish root causes (reader
+ * dead, timeout, pipe broken, method-not-found on old CLI, session-level
+ * business error) instead of a single generic string.
+ */
+function formatSubscribeError(resp: ZcodeResponse): string {
+  const err = resp.error ?? { message: "unknown error" };
+  const code = err.code !== undefined && err.code !== null ? ` (code ${err.code})` : "";
+  return `session/subscribe failed: ${err.message ?? "unknown error"}${code}`;
 }

--- a/src/backend/listener.ts
+++ b/src/backend/listener.ts
@@ -68,6 +68,14 @@ export class EventStreamListener {
     // Each attempt uses a fresh id from `nextId()` (monotonic, never reused), so
     // a late response to an earlier timed-out request is safely discarded by
     // `resolvePending` (no pending entry → dropped).
+    //
+    // includeSnapshot is FALSE here on purpose. The caller (prompt()) discards
+    // the returned snapshot anyway (`void snapshot`) — the projection baseline
+    // comes from a separate fetchMessages() call. Asking the backend for a
+    // snapshot here only makes it compute a full session snapshot (which grows
+    // O(messages) and can take seconds-to-tens-of-seconds on long sessions:
+    // observed 3.8s at 267 messages, 38s at 3500 messages) and is the primary
+    // cause of subscribe timeouts. The eventSeq watermark is all we need.
     const MAX_ATTEMPTS = 3;
     const backoffMs = (attempt: number): number => 1000 * attempt; // 1s, 2s
     let resp: ZcodeResponse;
@@ -78,7 +86,7 @@ export class EventStreamListener {
         {
           sessionId: this.sid,
           deliveryKind: "desktop-continuous",
-          includeSnapshot: true,
+          includeSnapshot: false,
           afterSeq: 0,
         },
         10000,

--- a/src/backend/listener.ts
+++ b/src/backend/listener.ts
@@ -19,7 +19,7 @@ import type {
   ZcodeSnapshot,
   ZcodeSubscribeResult,
 } from "./types.js";
-import { log } from "../utils.js";
+import { log, warn } from "../utils.js";
 
 /** ID generator function (the server's `_next_id`). */
 export type NextId = () => number;
@@ -56,21 +56,47 @@ export class EventStreamListener {
    * misleading "version too old" string.
    */
   async subscribe(nextId: NextId): Promise<ZcodeSnapshot> {
-    const resp = await this.backend.request(
-      nextId(),
-      "session/subscribe",
-      {
-        sessionId: this.sid,
-        deliveryKind: "desktop-continuous",
-        includeSnapshot: true,
-        afterSeq: 0,
-      },
-      10000,
-    );
-    if (resp.error) {
-      throw new Error(formatSubscribeError(resp));
+    // Retry transient timeouts: after a preempt (`session/stop`) the backend's
+    // main loop can be briefly busy finalising the cancelled turn (interrupting
+    // the model stream, persisting checkpoints). A subscribe issued in that
+    // window may not get a response within the per-attempt deadline. The backend
+    // recovers on its own ("wait a bit and resend works"), so a couple of
+    // retries absorb the intermittent stall instead of surfacing it to the user.
+    //
+    // Only `timeout` is retried — non-transient errors (reader dead, pipe
+    // broken, method-not-found, session-level business error) fail fast.
+    // Each attempt uses a fresh id from `nextId()` (monotonic, never reused), so
+    // a late response to an earlier timed-out request is safely discarded by
+    // `resolvePending` (no pending entry → dropped).
+    const MAX_ATTEMPTS = 3;
+    const backoffMs = (attempt: number): number => 1000 * attempt; // 1s, 2s
+    let resp: ZcodeResponse;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      resp = await this.backend.request(
+        nextId(),
+        "session/subscribe",
+        {
+          sessionId: this.sid,
+          deliveryKind: "desktop-continuous",
+          includeSnapshot: true,
+          afterSeq: 0,
+        },
+        10000,
+      );
+      if (!resp.error) break; // success
+      const isTimeout = resp.error.message === "timeout";
+      if (!isTimeout || attempt === MAX_ATTEMPTS) {
+        if (isTimeout) {
+          warn(`subscribe: all ${MAX_ATTEMPTS} attempts timed out (backend unresponsive for ~30s)`);
+        }
+        throw new Error(formatSubscribeError(resp));
+      }
+      log(
+        `subscribe attempt ${attempt}/${MAX_ATTEMPTS} timed out, retrying in ${backoffMs(attempt)}ms (preempt/busy window)`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, backoffMs(attempt)));
     }
-    const result = (resp.result ?? {}) as ZcodeSubscribeResult;
+    const result = (resp!.result ?? {}) as ZcodeSubscribeResult;
     this.lastSeq = result.eventSeq ?? 0;
     this.subscribed = true;
     return result.snapshot ?? { projection: undefined, messages: [] };

--- a/src/config/model-cache.ts
+++ b/src/config/model-cache.ts
@@ -10,30 +10,42 @@
 import type * as acp from "@agentclientprotocol/sdk";
 
 import type { ZcodeReadResult } from "../backend/types.js";
-import { modelContextWindow } from "./options.js";
+import { formatModelValue, loadAllModels, modelContextWindow, parseModelValue } from "./options.js";
 import { log } from "../utils.js";
 import type { ZcodeAcpServer } from "../server.js";
 import { dispatchEvent } from "../handlers/dispatch.js";
 import type { ProjectionDiffer } from "../translators/projection-differ.js";
 
-/** Read the session's current model id, with a per-session cache. */
+/**
+ * Read the session's current model as an encoded `"providerId\modelId"` string,
+ * with a per-session cache. Returns the encoded form so callers can resolve the
+ * provider (for context-window lookup / model switching) without a second read.
+ */
 export async function currentModelCached(
   server: ZcodeAcpServer,
   zcodeSid: string,
 ): Promise<string> {
   const cached = server.modelCache.get(zcodeSid);
   if (cached) return cached;
+  let providerId = "";
   let modelId = "GLM-5.2";
   try {
     const read = await sessionRead(server, zcodeSid);
     const settings = (read.settings ?? {}) as Record<string, unknown>;
-    const cur = (settings.model as { current?: { modelId?: string } })?.current;
+    const cur = (settings.model as { current?: { providerId?: string; modelId?: string } })
+      ?.current;
+    if (cur?.providerId) providerId = cur.providerId;
     if (cur?.modelId) modelId = cur.modelId;
   } catch (e) {
     log(`model-cache: session/read failed (${e instanceof Error ? e.message : String(e)})`);
   }
-  server.modelCache.set(zcodeSid, modelId);
-  return modelId;
+  if (!providerId) {
+    // Legacy session without a providerId — resolve to the first enabled provider.
+    providerId = loadAllModels()[0]?.providerId ?? "builtin:bigmodel-coding-plan";
+  }
+  const encoded = formatModelValue(providerId, modelId);
+  server.modelCache.set(zcodeSid, encoded);
+  return encoded;
 }
 
 /**
@@ -67,7 +79,10 @@ export async function emitInitialUsage(
     const used = proj.contextUsed || proj.totalTokenCount || 0;
     if (!used) return; // resume before any turn: skip to avoid showing 0.
     let size = proj.contextWindow ?? 0;
-    if (!size) size = modelContextWindow(await currentModelCached(server, zcodeSid));
+    if (!size) {
+      const { providerId, modelId } = parseModelValue(await currentModelCached(server, zcodeSid));
+      size = modelContextWindow(providerId, modelId);
+    }
     await dispatchEvent(
       server,
       cx,

--- a/src/config/options.ts
+++ b/src/config/options.ts
@@ -27,32 +27,109 @@ function readConfig(): unknown {
   return JSON.parse(readFileSync(ZCODE_CREDS_PATH, "utf8"));
 }
 
-interface ConfigShape {
-  provider?: Record<string, { models?: ProviderModelsJson }>;
+/** A single provider's entry in config.json (`provider.<providerId>`). */
+interface ProviderEntry {
+  name?: string;
+  kind?: string;
+  enabled?: boolean;
+  options?: { baseURL?: string; apiKey?: string };
+  models?: ProviderModelsJson;
 }
 
-/** Read the model id list for the enabled provider from config.json. */
-export function loadProviderModels(): string[] {
+interface ConfigShape {
+  provider?: Record<string, ProviderEntry>;
+}
+
+/** A model selectable in the dropdown, with its owning provider. */
+export interface ModelRef {
+  providerId: string;
+  providerName: string;
+  modelId: string;
+}
+
+/**
+ * Collect models from ALL enabled providers in config.json.
+ *
+ * Only providers with `enabled: true` are listed — unenabled providers
+ * (including builtins without an `enabled` flag) are excluded so the dropdown
+ * reflects exactly what the user has activated in the ZCode desktop app.
+ */
+export function loadAllModels(): ModelRef[] {
   try {
     const cfg = readConfig() as ConfigShape;
-    const models = cfg.provider?.["builtin:bigmodel-coding-plan"]?.models ?? {};
-    const keys = Object.keys(models);
-    return keys.length > 0 ? keys : ["GLM-5.2"];
+    const out: ModelRef[] = [];
+    for (const [pid, p] of Object.entries(cfg.provider ?? {})) {
+      if (!p?.enabled) continue;
+      const providerName = p.name ?? pid;
+      for (const modelId of Object.keys(p.models ?? {})) {
+        out.push({ providerId: pid, providerName, modelId });
+      }
+    }
+    if (out.length === 0) {
+      // Fallback: config unreadable or no enabled provider — keep the legacy
+      // default so a freshly-installed editor still shows something.
+      return [
+        {
+          providerId: "builtin:bigmodel-coding-plan",
+          providerName: "BigModel",
+          modelId: "GLM-5.2",
+        },
+      ];
+    }
+    return out;
   } catch {
-    return ["GLM-5.2"];
+    return [
+      { providerId: "builtin:bigmodel-coding-plan", providerName: "BigModel", modelId: "GLM-5.2" },
+    ];
   }
 }
 
-/** Read the context-window size for a model from config.json (limit.context). */
-export function modelContextWindow(modelId: string): number {
+/** Look up a provider entry by id (any provider, not just enabled). */
+export function findProviderConfig(providerId: string): ProviderEntry | null {
   try {
     const cfg = readConfig() as ConfigShape;
-    const models = cfg.provider?.["builtin:bigmodel-coding-plan"]?.models ?? {};
+    return cfg.provider?.[providerId] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Read the context-window size for a provider+model from config.json. */
+export function modelContextWindow(providerId: string, modelId: string): number {
+  try {
+    const cfg = readConfig() as ConfigShape;
+    const models = cfg.provider?.[providerId]?.models ?? {};
     const entry = models[modelId];
     return entry?.limit?.context ?? 0;
   } catch {
     return 0;
   }
+}
+
+/**
+ * Encode a provider+model pair into a configOption `value` string.
+ *
+ * Uses `\` as the separator: providerIds are `builtin:...` or UUIDs (no `\`),
+ * and modelIds use `/` (e.g. `nvidia/.../step-3.7-flash`), so `\` is unambiguous.
+ */
+export function formatModelValue(providerId: string, modelId: string): string {
+  return `${providerId}\\${modelId}`;
+}
+
+/**
+ * Parse a configOption `value` back into { providerId, modelId }.
+ *
+ * Backward compat: a value without `\` (legacy plain modelId) is treated as a
+ * modelId under the current enabled provider, preserving the old behaviour.
+ */
+export function parseModelValue(value: string): { providerId: string; modelId: string } {
+  const idx = value.indexOf("\\");
+  if (idx < 0) {
+    // Legacy plain modelId — resolve to the first enabled provider.
+    const first = loadAllModels()[0];
+    return { providerId: first?.providerId ?? "builtin:bigmodel-coding-plan", modelId: value };
+  }
+  return { providerId: value.slice(0, idx), modelId: value.slice(idx + 1) };
 }
 
 /** Build the ACP SessionModeState ({currentModeId, availableModes}). */
@@ -86,7 +163,8 @@ export async function buildConfigOptions(
   server: ZcodeAcpServer,
   zcodeSid: string,
 ): Promise<acp.SessionConfigOption[]> {
-  let currentModel = "GLM-5.2";
+  let currentProviderId = "";
+  let currentModelId = "GLM-5.2";
   let currentMode = "build";
   let currentThought = "high";
   let thoughtOptions: Array<{ value: string; name: string }> | null = null;
@@ -97,8 +175,11 @@ export async function buildConfigOptions(
     const modeSet = (settings.mode as Record<string, unknown>) ?? {};
     currentMode = (modeSet.current as string) ?? currentMode;
     const modelSet = (settings.model as Record<string, unknown>) ?? {};
-    const cur = (modelSet.current as { modelId?: string }) ?? {};
-    if (cur.modelId) currentModel = cur.modelId;
+    // settings.model.current is { providerId, modelId, variant? } — read BOTH so
+    // we can disambiguate same-named models across providers.
+    const cur = (modelSet.current as { providerId?: string; modelId?: string }) ?? {};
+    if (cur.providerId) currentProviderId = cur.providerId;
+    if (cur.modelId) currentModelId = cur.modelId;
     const tlSet = (settings.thoughtLevel as Record<string, unknown>) ?? {};
     currentThought = (tlSet.current as string) ?? currentThought;
     const tlAvail = (tlSet.available as Array<Record<string, string>>) ?? [];
@@ -109,10 +190,25 @@ export async function buildConfigOptions(
     // keep defaults
   }
 
-  // Model options: config.json is authoritative (settings.model.available is incomplete).
-  let modelOptions = loadProviderModels().map((k) => ({ value: k, name: k }));
+  // currentValue encodes provider+model so the switch handler can locate the
+  // right provider (and its apiKey). Fall back to the first enabled provider
+  // when settings omits providerId (legacy sessions).
+  const currentModel = formatModelValue(
+    currentProviderId || loadAllModels()[0]?.providerId || "builtin:bigmodel-coding-plan",
+    currentModelId,
+  );
+
+  // Model options: config.json enabled providers are authoritative. Show as
+  // "ProviderName › ModelId" so same-named models across providers stay distinct.
+  let modelOptions = loadAllModels().map((m) => ({
+    value: formatModelValue(m.providerId, m.modelId),
+    name: `${m.providerName} › ${m.modelId}`,
+  }));
   if (!modelOptions.some((o) => o.value === currentModel)) {
-    modelOptions = [{ value: currentModel, name: currentModel }, ...modelOptions];
+    // The current model isn't from an enabled provider (e.g. the session was
+    // created with a now-disabled provider). Append it so the dropdown still
+    // shows the active selection.
+    modelOptions = [{ value: currentModel, name: currentModelId }, ...modelOptions];
   }
   if (!thoughtOptions) thoughtOptions = [...CONFIG_META.thought.options];
 

--- a/src/config/options.ts
+++ b/src/config/options.ts
@@ -14,7 +14,7 @@ import { readFileSync } from "node:fs";
 import type * as acp from "@agentclientprotocol/sdk";
 
 import type { ZcodeReadResult } from "../backend/types.js";
-import { CONFIG_DISPATCH, CONFIG_META, ZCODE_CREDS_PATH } from "../utils.js";
+import { CONFIG_DISPATCH, CONFIG_META, log, ZCODE_CREDS_PATH } from "../utils.js";
 import type { ZcodeAcpServer } from "../server.js";
 import { sendSessionUpdate } from "../handlers/io.js";
 
@@ -286,7 +286,11 @@ export async function setConfigOption(
 }
 
 /** Emit a config_option_update (+ current_mode_update for mode) after a change.
- *  Returns the rebuilt options so the caller can include them in the response. */
+ *  Returns the rebuilt options so the caller can include them in the response.
+ *
+ *  For model switches, also emit a usage_update with the NEW model's context
+ *  window (from config.json) so the editor's context bar refreshes immediately
+ *  instead of waiting for the next turn's UsageDelta. */
 export async function emitConfigOptionUpdate(
   server: ZcodeAcpServer,
   cx: acp.AgentContext,
@@ -305,6 +309,29 @@ export async function emitConfigOptionUpdate(
       sessionUpdate: "current_mode_update",
       currentModeId: modes.currentModeId,
     });
+  }
+  if (kind === "model") {
+    // Refresh the context bar: the backend's projection.contextWindow lags
+    // behind a model switch, so read the new model's limit from config.json.
+    try {
+      const read = await sessionRead(server, zcodeSid);
+      const proj = (read.projection ?? {}) as {
+        contextUsed?: number;
+        totalTokenCount?: number;
+      };
+      const used = proj.contextUsed || proj.totalTokenCount || 0;
+      // The rebuilt options[0] (model) currentValue is the just-switched value.
+      const modelOpt = options.find((o) => o.id === "model");
+      const { providerId, modelId } = parseModelValue(String(modelOpt?.currentValue ?? ""));
+      const size = modelContextWindow(providerId, modelId);
+      await sendSessionUpdate(cx, acpSid, {
+        sessionUpdate: "usage_update",
+        used,
+        size,
+      });
+    } catch (e) {
+      log(`options: usage_update after model switch failed (${e instanceof Error ? e.message : String(e)})`);
+    }
   }
   return options;
 }

--- a/src/config/options.ts
+++ b/src/config/options.ts
@@ -106,28 +106,40 @@ export function modelContextWindow(providerId: string, modelId: string): number 
   }
 }
 
+/** Builtin providerIds are prefixed with `builtin:` (e.g. `builtin:bigmodel`). */
+function isBuiltinProvider(providerId: string): boolean {
+  return providerId.startsWith("builtin:");
+}
+
 /**
  * Encode a provider+model pair into a configOption `value` string.
  *
- * Uses `\` as the separator: providerIds are `builtin:...` or UUIDs (no `\`),
- * and modelIds use `/` (e.g. `nvidia/.../step-3.7-flash`), so `\` is unambiguous.
+ * Builtin providers encode as the bare modelId (legacy form, keeps the dropdown
+ * clean for the common case). Third-party providers encode as
+ * `providerId\modelId` — `\` is unambiguous because providerIds (UUIDs) and
+ * modelIds (`/`-separated) never contain it.
  */
 export function formatModelValue(providerId: string, modelId: string): string {
+  if (isBuiltinProvider(providerId)) return modelId;
   return `${providerId}\\${modelId}`;
 }
 
 /**
  * Parse a configOption `value` back into { providerId, modelId }.
  *
- * Backward compat: a value without `\` (legacy plain modelId) is treated as a
- * modelId under the current enabled provider, preserving the old behaviour.
+ * A value without `\` is a builtin modelId (legacy form) → resolve to the first
+ * enabled builtin provider. A value with `\` is a third-party provider+model.
  */
 export function parseModelValue(value: string): { providerId: string; modelId: string } {
   const idx = value.indexOf("\\");
   if (idx < 0) {
-    // Legacy plain modelId — resolve to the first enabled provider.
-    const first = loadAllModels()[0];
-    return { providerId: first?.providerId ?? "builtin:bigmodel-coding-plan", modelId: value };
+    // Builtin plain modelId — resolve to the first enabled builtin provider
+    // (falling back to the legacy default if none configured).
+    const firstBuiltin = loadAllModels().find((m) => isBuiltinProvider(m.providerId));
+    return {
+      providerId: firstBuiltin?.providerId ?? "builtin:bigmodel-coding-plan",
+      modelId: value,
+    };
   }
   return { providerId: value.slice(0, idx), modelId: value.slice(idx + 1) };
 }
@@ -198,11 +210,12 @@ export async function buildConfigOptions(
     currentModelId,
   );
 
-  // Model options: config.json enabled providers are authoritative. Show as
-  // "ProviderName › ModelId" so same-named models across providers stay distinct.
+  // Model options: config.json enabled providers are authoritative. Builtin
+  // models show as the bare modelId (clean dropdown for the common case);
+  // third-party models prefix the provider name so they're distinguishable.
   let modelOptions = loadAllModels().map((m) => ({
     value: formatModelValue(m.providerId, m.modelId),
-    name: `${m.providerName} › ${m.modelId}`,
+    name: isBuiltinProvider(m.providerId) ? m.modelId : `${m.providerName} › ${m.modelId}`,
   }));
   if (!modelOptions.some((o) => o.value === currentModel)) {
     // The current model isn't from an enabled provider (e.g. the session was

--- a/src/config/runtime-model.ts
+++ b/src/config/runtime-model.ts
@@ -8,32 +8,22 @@
  * overlay so the backend can authenticate; otherwise it is omitted and the
  * backend uses its own OAuth creds.
  *
- * Two uses:
- *
- *   1. Resume overlay (`buildResumeRuntimeModel`): a resumed session may carry
- *      a stale provider id in its history that the backend can no longer
- *      authenticate. Sending the *current* enabled provider's runtimeModel at
- *      resume makes the backend overlay it and use its own OAuth creds.
- *
- *   2. Model switch (`applyModelSwitch`): UI/slash model switching goes through
- *      `session/updateRuntimeModelConfig` with `applyModelSelection:true` (a
- *      runtime-only change, sidestepping `session/setModel`'s "no loaded config
- *      file" persistence failure).
+ * Used by the model switch path: UI/slash model switching goes through
+ * `session/updateRuntimeModelConfig` with `applyModelSelection:true` (a
+ * runtime-only change, sidestepping `session/setModel`'s "no loaded config
+ * file" persistence failure). Third-party providers are therefore supported
+ * only mid-conversation; session/resume loads with the backend's default
+ * (builtin) model — sending a runtimeModel there triggers "Invalid params"
+ * because session/resume's schema rejects provider.apiKey.
  */
 
-import { findProviderConfig, formatModelValue, loadAllModels, parseModelValue } from "./options.js";
+import { findProviderConfig, formatModelValue, parseModelValue } from "./options.js";
 import type { ModelRef } from "./options.js";
 import { log, warn } from "../utils.js";
 import type { ZcodeAcpServer } from "../server.js";
 
 const DEFAULT_KIND = "anthropic";
 const DEFAULT_BASE_URL = "https://open.bigmodel.cn/api/anthropic";
-
-/** The first enabled provider in config.json (used for resume overlay). */
-function firstEnabledProvider(): ModelRef | null {
-  const all = loadAllModels();
-  return all.length > 0 ? all[0] : null;
-}
 
 /** Build a runtimeModel overlay for the given provider+model. */
 export function buildRuntimeModel(ref: ModelRef, revision = "bridge"): unknown | null {
@@ -62,16 +52,6 @@ export function buildRuntimeModel(ref: ModelRef, revision = "bridge"): unknown |
       models,
     },
   };
-}
-
-/** Build the resume-time overlay (current enabled provider, default model). */
-export function buildResumeRuntimeModel(): unknown | null {
-  const first = firstEnabledProvider();
-  if (!first) {
-    log("runtime-model: no enabled provider in config.json (resume overlay skipped)");
-    return null;
-  }
-  return buildRuntimeModel(first, "bridge-resume");
 }
 
 /**

--- a/src/config/runtime-model.ts
+++ b/src/config/runtime-model.ts
@@ -1,23 +1,27 @@
 /**
  * runtimeModel overlay plumbing.
  *
- * The backend resolves auth either from its OAuth token store (builtin OAuth
- * providers) or from the apiKey embedded in the runtimeModel (custom providers
- * and builtin apiKey-mode providers). `buildRuntimeModel` auto-detects: when the
- * provider's config.json entry has an `options.apiKey`, it is carried into the
- * overlay so the backend can authenticate; otherwise it is omitted and the
- * backend uses its own OAuth creds.
+ * The runtimeModel NEVER carries `provider.apiKey`: the backend's runtimeModel
+ * schema (`.strict()`) types apiKey as a discriminated union object
+ * `{source:"inline"|"credential"|"env"|"server-config", ...}` — a bare string
+ * is rejected with "Invalid params". The backend resolves auth itself from
+ * config.json / its OAuth store, so the overlay only needs to name the
+ * provider+model.
  *
- * Used by the model switch path: UI/slash model switching goes through
- * `session/updateRuntimeModelConfig` with `applyModelSelection:true` (a
- * runtime-only change, sidestepping `session/setModel`'s "no loaded config
- * file" persistence failure). Third-party providers are therefore supported
- * only mid-conversation; session/resume loads with the backend's default
- * (builtin) model — sending a runtimeModel there triggers "Invalid params"
- * because session/resume's schema rejects provider.apiKey.
+ * Two uses:
+ *
+ *   1. Resume overlay (`buildResumeRuntimeModel`): a resumed session may carry a
+ *      stale/revoked model in its history → send fails with "历史模型不可用".
+ *      Overlaying the current enabled provider at resume redirects the session
+ *      onto a working model.
+ *
+ *   2. Model switch (`applyModelSwitch`): UI/slash model switching goes through
+ *      `session/updateRuntimeModelConfig` with `applyModelSelection:true` (a
+ *      runtime-only change, sidestepping `session/setModel`'s "no loaded config
+ *      file" persistence failure).
  */
 
-import { findProviderConfig, formatModelValue, parseModelValue } from "./options.js";
+import { findProviderConfig, formatModelValue, loadAllModels, parseModelValue } from "./options.js";
 import type { ModelRef } from "./options.js";
 import { log, warn } from "../utils.js";
 import type { ZcodeAcpServer } from "../server.js";
@@ -25,14 +29,13 @@ import type { ZcodeAcpServer } from "../server.js";
 const DEFAULT_KIND = "anthropic";
 const DEFAULT_BASE_URL = "https://open.bigmodel.cn/api/anthropic";
 
-/** Build a runtimeModel overlay for the given provider+model. */
+/** Build a runtimeModel overlay for the given provider+model (no apiKey). */
 export function buildRuntimeModel(ref: ModelRef, revision = "bridge"): unknown | null {
   const p = findProviderConfig(ref.providerId);
   if (!p) {
     log(`runtime-model: provider "${ref.providerId}" not in config.json`);
     return null;
   }
-  const apiKey = p.options?.apiKey;
   const baseURL = p.options?.baseURL ?? DEFAULT_BASE_URL;
   const models =
     Object.keys(p.models ?? {}).length > 0
@@ -46,12 +49,19 @@ export function buildRuntimeModel(ref: ModelRef, revision = "bridge"): unknown |
       providerId: ref.providerId,
       kind: p.kind ?? DEFAULT_KIND,
       baseURL,
-      // Auto-detect: custom/apiKey-mode providers carry their key so the backend
-      // can authenticate; OAuth builtins omit it and use backend-managed tokens.
-      ...(apiKey ? { apiKey } : {}),
       models,
     },
   };
+}
+
+/** Build the resume-time overlay (current enabled provider, default model). */
+export function buildResumeRuntimeModel(): unknown | null {
+  const first = loadAllModels()[0];
+  if (!first) {
+    log("runtime-model: no enabled provider in config.json (resume overlay skipped)");
+    return null;
+  }
+  return buildRuntimeModel(first, "bridge-resume");
 }
 
 /**

--- a/src/config/runtime-model.ts
+++ b/src/config/runtime-model.ts
@@ -65,13 +65,20 @@ export function buildResumeRuntimeModel(): unknown | null {
 }
 
 /**
- * Switch a session's model via session/updateRuntimeModelConfig.
+ * Switch a session's model via `session/setModel`.
  *
  * `value` is the configOption value: either `"providerId\modelId"` (encoded) or
- * a legacy plain modelId (resolved to the first enabled provider). Uses
- * `applyModelSelection:true` so the change applies at runtime without
- * persistence — sidestepping `session/setModel`'s "no loaded config file"
- * failure. Invalidates the model cache on success. Returns true on success.
+ * a legacy plain modelId (resolved to the first enabled builtin provider).
+ *
+ * Sends BOTH a `model` ref (the target) AND a `runtimeModel` (the full provider
+ * definition). The runtimeModel lets the backend register the provider into its
+ * workspace catalog (so even third-party / non-default models are recognised),
+ * while `model` names the selection. `persistAsWorkspaceLastUsed:false` keeps
+ * this a runtime-only change. Invalidates the model cache on success.
+ *
+ * NOTE: the older `session/updateRuntimeModelConfig` path returns `changed:false`
+ * on current backends without applying — `session/setModel` is the working
+ * protocol since the backend model-management refactor.
  */
 export async function applyModelSwitch(
   server: ZcodeAcpServer,
@@ -87,8 +94,13 @@ export async function applyModelSwitch(
   const backend = server.ensureBackend();
   const resp = await backend.request(
     server.nextId(),
-    "session/updateRuntimeModelConfig",
-    { sessionId: zcodeSid, runtimeModel, applyModelSelection: true },
+    "session/setModel",
+    {
+      sessionId: zcodeSid,
+      model: { providerId, modelId },
+      runtimeModel,
+      persistAsWorkspaceLastUsed: false,
+    },
     15000,
   );
   if (resp.error) {

--- a/src/config/runtime-model.ts
+++ b/src/config/runtime-model.ts
@@ -10,15 +10,16 @@
  *
  * Two uses:
  *
- *   1. Resume overlay (`buildResumeRuntimeModel`): a resumed session may carry a
- *      stale/revoked model in its history → send fails with "历史模型不可用".
- *      Overlaying the current enabled provider at resume redirects the session
- *      onto a working model.
+ *   1. Resume/load overlay (`buildResumeRuntimeModel`): a resumed session may
+ *      carry a stale/revoked model in its history → send fails with "历史模型
+ *      不可用". The overlay pins the session onto the default model — the FIRST
+ *      enabled provider's FIRST model, the same one a fresh `session/new` lands
+ *      on — so resume never inherits the session's last-used (possibly
+ *      third-party / unavailable) model.
  *
  *   2. Model switch (`applyModelSwitch`): UI/slash model switching goes through
- *      `session/updateRuntimeModelConfig` with `applyModelSelection:true` (a
- *      runtime-only change, sidestepping `session/setModel`'s "no loaded config
- *      file" persistence failure).
+ *      `session/setModel` with both a `model` ref and a `runtimeModel` provider
+ *      definition (runtime-only via `persistAsWorkspaceLastUsed:false`).
  */
 
 import { findProviderConfig, formatModelValue, loadAllModels, parseModelValue } from "./options.js";
@@ -54,7 +55,12 @@ export function buildRuntimeModel(ref: ModelRef, revision = "bridge"): unknown |
   };
 }
 
-/** Build the resume-time overlay (current enabled provider, default model). */
+/**
+ * Build the resume-time overlay pinned to the default model: the FIRST enabled
+ * provider's FIRST model (the same one a fresh `session/new` lands on). This
+ * ensures resume never inherits the session's last-used model, which may be a
+ * now-unavailable third-party model (e.g. Nvidia) and cause "历史模型不可用".
+ */
 export function buildResumeRuntimeModel(): unknown | null {
   const first = loadAllModels()[0];
   if (!first) {

--- a/src/config/runtime-model.ts
+++ b/src/config/runtime-model.ts
@@ -1,9 +1,14 @@
 /**
  * runtimeModel overlay plumbing.
  *
- * The backend resolves auth from its OAuth token store, so the `runtimeModel`
- * provider deliberately carries NO `apiKey` (the config.json apiKey is the
- * legacy plain key and has expired → 401). Two uses:
+ * The backend resolves auth either from its OAuth token store (builtin OAuth
+ * providers) or from the apiKey embedded in the runtimeModel (custom providers
+ * and builtin apiKey-mode providers). `buildRuntimeModel` auto-detects: when the
+ * provider's config.json entry has an `options.apiKey`, it is carried into the
+ * overlay so the backend can authenticate; otherwise it is omitted and the
+ * backend uses its own OAuth creds.
+ *
+ * Two uses:
  *
  *   1. Resume overlay (`buildResumeRuntimeModel`): a resumed session may carry
  *      a stale provider id in its history that the backend can no longer
@@ -16,98 +21,77 @@
  *      file" persistence failure).
  */
 
-import { readFileSync } from "node:fs";
-
-import { ZCODE_CREDS_PATH, log, warn } from "../utils.js";
+import { findProviderConfig, formatModelValue, loadAllModels, parseModelValue } from "./options.js";
+import type { ModelRef } from "./options.js";
+import { log, warn } from "../utils.js";
 import type { ZcodeAcpServer } from "../server.js";
 
-interface ProviderConfig {
-  providerId: string;
-  kind: string;
-  baseURL: string;
-  modelId: string;
-  models: string[];
+const DEFAULT_KIND = "anthropic";
+const DEFAULT_BASE_URL = "https://open.bigmodel.cn/api/anthropic";
+
+/** The first enabled provider in config.json (used for resume overlay). */
+function firstEnabledProvider(): ModelRef | null {
+  const all = loadAllModels();
+  return all.length > 0 ? all[0] : null;
 }
 
-interface ProviderEntry {
-  enabled?: boolean;
-  kind?: string;
-  options?: { baseURL?: string };
-  models?: Record<string, unknown>;
-}
-
-interface ConfigJson {
-  provider?: Record<string, ProviderEntry>;
-}
-
-const DEFAULTS: ProviderConfig = {
-  providerId: "builtin:bigmodel-coding-plan",
-  kind: "anthropic",
-  baseURL: "https://open.bigmodel.cn/api/anthropic",
-  modelId: "GLM-5.2",
-  models: ["GLM-5.2"],
-};
-
-/** Read the enabled provider's config from config.json (no apiKey). */
-function readEnabledProvider(): ProviderConfig {
-  try {
-    const cfg = JSON.parse(readFileSync(ZCODE_CREDS_PATH, "utf8")) as ConfigJson;
-    for (const [pid, p] of Object.entries(cfg.provider ?? {})) {
-      if (p?.enabled) {
-        const opts = p.options ?? {};
-        const modelKeys = Object.keys(p.models ?? {});
-        return {
-          providerId: pid,
-          kind: p.kind ?? DEFAULTS.kind,
-          baseURL: opts.baseURL || DEFAULTS.baseURL,
-          modelId: modelKeys[0] ?? DEFAULTS.modelId,
-          models: modelKeys.length > 0 ? modelKeys : DEFAULTS.models,
-        };
-      }
-    }
-  } catch (e) {
-    log(`runtime-model: read config.json failed (${e instanceof Error ? e.message : String(e)})`);
+/** Build a runtimeModel overlay for the given provider+model. */
+export function buildRuntimeModel(ref: ModelRef, revision = "bridge"): unknown | null {
+  const p = findProviderConfig(ref.providerId);
+  if (!p) {
+    log(`runtime-model: provider "${ref.providerId}" not in config.json`);
+    return null;
   }
-  return DEFAULTS;
-}
-
-/** Build a runtimeModel overlay object for the enabled provider. */
-export function buildRuntimeModel(modelId?: string, revision = "bridge"): unknown | null {
-  const pc = readEnabledProvider();
-  const targetModel = modelId ?? pc.modelId;
+  const apiKey = p.options?.apiKey;
+  const baseURL = p.options?.baseURL ?? DEFAULT_BASE_URL;
+  const models =
+    Object.keys(p.models ?? {}).length > 0
+      ? Object.keys(p.models ?? {}).map((m) => ({ modelId: m }))
+      : [{ modelId: ref.modelId }];
   return {
     revision,
     generatedAt: Date.now(),
-    model: { providerId: pc.providerId, modelId: targetModel },
+    model: { providerId: ref.providerId, modelId: ref.modelId },
     provider: {
-      providerId: pc.providerId,
-      kind: pc.kind,
-      baseURL: pc.baseURL,
-      models: pc.models.map((m) => ({ modelId: m })),
+      providerId: ref.providerId,
+      kind: p.kind ?? DEFAULT_KIND,
+      baseURL,
+      // Auto-detect: custom/apiKey-mode providers carry their key so the backend
+      // can authenticate; OAuth builtins omit it and use backend-managed tokens.
+      ...(apiKey ? { apiKey } : {}),
+      models,
     },
   };
 }
 
 /** Build the resume-time overlay (current enabled provider, default model). */
 export function buildResumeRuntimeModel(): unknown | null {
-  return buildRuntimeModel(undefined, "bridge-resume");
+  const first = firstEnabledProvider();
+  if (!first) {
+    log("runtime-model: no enabled provider in config.json (resume overlay skipped)");
+    return null;
+  }
+  return buildRuntimeModel(first, "bridge-resume");
 }
 
 /**
  * Switch a session's model via session/updateRuntimeModelConfig.
  *
- * Uses `applyModelSelection:true` so the change applies at runtime without
+ * `value` is the configOption value: either `"providerId\modelId"` (encoded) or
+ * a legacy plain modelId (resolved to the first enabled provider). Uses
+ * `applyModelSelection:true` so the change applies at runtime without
  * persistence — sidestepping `session/setModel`'s "no loaded config file"
  * failure. Invalidates the model cache on success. Returns true on success.
  */
 export async function applyModelSwitch(
   server: ZcodeAcpServer,
   zcodeSid: string,
-  modelId: string,
+  value: string,
 ): Promise<boolean> {
-  const runtimeModel = buildRuntimeModel(modelId, "bridge-switch");
+  const { providerId, modelId } = parseModelValue(value);
+  const runtimeModel = buildRuntimeModel({ providerId, providerName: providerId, modelId });
   if (runtimeModel === null) {
-    log("runtime-model: cannot read provider config (config.json)");
+    log(`runtime-model: cannot build overlay for "${value}" (provider not found)`);
     return false;
   }
   const backend = server.ensureBackend();
@@ -129,3 +113,6 @@ export async function applyModelSwitch(
 export function invalidateModelCache(server: ZcodeAcpServer, zcodeSid: string): void {
   server.modelCache.delete(zcodeSid);
 }
+
+// Re-exported so callers that only import runtime-model.ts can format values.
+export { formatModelValue };

--- a/src/handlers/dispatch.ts
+++ b/src/handlers/dispatch.ts
@@ -12,7 +12,7 @@ import { randomUUID } from "node:crypto";
 import type * as acp from "@agentclientprotocol/sdk";
 
 import { currentModelCached } from "../config/model-cache.js";
-import { modelContextWindow } from "../config/options.js";
+import { modelContextWindow, parseModelValue } from "../config/options.js";
 import {
   extractExitCode,
   parseSubagentMetadata,
@@ -258,8 +258,8 @@ async function dispatchUsageDelta(
   // config.json limit.context so the editor can render the context bar.
   let size = ev.size;
   if (!size) {
-    const modelId = await currentModelCached(server, acpSid);
-    size = modelContextWindow(modelId);
+    const { providerId, modelId } = parseModelValue(await currentModelCached(server, acpSid));
+    size = modelContextWindow(providerId, modelId);
   }
   await sendSessionUpdate(cx, acpSid, {
     sessionUpdate: "usage_update",

--- a/src/handlers/extensions.ts
+++ b/src/handlers/extensions.ts
@@ -304,7 +304,7 @@ export async function setMode(
  * With expectLock=true, we first require observing "prompt is running" once
  * (proving the turn truly started) before trusting a later success.
  */
-async function waitForTurnIdle(
+export async function waitForTurnIdle(
   server: ZcodeAcpServer,
   zcodeSid: string,
   timeoutMs: number,

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -33,6 +33,7 @@ import {
 import type { InternalEvent } from "../translators/index.js";
 import { log, warn } from "../utils.js";
 import type { PendingTurn, ZcodeAcpServer } from "../server.js";
+import { waitForTurnIdle } from "./extensions.js";
 import { dispatchEvent } from "./dispatch.js";
 import { sendSessionUpdate, sendTextChunk } from "./io.js";
 import { handleServerRequests } from "./server-requests.js";
@@ -459,10 +460,11 @@ export async function cancel(
  * `_cancel_backend_turn`: send stop with an id (some backends route by id
  * presence), never wait for a response, never throw.
  *
- * The backend's turn loop will emit turn.completed(cancelled) on its own;
- * the ACP turn loop observes that event and exits. No probing needed on the
- * prompt path — an earlier ensureTurnStopped probed session/goal show for 30s
- * but returned inconsistent values and caused severe stalls.
+ * Probing the lock afterward is the caller's job — on the preempt path
+ * (preemptInFlightTurn) we follow up with waitForTurnIdle to confirm release;
+ * the turn-loop cancel sites call this and rely on their own event-driven
+ * exit. The backend's turn loop emits turn.completed on its own (success if
+ * stop didn't catch the streaming turn in time, cancelled otherwise).
  */
 function stopBackendTurn(server: ZcodeAcpServer, zcodeSid: string): void {
   try {
@@ -547,23 +549,32 @@ async function preemptInFlightTurn(
 
   log(`  [preempt] in-flight turn ${oldRequestId} found, stopping it`);
   // Fire-and-forget stop (mirrors Python's _cancel_backend_turn). The old
-  // turn loop will receive turn.completed(cancelled) and exit on its own.
+  // turn loop will receive turn.completed and exit on its own.
   stopBackendTurn(server, zcodeSid);
 
-  // Wait for the old turn's prompt() to fully exit (its finally block deletes
-  // the pendingTurns entry). This is the synchronization point that guarantees
-  // both lock release (backend turn ended) and listener unregistration before
-  // we subscribe/send. More reliable than probing session/goal show.
+  // The old turn is already streaming (lock held), so expectLock=false: we
+  // don't need to observe the lock appearing first, only its release. Probe
+  // session/goal show until it stops reporting "prompt is running" — this is
+  // the same mechanism waitForTurnIdle uses for compact/goal, and unlike
+  // pendingTurns polling it does NOT depend on the backend emitting a
+  // cancelled event (which never comes for a streaming turn hit by stop:
+  // it completes as success, not cancelled).
+  //
+  // pendingTurns cleanup by the old turn's finally block still happens and
+  // remains the listener-overwrite guard, but we no longer BLOCK on it.
   const PREEMPT_TIMEOUT_MS = 35_000;
-  const t0 = Date.now();
-  while (server.pendingTurns.has(oldRequestId)) {
-    if (Date.now() - t0 > PREEMPT_TIMEOUT_MS) {
-      warn(`  [preempt] timed out waiting for old turn ${oldRequestId} to exit`);
-      return; // best-effort: continue anyway, session/send may fail
-    }
-    await sleep(200);
+  const released = await waitForTurnIdle(
+    server,
+    zcodeSid,
+    PREEMPT_TIMEOUT_MS,
+    "session/goal",
+    false, // old turn already holds the lock; just wait for release
+  );
+  if (!released) {
+    warn(`  [preempt] lock wait timed out for old turn ${oldRequestId}, proceeding best-effort`);
+  } else {
+    log(`  [preempt] old turn ${oldRequestId} lock released, proceeding`);
   }
-  log(`  [preempt] old turn ${oldRequestId} exited, proceeding`);
 }
 
 // ---------- internals ----------

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -279,9 +279,12 @@ export async function prompt(
   const zcodeSid = server.resolveSid(params.sessionId);
   if (!zcodeSid) throw new Error(`session ${params.sessionId} not found`);
 
-  // Extract prompt text from ACP ContentBlock[].
+  // Extract prompt text + image attachments from ACP ContentBlock[].
   const text = extractPromptText(params.prompt);
-  if (!text) throw new Error("empty prompt");
+  const attachments = extractAttachments(params.prompt);
+  // A prompt is valid if it has text OR at least one image attachment (a user
+  // may drag in an image with no accompanying text).
+  if (!text && attachments.length === 0) throw new Error("empty prompt");
 
   // Slash-command interception: dispatches directly to ZCode methods and
   // returns end_turn without entering the turn loop. Unknown /x falls through.
@@ -335,7 +338,9 @@ export async function prompt(
     const sendResp = await backend.request(
       server.nextId(),
       "session/send",
-      { sessionId: zcodeSid, content: text },
+      attachments.length > 0
+        ? { sessionId: zcodeSid, content: text, attachments }
+        : { sessionId: zcodeSid, content: text },
       15000,
     );
     if (sendResp.error) {
@@ -599,6 +604,89 @@ export function extractPromptText(blocks: acp.ContentBlock[] | undefined): strin
     }
   }
   return parts.join("\n").trim();
+}
+
+/**
+ * ACP `ContentBlock::Image` → zcode `session/send` attachment.
+ *
+ * zcode's per-attachment normalizer accepts either a `localPath` (absolute FS
+ * path, preferred) or `dataBase64` + `mimeType` (raw base64, no data: prefix).
+ * ACP `ImageContent` carries `data` (base64) and an optional `uri`; when the
+ * uri is a file:// pointer we send localPath so the backend streams from disk
+ * instead of re-encoding.
+ */
+export interface ImageAttachment {
+  kind: "image";
+  filename: string;
+  mimeType: string;
+  sizeBytes?: number;
+  dataBase64?: string;
+  localPath?: string;
+}
+
+/** Extension inferred from mimeType for synthesizing a filename. */
+const MIME_EXT: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/gif": "gif",
+  "image/webp": "webp",
+  "image/bmp": "bmp",
+  "image/svg+xml": "svg",
+};
+
+/**
+ * Extract image attachments from ACP ContentBlock[]. Non-image blocks are
+ * ignored (text/resource_link/resource stay owned by `extractPromptText`).
+ * Exported for unit testing.
+ */
+export function extractAttachments(blocks: acp.ContentBlock[] | undefined): ImageAttachment[] {
+  const out: ImageAttachment[] = [];
+  let imageIndex = 0;
+  for (const block of blocks ?? []) {
+    const b = block as {
+      type?: string;
+      data?: string;
+      mimeType?: string;
+      uri?: string | null;
+    };
+    if (b.type !== "image") continue;
+    imageIndex += 1;
+    const mimeType = b.mimeType ?? "image/png";
+    // Prefer a file:// uri → localPath so the backend streams from disk.
+    const uri = typeof b.uri === "string" ? b.uri : "";
+    if (uri.startsWith("file://")) {
+      const localPath = fileUriToPath(uri);
+      out.push({
+        kind: "image",
+        filename: basename(localPath) ?? `image-${imageIndex}.${MIME_EXT[mimeType] ?? "png"}`,
+        mimeType,
+        localPath,
+      });
+      continue;
+    }
+    // Otherwise fall back to the base64 payload.
+    if (b.data) {
+      out.push({
+        kind: "image",
+        filename: uri
+          ? (basename(uri) ?? `image-${imageIndex}.${MIME_EXT[mimeType] ?? "png"}`)
+          : `image-${imageIndex}.${MIME_EXT[mimeType] ?? "png"}`,
+        mimeType,
+        dataBase64: b.data,
+        sizeBytes: Math.floor((b.data.length * 3) / 4),
+      });
+    }
+    // An image block with neither a usable uri nor data is dropped defensively.
+  }
+  return out;
+}
+
+/** Best-effort basename from a path/uri (no node:path import for a tiny helper). */
+function basename(p: string): string | null {
+  const clean = p.replace(/\/+$/, "");
+  const slash = clean.lastIndexOf("/");
+  const name = slash >= 0 ? clean.slice(slash + 1) : clean;
+  return name || null;
 }
 
 /** Convert a file:// URI to an absolute filesystem path. */

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -22,6 +22,7 @@ import type {
 } from "../backend/types.js";
 import { buildModes, buildConfigOptions } from "../config/options.js";
 import { emitInitialUsage } from "../config/model-cache.js";
+import { buildResumeRuntimeModel } from "../config/runtime-model.js";
 import {
   buildDiffContent,
   EventTranslator,
@@ -122,7 +123,7 @@ export async function listSessions(
   return { sessions };
 }
 
-/** `session/resume` → zcode `session/resume`. */
+/** `session/resume` → zcode `session/resume` (with runtimeModel overlay). */
 export async function resumeSession(
   server: ZcodeAcpServer,
   params: acp.ResumeSessionRequest,
@@ -133,15 +134,17 @@ export async function resumeSession(
   const cwd = params.cwd ?? process.cwd();
   if (!targetSid) throw new Error("sessionId required");
 
-  // No runtimeModel overlay: session/resume loads with the backend's default
-  // (builtin) model. Third-party providers are only switched mid-conversation
-  // via session/updateRuntimeModelConfig — sending a runtimeModel at resume
-  // triggers "Invalid params" because session/resume's schema rejects
-  // provider.apiKey.
+  // runtimeModel overlay: a resumed session may carry a stale/revoked model in
+  // its history → send fails with "历史模型不可用". Overlaying the current
+  // enabled provider redirects the session onto a working model. The overlay
+  // deliberately carries NO apiKey (the backend's schema rejects it; it resolves
+  // auth from its own config/OAuth store).
   const zcParams: Record<string, unknown> = {
     sessionId: targetSid,
     workspace: workspaceFor(cwd),
   };
+  const runtimeModel = buildResumeRuntimeModel();
+  if (runtimeModel !== null) zcParams.runtimeModel = runtimeModel;
   const resp = await backend.request(server.nextId(), "session/resume", zcParams, 15000);
   if (resp.error) throw new Error(`zcode resume failed: ${resp.error.message ?? ""}`);
 
@@ -177,6 +180,8 @@ export async function loadSession(
     sessionId: targetSid,
     workspace: workspaceFor(cwd),
   };
+  const runtimeModel = buildResumeRuntimeModel();
+  if (runtimeModel !== null) zcParams.runtimeModel = runtimeModel;
   const resp = await backend.request(server.nextId(), "session/resume", zcParams, 15000);
   if (resp.error) throw new Error(`zcode resume failed: ${resp.error.message ?? ""}`);
   server.registerSession(targetSid, targetSid);

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -329,8 +329,10 @@ export async function prompt(
     server.pendingTurns.delete(requestId);
     throw e;
   }
-  // The snapshot isn't consumed (differ baseline is set above); subscribe is
-  // what matters — it arms the event stream for the upcoming turn.
+  // subscribe() requests includeSnapshot:false (it only needs the eventSeq
+  // watermark to arm the event stream), so `snapshot` is an empty fallback.
+  // The real projection baseline comes from fetchMessages + differ.markSeen
+  // above. Kept as a binding only so the call fits the Promise-returning shape.
   void snapshot;
   backend.registerEventListener(zcodeSid, listener);
 

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -312,11 +312,20 @@ export async function prompt(
   differ.markSeen(baselineMsgs);
 
   // Subscribe BEFORE send so we don't lose early turn.completed on short turns.
-  const snapshot = await listener.subscribe(() => server.nextId());
-  if (snapshot === null) {
+  // subscribe() throws on failure, surfacing the backend's real error (reader
+  // dead, timeout, pipe broken, method-not-found on old CLI, session error) so
+  // the cause is distinguishable. Clean up the pending turn before propagating
+  // — this call site is outside the try/finally below.
+  let snapshot: ZcodeSnapshot;
+  try {
+    snapshot = await listener.subscribe(() => server.nextId());
+  } catch (e) {
     server.pendingTurns.delete(requestId);
-    throw new Error("session/subscribe failed (ZCode CLI 0.14.8+ required)");
+    throw e;
   }
+  // The snapshot isn't consumed (differ baseline is set above); subscribe is
+  // what matters — it arms the event stream for the upcoming turn.
+  void snapshot;
   backend.registerEventListener(zcodeSid, listener);
 
   const chunkMsgId = randomUUID();

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -22,7 +22,6 @@ import type {
 } from "../backend/types.js";
 import { buildModes, buildConfigOptions } from "../config/options.js";
 import { emitInitialUsage } from "../config/model-cache.js";
-import { buildResumeRuntimeModel } from "../config/runtime-model.js";
 import {
   buildDiffContent,
   EventTranslator,
@@ -123,7 +122,7 @@ export async function listSessions(
   return { sessions };
 }
 
-/** `session/resume` → zcode `session/resume` (with runtimeModel overlay for resumed sessions). */
+/** `session/resume` → zcode `session/resume`. */
 export async function resumeSession(
   server: ZcodeAcpServer,
   params: acp.ResumeSessionRequest,
@@ -134,15 +133,15 @@ export async function resumeSession(
   const cwd = params.cwd ?? process.cwd();
   if (!targetSid) throw new Error("sessionId required");
 
+  // No runtimeModel overlay: session/resume loads with the backend's default
+  // (builtin) model. Third-party providers are only switched mid-conversation
+  // via session/updateRuntimeModelConfig — sending a runtimeModel at resume
+  // triggers "Invalid params" because session/resume's schema rejects
+  // provider.apiKey.
   const zcParams: Record<string, unknown> = {
     sessionId: targetSid,
     workspace: workspaceFor(cwd),
   };
-  // runtimeModel overlay: a resumed session may carry a stale provider id in
-  // its history → backend can't auth. Send the current enabled provider so the
-  // backend overlays it and uses its own OAuth creds.
-  const runtimeModel = buildResumeRuntimeModel();
-  if (runtimeModel !== null) zcParams.runtimeModel = runtimeModel;
   const resp = await backend.request(server.nextId(), "session/resume", zcParams, 15000);
   if (resp.error) throw new Error(`zcode resume failed: ${resp.error.message ?? ""}`);
 
@@ -178,8 +177,6 @@ export async function loadSession(
     sessionId: targetSid,
     workspace: workspaceFor(cwd),
   };
-  const runtimeModel = buildResumeRuntimeModel();
-  if (runtimeModel !== null) zcParams.runtimeModel = runtimeModel;
   const resp = await backend.request(server.nextId(), "session/resume", zcParams, 15000);
   if (resp.error) throw new Error(`zcode resume failed: ${resp.error.message ?? ""}`);
   server.registerSession(targetSid, targetSid);

--- a/src/interaction/adapter.ts
+++ b/src/interaction/adapter.ts
@@ -300,7 +300,6 @@ export function buildAskUserElicitationForm(
         type: "array",
         items: { type: "string", enum: labels },
         title: q.question,
-        description: q.question,
       };
     } else {
       // Append a Skip option so the user can opt out of this question without
@@ -309,14 +308,18 @@ export function buildAskUserElicitationForm(
         type: "string",
         enum: [...labels, ELICIT_SKIP],
         title: q.question,
-        description: q.question,
       };
       required.push(key);
     }
   }
+  // The question text already appears as each field's `title` (its label), so
+  // the form `message` must NOT repeat it — otherwise Zed shows the question
+  // twice (top banner + field label). Use a neutral prompt instead. For a
+  // single question this reads naturally above its labeled field; for several,
+  // it tells the user how many fields follow.
   const message =
     questions.length === 1
-      ? (questions[0]?.question ?? "Please answer the question.")
+      ? "Please answer the question."
       : `Please answer ${questions.length} questions.`;
   const form: {
     mode: "form";

--- a/src/server.ts
+++ b/src/server.ts
@@ -208,7 +208,7 @@ export class ZcodeAcpServer {
       agentInfo: { ...AGENT_INFO },
       agentCapabilities: {
         loadSession: true,
-        promptCapabilities: { image: false, audio: false, embeddedContext: false },
+        promptCapabilities: { image: true, audio: false, embeddedContext: false },
         mcpCapabilities: { http: false, sse: false },
         sessionCapabilities: { list: {}, resume: {}, fork: {} },
       },

--- a/tests/bugfixes.test.ts
+++ b/tests/bugfixes.test.ts
@@ -8,14 +8,14 @@
  * Bug I  — stableStringify sorts keys (stable plan signature).
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { EventStreamListener } from "../src/backend/listener.js";
 import { ZcodeBackend } from "../src/backend/client.js";
 import { ProjectionDiffer } from "../src/translators/projection-differ.js";
 import { flattenTodos } from "../src/handlers/session.js";
 import { CONFIG_META } from "../src/utils.js";
-import type { ZcodeEvent } from "../src/backend/types.js";
+import type { ZcodeEvent, ZcodeResponse } from "../src/backend/types.js";
 
 /** Build a listener over a fake backend (no subprocess; we drive handleEvent). */
 function makeListener(): EventStreamListener {
@@ -47,6 +47,54 @@ describe("Bug A: pollEvent zombie waiter", () => {
     listener.handleEvent(makeEvent(1, "turn.started"));
     const r = await pollP;
     expect(r?.type).toBe("turn.started");
+  });
+});
+
+describe('subscribe error surfacing (no more misleading "0.14.8 required")', () => {
+  // Before the fix, subscribe() returned null on ANY backend error and the
+  // caller threw a hardcoded "session/subscribe failed (ZCode CLI 0.14.8+
+  // required)" string. That misled users whose CLI was already new — the real
+  // cause (backend dead / timeout / pipe broken / session error) was swallowed.
+  // Now subscribe() throws with the backend's real error message.
+
+  it("throws with the backend's real error message on reader-dead failure", async () => {
+    const fake = new ZcodeBackend([process.execPath, "-e", "process.stdin.resume()"], process.env);
+    const listener = new EventStreamListener(fake, "sess_x");
+    vi.spyOn(fake, "request").mockResolvedValue({
+      id: 1,
+      error: { message: "zcode backend reader exited (backend dead)" },
+    });
+    await expect(listener.subscribe(() => 1)).rejects.toThrow(
+      /session\/subscribe failed: zcode backend reader exited/,
+    );
+    // Crucially, the error must NOT blame the CLI version.
+    await expect(listener.subscribe(() => 1)).rejects.toThrow(/^((?!0\.14\.8).)*$/s);
+  });
+
+  it("includes the error code when the backend provides one (old CLI method-not-found)", async () => {
+    const fake = new ZcodeBackend([process.execPath, "-e", "process.stdin.resume()"], process.env);
+    const listener = new EventStreamListener(fake, "sess_x");
+    vi.spyOn(fake, "request").mockResolvedValue({
+      id: 1,
+      error: { message: "method not found", code: -32601 },
+    });
+    await expect(listener.subscribe(() => 1)).rejects.toThrow(
+      /session\/subscribe failed: method not found \(code -32601\)/,
+    );
+  });
+
+  it("returns the snapshot (not null) on success", async () => {
+    const fake = new ZcodeBackend([process.execPath, "-e", "process.stdin.resume()"], process.env);
+    const listener = new EventStreamListener(fake, "sess_x");
+    const snap = { projection: { status: "idle" }, messages: [] };
+    vi.spyOn(fake, "request").mockResolvedValue({
+      id: 1,
+      result: { eventSeq: 5, snapshot: snap },
+    } as ZcodeResponse);
+    const result = await listener.subscribe(() => 1);
+    expect(result).toEqual(snap);
+    expect(listener.subscribed).toBe(true);
+    expect(listener.lastSeq).toBe(5);
   });
 });
 

--- a/tests/bugfixes.test.ts
+++ b/tests/bugfixes.test.ts
@@ -98,6 +98,77 @@ describe('subscribe error surfacing (no more misleading "0.14.8 required")', () 
   });
 });
 
+describe("subscribe retries transient timeout (preempt busy window)", () => {
+  // After a preempt the backend can be briefly busy; a subscribe issued in that
+  // window times out. subscribe() should retry transient timeouts and succeed
+  // once the backend recovers, instead of failing the turn.
+
+  it("retries on timeout and succeeds on a later attempt", async () => {
+    const fake = new ZcodeBackend([process.execPath, "-e", "process.stdin.resume()"], process.env);
+    const listener = new EventStreamListener(fake, "sess_x");
+    const snap = { projection: { status: "idle" }, messages: [] };
+    const requestSpy = vi.spyOn(fake, "request");
+    requestSpy
+      .mockResolvedValueOnce({ id: 1, error: { message: "timeout" } })
+      .mockResolvedValueOnce({ id: 2, error: { message: "timeout" } })
+      .mockResolvedValueOnce({
+        id: 3,
+        result: { eventSeq: 5, snapshot: snap },
+      } as ZcodeResponse);
+    // Fake timers so the backoff sleeps don't slow the test.
+    vi.useFakeTimers();
+    const subP = listener.subscribe(() => 1);
+    // Flush the backoff sleeps interleaved with the awaits.
+    await vi.runAllTimersAsync();
+    const result = await subP;
+    vi.useRealTimers();
+    expect(result).toEqual(snap);
+    expect(listener.subscribed).toBe(true);
+    expect(listener.lastSeq).toBe(5);
+    expect(requestSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it("does NOT retry on non-transient errors (reader dead)", async () => {
+    const fake = new ZcodeBackend([process.execPath, "-e", "process.stdin.resume()"], process.env);
+    const listener = new EventStreamListener(fake, "sess_x");
+    const requestSpy = vi.spyOn(fake, "request").mockResolvedValue({
+      id: 1,
+      error: { message: "zcode backend reader exited (backend dead)" },
+    } as ZcodeResponse);
+    await expect(listener.subscribe(() => 1)).rejects.toThrow(/reader exited/);
+    expect(requestSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT retry on method-not-found (old CLI)", async () => {
+    const fake = new ZcodeBackend([process.execPath, "-e", "process.stdin.resume()"], process.env);
+    const listener = new EventStreamListener(fake, "sess_x");
+    const requestSpy = vi.spyOn(fake, "request").mockResolvedValue({
+      id: 1,
+      error: { message: "method not found", code: -32601 },
+    } as ZcodeResponse);
+    await expect(listener.subscribe(() => 1)).rejects.toThrow(/method not found \(code -32601\)/);
+    expect(requestSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws after exhausting all retries", async () => {
+    const fake = new ZcodeBackend([process.execPath, "-e", "process.stdin.resume()"], process.env);
+    const listener = new EventStreamListener(fake, "sess_x");
+    vi.spyOn(fake, "request").mockResolvedValue({
+      id: 1,
+      error: { message: "timeout" },
+    } as ZcodeResponse);
+    vi.useFakeTimers();
+    // Attach the rejection handler up front so the eventual rejection is never
+    // "unhandled" during the timer flush window.
+    const subP = listener.subscribe(() => 1).catch((e: unknown) => e);
+    await vi.runAllTimersAsync();
+    const err = await subP;
+    vi.useRealTimers();
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/session\/subscribe failed: timeout/);
+  });
+});
+
 describe("Bug I: stableStringify / plan signature stability", () => {
   it("treats same todos with different key order as the same signature", () => {
     const d1 = new ProjectionDiffer();

--- a/tests/extract-prompt.test.ts
+++ b/tests/extract-prompt.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { extractPromptText } from "../src/handlers/session.js";
+import { extractAttachments, extractPromptText } from "../src/handlers/session.js";
 
 describe("extractPromptText", () => {
   it("concatenates multiple text blocks with newlines", () => {
@@ -125,5 +125,102 @@ describe("extractPromptText", () => {
       ] as never);
       expect(out).toBe("");
     });
+  });
+});
+
+describe("extractAttachments", () => {
+  it("returns [] for no blocks / non-image blocks", () => {
+    expect(extractAttachments(undefined)).toEqual([]);
+    expect(extractAttachments([])).toEqual([]);
+    expect(
+      extractAttachments([
+        { type: "text", text: "hello" },
+        { type: "resource_link", name: "f", uri: "file:///x" },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("converts a base64 image block to a dataBase64 attachment", () => {
+    const out = extractAttachments([
+      { type: "image", data: "aGVsbG8=", mimeType: "image/png" } as never,
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].kind).toBe("image");
+    expect(out[0].mimeType).toBe("image/png");
+    expect(out[0].dataBase64).toBe("aGVsbG8=");
+    // sizeBytes estimated from base64 length (8 chars → 6 bytes)
+    expect(out[0].sizeBytes).toBe(6);
+    expect(out[0].localPath).toBeUndefined();
+    // synthesized filename from mimeType
+    expect(out[0].filename).toBe("image-1.png");
+  });
+
+  it("prefers a file:// uri → localPath over the base64 payload", () => {
+    const out = extractAttachments([
+      {
+        type: "image",
+        data: "aGVsbG8=",
+        mimeType: "image/jpeg",
+        uri: "file:///Users/william/pics/cat.jpeg",
+      } as never,
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].localPath).toBe("/Users/william/pics/cat.jpeg");
+    expect(out[0].dataBase64).toBeUndefined();
+    // filename derived from the uri basename
+    expect(out[0].filename).toBe("cat.jpeg");
+  });
+
+  it("decodes percent-encoded file:// uris for localPath", () => {
+    const out = extractAttachments([
+      {
+        type: "image",
+        mimeType: "image/png",
+        uri: "file:///Users/some%20one/my%20pic.png",
+      } as never,
+    ]);
+    expect(out[0].localPath).toBe("/Users/some one/my pic.png");
+    expect(out[0].filename).toBe("my pic.png");
+  });
+
+  it("synthesizes filename from uri basename when mimeType is unknown", () => {
+    const out = extractAttachments([
+      {
+        type: "image",
+        data: "AAAA",
+        mimeType: "image/x-weird",
+        uri: "https://example.com/foo.png",
+      } as never,
+    ]);
+    // http uri is not a localPath, so falls to dataBase64; filename from uri basename
+    expect(out[0].dataBase64).toBe("AAAA");
+    expect(out[0].localPath).toBeUndefined();
+    expect(out[0].filename).toBe("foo.png");
+  });
+
+  it("keeps image order and indexes filenames for multiple base64 images", () => {
+    const out = extractAttachments([
+      { type: "image", data: "AAAA", mimeType: "image/png" } as never,
+      { type: "text", text: "and another" },
+      { type: "image", data: "BBBB", mimeType: "image/jpeg" } as never,
+    ]);
+    expect(out).toHaveLength(2);
+    expect(out[0].filename).toBe("image-1.png");
+    expect(out[1].filename).toBe("image-2.jpg");
+  });
+
+  it("drops an image block with neither a usable uri nor data", () => {
+    const out = extractAttachments([{ type: "image", mimeType: "image/png" } as never]);
+    expect(out).toEqual([]);
+  });
+
+  it("image blocks do not leak into extractPromptText text", () => {
+    // Images are routed via attachments, never inlined into the prompt text.
+    const blocks = [
+      { type: "image", data: "aGVsbG8=", mimeType: "image/png" },
+      { type: "text", text: "describe this" },
+    ];
+    expect(extractPromptText(blocks as never)).toBe("describe this");
+    expect(extractAttachments(blocks as never)).toHaveLength(1);
   });
 });

--- a/tests/runtime-model.test.ts
+++ b/tests/runtime-model.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for multi-provider model discovery and runtimeModel construction.
+ *
+ * History: loadProviderModels() hardcoded a single builtin provider id, so
+ * custom providers configured in the ZCode desktop app never appeared in the
+ * dropdown. These tests lock the new behaviour: loadAllModels() aggregates ALL
+ * enabled providers, buildRuntimeModel() carries the apiKey for custom/apiKey
+ * providers, and the encoded value format round-trips correctly.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { ZCODE_CREDS_PATH } from "../src/utils.js";
+
+/** Fake config.json with one builtin (OAuth, no apiKey) + one custom (apiKey). */
+const FAKE_CONFIG = {
+  provider: {
+    "builtin:bigmodel-coding-plan": {
+      name: "BigModel",
+      kind: "anthropic",
+      enabled: true,
+      options: { baseURL: "https://open.bigmodel.cn/api/anthropic" },
+      models: {
+        "GLM-5.2": { limit: { context: 1000000 } },
+        "GLM-5-Turbo": { limit: { context: 200000 } },
+      },
+    },
+    "builtin:zai-coding-plan": {
+      name: "ZAI",
+      kind: "anthropic",
+      enabled: false,
+      options: { baseURL: "https://api.z.ai" },
+      models: { "GLM-5.2": { limit: { context: 1000000 } } },
+    },
+    "2e06bf1a-custom-nvidia": {
+      name: "Nvidia",
+      kind: "openai-compatible",
+      enabled: true,
+      source: "custom",
+      options: {
+        apiKey: "sk-custom-key-123",
+        baseURL: "http://127.0.0.1:18586/openai",
+      },
+      models: {
+        "nvidia/stepfun-ai/step-3.7-flash": { limit: { context: 200000 } },
+      },
+    },
+    "b5b27f58-custom-glm": {
+      name: "GLM-Code-Plan",
+      kind: "anthropic",
+      source: "custom",
+      options: { apiKey: "key-456", baseURL: "https://open.bigmodel.cn/api/anthropic" },
+      models: { "glm-4.7": { limit: { context: 200000 } } },
+    },
+  },
+};
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    readFileSync: (p: string) => {
+      if (p === ZCODE_CREDS_PATH) return JSON.stringify(FAKE_CONFIG);
+      return actual.readFileSync(p);
+    },
+  };
+});
+
+// Import AFTER vi.mock is set up.
+const { loadAllModels, modelContextWindow, parseModelValue, formatModelValue, buildRuntimeModel } =
+  await import("../src/config/options.js").then(async () => {
+    const opts = await import("../src/config/options.js");
+    const rm = await import("../src/config/runtime-model.js");
+    return { ...opts, buildRuntimeModel: rm.buildRuntimeModel };
+  });
+
+describe("loadAllModels", () => {
+  it("only collects models from enabled providers", () => {
+    const models = loadAllModels();
+    const ids = models.map((m) => m.modelId);
+    // Enabled builtin + enabled custom. The disabled ZAI and the custom-without-
+    // enabled (b5b27f58) must NOT appear.
+    expect(ids).toContain("GLM-5.2");
+    expect(ids).toContain("GLM-5-Turbo");
+    expect(ids).toContain("nvidia/stepfun-ai/step-3.7-flash");
+    // glm-4.7 is in a provider WITHOUT an enabled flag → excluded.
+    expect(ids).not.toContain("glm-4.7");
+  });
+
+  it("carries the provider name for display", () => {
+    const models = loadAllModels();
+    const nvidia = models.find((m) => m.modelId.includes("step-3.7-flash"));
+    expect(nvidia?.providerName).toBe("Nvidia");
+    expect(nvidia?.providerId).toBe("2e06bf1a-custom-nvidia");
+  });
+});
+
+describe("modelContextWindow", () => {
+  it("looks up context by provider+model (not hardcoded provider)", () => {
+    expect(modelContextWindow("builtin:bigmodel-coding-plan", "GLM-5.2")).toBe(1000000);
+    expect(modelContextWindow("2e06bf1a-custom-nvidia", "nvidia/stepfun-ai/step-3.7-flash")).toBe(
+      200000,
+    );
+  });
+
+  it("returns 0 for an unknown provider/model", () => {
+    expect(modelContextWindow("unknown", "nope")).toBe(0);
+  });
+});
+
+describe("parseModelValue / formatModelValue", () => {
+  it("round-trips providerId + modelId", () => {
+    const value = formatModelValue("2e06bf1a-custom-nvidia", "nvidia/stepfun-ai/step-3.7-flash");
+    expect(value).toBe("2e06bf1a-custom-nvidia\\nvidia/stepfun-ai/step-3.7-flash");
+    expect(parseModelValue(value)).toEqual({
+      providerId: "2e06bf1a-custom-nvidia",
+      modelId: "nvidia/stepfun-ai/step-3.7-flash",
+    });
+  });
+
+  it("legacy plain modelId (no backslash) resolves to first enabled provider", () => {
+    const parsed = parseModelValue("GLM-5.2");
+    // No backslash → treat as legacy modelId, providerId = first enabled.
+    expect(parsed.modelId).toBe("GLM-5.2");
+    expect(parsed.providerId).toBe("builtin:bigmodel-coding-plan");
+  });
+
+  it("splits on the FIRST backslash only (modelId may contain none)", () => {
+    const parsed = parseModelValue("pid\\GLM-5.2");
+    expect(parsed).toEqual({ providerId: "pid", modelId: "GLM-5.2" });
+  });
+});
+
+describe("buildRuntimeModel", () => {
+  it("carries apiKey for custom/apiKey providers", () => {
+    const rm = buildRuntimeModel({
+      providerId: "2e06bf1a-custom-nvidia",
+      providerName: "Nvidia",
+      modelId: "nvidia/stepfun-ai/step-3.7-flash",
+    }) as { provider: { apiKey?: string; baseURL?: string; kind?: string } };
+
+    expect(rm.provider.apiKey).toBe("sk-custom-key-123");
+    expect(rm.provider.baseURL).toBe("http://127.0.0.1:18586/openai");
+    expect(rm.provider.kind).toBe("openai-compatible");
+  });
+
+  it("omits apiKey for builtin OAuth providers (no apiKey in config)", () => {
+    const rm = buildRuntimeModel({
+      providerId: "builtin:bigmodel-coding-plan",
+      providerName: "BigModel",
+      modelId: "GLM-5.2",
+    }) as { provider: { apiKey?: string } };
+
+    expect(rm.provider.apiKey).toBeUndefined();
+  });
+
+  it("returns null for an unknown provider", () => {
+    expect(
+      buildRuntimeModel({ providerId: "nope", providerName: "nope", modelId: "x" }),
+    ).toBeNull();
+  });
+
+  it("includes all the provider's models in the overlay", () => {
+    const rm = buildRuntimeModel({
+      providerId: "builtin:bigmodel-coding-plan",
+      providerName: "BigModel",
+      modelId: "GLM-5.2",
+    }) as { provider: { models: Array<{ modelId: string }> } };
+
+    const modelIds = rm.provider.models.map((m) => m.modelId);
+    expect(modelIds).toEqual(["GLM-5.2", "GLM-5-Turbo"]);
+  });
+});

--- a/tests/runtime-model.test.ts
+++ b/tests/runtime-model.test.ts
@@ -4,8 +4,9 @@
  * History: loadProviderModels() hardcoded a single builtin provider id, so
  * custom providers configured in the ZCode desktop app never appeared in the
  * dropdown. These tests lock the new behaviour: loadAllModels() aggregates ALL
- * enabled providers, buildRuntimeModel() carries the apiKey for custom/apiKey
- * providers, and the encoded value format round-trips correctly.
+ * enabled providers, buildRuntimeModel() NEVER carries apiKey (the backend's
+ * runtimeModel schema rejects it), builtin models encode as bare modelIds, and
+ * third-party models carry their providerId prefix.
  */
 
 import { describe, expect, it, vi } from "vitest";
@@ -109,7 +110,17 @@ describe("modelContextWindow", () => {
 });
 
 describe("parseModelValue / formatModelValue", () => {
-  it("round-trips providerId + modelId", () => {
+  it("builtin providers encode as bare modelId (no prefix)", () => {
+    // The common case stays clean — builtin models show just the modelId.
+    const value = formatModelValue("builtin:bigmodel-coding-plan", "GLM-5.2");
+    expect(value).toBe("GLM-5.2");
+    expect(parseModelValue(value)).toEqual({
+      providerId: "builtin:bigmodel-coding-plan",
+      modelId: "GLM-5.2",
+    });
+  });
+
+  it("third-party providers round-trip providerId + modelId", () => {
     const value = formatModelValue("2e06bf1a-custom-nvidia", "nvidia/stepfun-ai/step-3.7-flash");
     expect(value).toBe("2e06bf1a-custom-nvidia\\nvidia/stepfun-ai/step-3.7-flash");
     expect(parseModelValue(value)).toEqual({
@@ -118,9 +129,8 @@ describe("parseModelValue / formatModelValue", () => {
     });
   });
 
-  it("legacy plain modelId (no backslash) resolves to first enabled provider", () => {
+  it("a plain modelId (no backslash) resolves to the first enabled builtin provider", () => {
     const parsed = parseModelValue("GLM-5.2");
-    // No backslash → treat as legacy modelId, providerId = first enabled.
     expect(parsed.modelId).toBe("GLM-5.2");
     expect(parsed.providerId).toBe("builtin:bigmodel-coding-plan");
   });
@@ -132,14 +142,17 @@ describe("parseModelValue / formatModelValue", () => {
 });
 
 describe("buildRuntimeModel", () => {
-  it("carries apiKey for custom/apiKey providers", () => {
+  it("NEVER carries apiKey — the backend schema rejects it and resolves auth itself", () => {
+    // Even for a custom provider WITH an apiKey in config (2e06bf1a-custom-nvidia),
+    // the overlay must omit it: the backend's runtimeModel schema types apiKey as
+    // a discriminated-union object, and a bare string → "Invalid params".
     const rm = buildRuntimeModel({
       providerId: "2e06bf1a-custom-nvidia",
       providerName: "Nvidia",
       modelId: "nvidia/stepfun-ai/step-3.7-flash",
     }) as { provider: { apiKey?: string; baseURL?: string; kind?: string } };
 
-    expect(rm.provider.apiKey).toBe("sk-custom-key-123");
+    expect(rm.provider.apiKey).toBeUndefined();
     expect(rm.provider.baseURL).toBe("http://127.0.0.1:18586/openai");
     expect(rm.provider.kind).toBe("openai-compatible");
   });

--- a/tests/runtime-model.test.ts
+++ b/tests/runtime-model.test.ts
@@ -16,42 +16,42 @@ import { ZCODE_CREDS_PATH } from "../src/utils.js";
 /** Fake config.json with one builtin (OAuth, no apiKey) + one custom (apiKey). */
 const FAKE_CONFIG = {
   provider: {
-    "builtin:bigmodel-coding-plan": {
-      name: "BigModel",
+    "builtin:primary": {
+      name: "Primary",
       kind: "anthropic",
       enabled: true,
-      options: { baseURL: "https://open.bigmodel.cn/api/anthropic" },
+      options: { baseURL: "https://example.test/api" },
       models: {
-        "GLM-5.2": { limit: { context: 1000000 } },
-        "GLM-5-Turbo": { limit: { context: 200000 } },
+        "model-a": { limit: { context: 1000000 } },
+        "model-b": { limit: { context: 200000 } },
       },
     },
-    "builtin:zai-coding-plan": {
-      name: "ZAI",
+    "builtin:secondary": {
+      name: "Secondary",
       kind: "anthropic",
       enabled: false,
-      options: { baseURL: "https://api.z.ai" },
-      models: { "GLM-5.2": { limit: { context: 1000000 } } },
+      options: { baseURL: "https://example.test/api2" },
+      models: { "model-a": { limit: { context: 1000000 } } },
     },
-    "2e06bf1a-custom-nvidia": {
-      name: "Nvidia",
+    "custom-provider-alpha": {
+      name: "Alpha",
       kind: "openai-compatible",
       enabled: true,
       source: "custom",
       options: {
-        apiKey: "sk-custom-key-123",
-        baseURL: "http://127.0.0.1:18586/openai",
+        apiKey: "test-key-alpha",
+        baseURL: "http://127.0.0.1:8000/v1",
       },
       models: {
-        "nvidia/stepfun-ai/step-3.7-flash": { limit: { context: 200000 } },
+        "alpha-1": { limit: { context: 200000 } },
       },
     },
-    "b5b27f58-custom-glm": {
-      name: "GLM-Code-Plan",
+    "custom-provider-beta": {
+      name: "Beta",
       kind: "anthropic",
       source: "custom",
-      options: { apiKey: "key-456", baseURL: "https://open.bigmodel.cn/api/anthropic" },
-      models: { "glm-4.7": { limit: { context: 200000 } } },
+      options: { apiKey: "test-key-beta", baseURL: "https://example.test/api" },
+      models: { "beta-1": { limit: { context: 200000 } } },
     },
   },
 };
@@ -79,29 +79,27 @@ describe("loadAllModels", () => {
   it("only collects models from enabled providers", () => {
     const models = loadAllModels();
     const ids = models.map((m) => m.modelId);
-    // Enabled builtin + enabled custom. The disabled ZAI and the custom-without-
-    // enabled (b5b27f58) must NOT appear.
-    expect(ids).toContain("GLM-5.2");
-    expect(ids).toContain("GLM-5-Turbo");
-    expect(ids).toContain("nvidia/stepfun-ai/step-3.7-flash");
-    // glm-4.7 is in a provider WITHOUT an enabled flag → excluded.
-    expect(ids).not.toContain("glm-4.7");
+    // Enabled builtin + enabled custom. The disabled Secondary and the
+    // custom-without-enabled (Beta) must NOT appear.
+    expect(ids).toContain("model-a");
+    expect(ids).toContain("model-b");
+    expect(ids).toContain("alpha-1");
+    // beta-1 is in a provider WITHOUT an enabled flag → excluded.
+    expect(ids).not.toContain("beta-1");
   });
 
   it("carries the provider name for display", () => {
     const models = loadAllModels();
-    const nvidia = models.find((m) => m.modelId.includes("step-3.7-flash"));
-    expect(nvidia?.providerName).toBe("Nvidia");
-    expect(nvidia?.providerId).toBe("2e06bf1a-custom-nvidia");
+    const alpha = models.find((m) => m.modelId === "alpha-1");
+    expect(alpha?.providerName).toBe("Alpha");
+    expect(alpha?.providerId).toBe("custom-provider-alpha");
   });
 });
 
 describe("modelContextWindow", () => {
   it("looks up context by provider+model (not hardcoded provider)", () => {
-    expect(modelContextWindow("builtin:bigmodel-coding-plan", "GLM-5.2")).toBe(1000000);
-    expect(modelContextWindow("2e06bf1a-custom-nvidia", "nvidia/stepfun-ai/step-3.7-flash")).toBe(
-      200000,
-    );
+    expect(modelContextWindow("builtin:primary", "model-a")).toBe(1000000);
+    expect(modelContextWindow("custom-provider-alpha", "alpha-1")).toBe(200000);
   });
 
   it("returns 0 for an unknown provider/model", () => {
@@ -112,56 +110,56 @@ describe("modelContextWindow", () => {
 describe("parseModelValue / formatModelValue", () => {
   it("builtin providers encode as bare modelId (no prefix)", () => {
     // The common case stays clean — builtin models show just the modelId.
-    const value = formatModelValue("builtin:bigmodel-coding-plan", "GLM-5.2");
-    expect(value).toBe("GLM-5.2");
+    const value = formatModelValue("builtin:primary", "model-a");
+    expect(value).toBe("model-a");
     expect(parseModelValue(value)).toEqual({
-      providerId: "builtin:bigmodel-coding-plan",
-      modelId: "GLM-5.2",
+      providerId: "builtin:primary",
+      modelId: "model-a",
     });
   });
 
   it("third-party providers round-trip providerId + modelId", () => {
-    const value = formatModelValue("2e06bf1a-custom-nvidia", "nvidia/stepfun-ai/step-3.7-flash");
-    expect(value).toBe("2e06bf1a-custom-nvidia\\nvidia/stepfun-ai/step-3.7-flash");
+    const value = formatModelValue("custom-provider-alpha", "alpha-1");
+    expect(value).toBe("custom-provider-alpha\\alpha-1");
     expect(parseModelValue(value)).toEqual({
-      providerId: "2e06bf1a-custom-nvidia",
-      modelId: "nvidia/stepfun-ai/step-3.7-flash",
+      providerId: "custom-provider-alpha",
+      modelId: "alpha-1",
     });
   });
 
   it("a plain modelId (no backslash) resolves to the first enabled builtin provider", () => {
-    const parsed = parseModelValue("GLM-5.2");
-    expect(parsed.modelId).toBe("GLM-5.2");
-    expect(parsed.providerId).toBe("builtin:bigmodel-coding-plan");
+    const parsed = parseModelValue("model-a");
+    expect(parsed.modelId).toBe("model-a");
+    expect(parsed.providerId).toBe("builtin:primary");
   });
 
   it("splits on the FIRST backslash only (modelId may contain none)", () => {
-    const parsed = parseModelValue("pid\\GLM-5.2");
-    expect(parsed).toEqual({ providerId: "pid", modelId: "GLM-5.2" });
+    const parsed = parseModelValue("pid\\model-a");
+    expect(parsed).toEqual({ providerId: "pid", modelId: "model-a" });
   });
 });
 
 describe("buildRuntimeModel", () => {
   it("NEVER carries apiKey — the backend schema rejects it and resolves auth itself", () => {
-    // Even for a custom provider WITH an apiKey in config (2e06bf1a-custom-nvidia),
+    // Even for a custom provider WITH an apiKey in config (custom-provider-alpha),
     // the overlay must omit it: the backend's runtimeModel schema types apiKey as
     // a discriminated-union object, and a bare string → "Invalid params".
     const rm = buildRuntimeModel({
-      providerId: "2e06bf1a-custom-nvidia",
-      providerName: "Nvidia",
-      modelId: "nvidia/stepfun-ai/step-3.7-flash",
+      providerId: "custom-provider-alpha",
+      providerName: "Alpha",
+      modelId: "alpha-1",
     }) as { provider: { apiKey?: string; baseURL?: string; kind?: string } };
 
     expect(rm.provider.apiKey).toBeUndefined();
-    expect(rm.provider.baseURL).toBe("http://127.0.0.1:18586/openai");
+    expect(rm.provider.baseURL).toBe("http://127.0.0.1:8000/v1");
     expect(rm.provider.kind).toBe("openai-compatible");
   });
 
   it("omits apiKey for builtin OAuth providers (no apiKey in config)", () => {
     const rm = buildRuntimeModel({
-      providerId: "builtin:bigmodel-coding-plan",
-      providerName: "BigModel",
-      modelId: "GLM-5.2",
+      providerId: "builtin:primary",
+      providerName: "Primary",
+      modelId: "model-a",
     }) as { provider: { apiKey?: string } };
 
     expect(rm.provider.apiKey).toBeUndefined();
@@ -175,12 +173,12 @@ describe("buildRuntimeModel", () => {
 
   it("includes all the provider's models in the overlay", () => {
     const rm = buildRuntimeModel({
-      providerId: "builtin:bigmodel-coding-plan",
-      providerName: "BigModel",
-      modelId: "GLM-5.2",
+      providerId: "builtin:primary",
+      providerName: "Primary",
+      modelId: "model-a",
     }) as { provider: { models: Array<{ modelId: string }> } };
 
     const modelIds = rm.provider.models.map((m) => m.modelId);
-    expect(modelIds).toEqual(["GLM-5.2", "GLM-5-Turbo"]);
+    expect(modelIds).toEqual(["model-a", "model-b"]);
   });
 });


### PR DESCRIPTION
## Summary

Adds multi-provider model support (custom third-party providers in the dropdown) and fixes model switching / resume regressions caused by backend version upgrades.

## Changes

### Multi-provider dropdown (678c6ab)
- `loadAllModels()` aggregates models from all enabled providers in config.json (not just the hardcoded builtin)
- Builtin models encode as the bare modelId; third-party models carry a `providerId\modelId` prefix

### Never send provider.apiKey in runtimeModel (5ef5648)
- The backend's runtimeModel schema (`.strict()`) types `provider.apiKey` as a discriminated-union object — a bare string is rejected with `Invalid params`
- `buildRuntimeModel` never carries apiKey; the backend resolves auth itself from config.json / its OAuth store

### Switch via session/setModel (46dbea9)
- `session/updateRuntimeModelConfig` silently fails (`changed:false`) on current backends
- Switched to `session/setModel` with `{model: {providerId, modelId}, runtimeModel, persistAsWorkspaceLastUsed:false}` — the runtimeModel registers the provider into the backend's workspace catalog
- Verified against the real backend: builtin (GLM-5.2 ↔ GLM-5-Turbo) and third-party (Nvidia) both switch correctly

### Refresh context bar after switch (3158556)
- The backend's `projection.contextWindow` lags behind a model switch
- `emitConfigOptionUpdate` now emits a `usage_update` with the new model's context window read from config.json