### PR TITLE
feat: revamp elicitation forms for free-text input

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -552,15 +552,33 @@ mechanisms based on client capabilities:
       "properties": {
         "q_0": {
           "type": "string",
-          "enum": ["auth.test.ts", "user.test.ts"],
-          "title": "Select the files to test"
+          "title": "Select the files to test",
+          "oneOf": [
+            { "const": "auth.test.ts", "title": "auth.test.ts" },
+            { "const": "user.test.ts", "title": "user.test.ts" },
+            { "const": "__skip__", "title": "Skip this question" }
+          ]
+        },
+        "q_0_other": {
+          "type": "string",
+          "title": "↳    or type a custom value (overrides the selection)"
         }
       },
-      "required": ["q_0"]
+      "required": []
     }
   }
 }
 ```
+
+ACP/MCP elicitation string fields are EITHER an enum (restricted dropdown) OR
+free text — the spec forbids a single field that is both. So each question is
+rendered as TWO fields: `q_<i>` (a `oneOf`/`anyOf` enum dropdown of the model's
+suggested answers, with a trailing "Skip this question" option whose `const` is
+the `__skip__` sentinel and whose `title` is the readable label) and
+`q_<i>_other` (a free-text companion). On submit, a non-empty `q_<i>_other`
+overrides the dropdown (single-select) or is appended to the picked values
+(multi-select); selecting "Skip this question" or leaving both blank skips just
+that question without cancelling the form.
 
 **elicitation response** (accept/decline/cancel):
 ```json

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -588,6 +588,34 @@ that question without cancelling the form.
 }
 ```
 
+**ExitPlanMode elicitation form** — single `feedback` text field; no
+approve/reject dropdown. The client's own submit button is the approve action;
+typing into the field is the reject action. Submitting with the field empty
+approves the plan; submitting with text rejects it and returns the text to
+zcode as the decline `reason` (so the agent sees the redirection when it
+re-plans). The cancel/decline button is a plain reject with no reason.
+```json
+{
+  "method": "elicitation/create",
+  "params": {
+    "mode": "form",
+    "sessionId": "sess_abc123",
+    "message": "Ready to code?\n\n1. Implement login\n2. Implement signup\n\nLeave the box empty and submit to approve; type feedback to reject and redirect.",
+    "requestedSchema": {
+      "type": "object",
+      "properties": {
+        "feedback": {
+          "type": "string",
+          "title": "Feedback",
+          "description": "Empty = approve the plan. Anything typed = reject and use this text as the redirection."
+        }
+      },
+      "required": []
+    }
+  }
+}
+```
+
 ## Extension Methods (0.14.8+)
 
 ### `session/fork`

--- a/src/interaction/adapter.ts
+++ b/src/interaction/adapter.ts
@@ -257,17 +257,29 @@ export function parseAskUserResponse(acpResp: unknown): string | null {
 // ---------- elicitation form (preferred when client supports it) ----------
 
 /**
+ * Sentinel `const` value marking a single-select question as skipped in the
+ * elicitation form. Paired with a human-readable `title` ("Skip this question")
+ * via `oneOf`, so the client renders the label — never the raw sentinel.
+ */
+const ELICIT_SKIP = "__skip__";
+
+/**
  * Build an elicitation form schema for an AskUserQuestion request.
  *
- * Each question becomes one property in the form:
- *   - Single-select → string enum of labels + a trailing "Skip" option
- *   - Multi-select  → string array enum of labels
+ * ACP/MCP elicitation string fields are EITHER an enum (restricted dropdown) OR
+ * free text — the spec ("enum strictly restricts the allowed string values")
+ * forbids "dropdown whose last row accepts custom input". To give the user both
+ * a pick list AND custom entry, each question is rendered as TWO fields:
  *
- * When the client supports form-based elicitation, this lets the user answer
- * all questions in one form rather than one popup per question. Single-select
- * fields include a "Skip" option so the user can opt out of a question without
- * cancelling the whole form (mirrors the request_permission fallback, which
- * appends a Skip option per question).
+ *   - `q_<i>`: enum dropdown of the model's suggested answers + a trailing
+ *     "Skip this question" option. Uses `oneOf`/`anyOf` with `{const, title}`
+ *     so the skip sentinel has a readable label instead of the raw `__skip__`.
+ *   - `q_<i>_other`: free-text string. If non-empty it OVERRIDES the dropdown
+ *     (single-select) or is APPENDED to the picked values (multi-select).
+ *
+ * A non-required free-text field plus a Skip enum option lets the user opt out
+ * of a single question without cancelling the whole form. Required is left
+ * empty so neither field forces an answer.
  */
 export function buildAskUserElicitationForm(
   params: ZcodeInteractionUserInputParams,
@@ -286,7 +298,6 @@ export function buildAskUserElicitationForm(
 } {
   const questions = params.questions?.length ? params.questions : (params.input?.questions ?? []);
   const properties: Record<string, unknown> = {};
-  const required: string[] = [];
   for (let i = 0; i < questions.length; i++) {
     const q = questions[i];
     if (!q || typeof q.question !== "string") continue;
@@ -295,22 +306,33 @@ export function buildAskUserElicitationForm(
       .map((o) => o.label ?? o.value ?? "")
       .filter((l) => l.length > 0);
     if (labels.length === 0) continue;
+    // Titled enum option for "skip": const carries the sentinel value the
+    // parser recognizes; title is what the client renders in the dropdown.
+    const skipOption = { const: ELICIT_SKIP, title: "Skip this question" };
     if (q.multiSelect) {
       properties[key] = {
         type: "array",
-        items: { type: "string", enum: labels },
         title: q.question,
+        items: { anyOf: labels.map((l) => ({ const: l, title: l })) },
       };
     } else {
-      // Append a Skip option so the user can opt out of this question without
-      // cancelling the whole form (parity with the request_permission path).
       properties[key] = {
         type: "string",
-        enum: [...labels, ELICIT_SKIP],
         title: q.question,
+        oneOf: [...labels.map((l) => ({ const: l, title: l })), skipOption],
       };
-      required.push(key);
     }
+    // Companion free-text field. Zed renders a string field's title
+    // prominently, and falls back to the description when title is absent — so
+    // a bright label here is unavoidable. Prefix with "↳" + padding so it reads
+    // as a continuation of the question above, and make the title self-contained
+    // (no description needed).
+    properties[`${key}_other`] = {
+      type: "string",
+      title: q.multiSelect
+        ? "↳    or add a custom value (combined with the selection)"
+        : "↳    or type a custom value (overrides the selection)",
+    };
   }
   // The question text already appears as each field's `title` (its label), so
   // the form `message` must NOT repeat it — otherwise Zed shows the question
@@ -335,21 +357,23 @@ export function buildAskUserElicitationForm(
     mode: "form",
     sessionId: acpSid,
     message,
-    requestedSchema: { type: "object", properties, required },
+    // No required fields: the user can skip any question (via Skip option or
+    // blank free-text) without being blocked by validation.
+    requestedSchema: { type: "object", properties, required: [] },
   };
   if (toolCallId) form.toolCallId = toolCallId;
   return form;
 }
 
-/** Sentinel enum value marking a single-select question as skipped in the form. */
-const ELICIT_SKIP = "__skip__";
-
 /**
  * Parse an elicitation form response into the zcode answers map.
  *
- * Maps each `q_<i>` form field back to the original question text. Multi-select
- * answers (arrays) are comma-joined to match the request_permission path's
- * `"a, b"` format. Returns null if the user declined/cancelled.
+ * For each question the free-text companion (`q_<i>_other`) takes precedence:
+ *   - Single-select: non-empty free-text OVERRIDES the dropdown. Otherwise the
+ *     dropdown value is used, unless it's the skip sentinel or absent (omitted).
+ *   - Multi-select: free-text is APPENDED to the picked values (de-duped, order
+ *     preserved). The skip sentinel never appears in multi-select.
+ * Returns null if the user declined/cancelled.
  */
 export function parseAskUserElicitationResponse(
   acpResp: unknown,
@@ -364,15 +388,29 @@ export function parseAskUserElicitationResponse(
     const q = questions[i];
     if (!q || typeof q.question !== "string") continue;
     const key = `q_${i}`;
-    const val = resp.content[key];
-    if (val == null) continue;
-    if (Array.isArray(val)) {
-      answers[q.question] = val.filter((v) => typeof v === "string").join(", ");
-    } else if (typeof val === "string" && val !== ELICIT_SKIP) {
-      // Skip the sentinel "__skip__" so a skipped single-select question is
-      // simply omitted from the answers map (parity with the request_permission
-      // path, which leaves the question unanswered on Skip).
-      answers[q.question] = val;
+    const otherKey = `${key}_other`;
+    const picked = resp.content[key];
+    const otherRaw = resp.content[otherKey];
+    const other = typeof otherRaw === "string" ? otherRaw.trim() : "";
+
+    if (q.multiSelect) {
+      const arr = Array.isArray(picked)
+        ? picked.filter((v): v is string => typeof v === "string" && v.length > 0)
+        : [];
+      // Merge selected values + custom free-text, preserving order and dropping dups.
+      const merged: string[] = [];
+      for (const v of [...arr, ...(other ? [other] : [])]) {
+        if (!merged.includes(v)) merged.push(v);
+      }
+      if (merged.length > 0) answers[q.question] = merged.join(", ");
+    } else {
+      // Free-text override wins when present; else use the dropdown value
+      // (skip sentinel / absent → question left unanswered).
+      if (other) {
+        answers[q.question] = other;
+      } else if (typeof picked === "string" && picked.length > 0 && picked !== ELICIT_SKIP) {
+        answers[q.question] = picked;
+      }
     }
   }
   return answers;

--- a/src/interaction/adapter.ts
+++ b/src/interaction/adapter.ts
@@ -417,10 +417,17 @@ export function parseAskUserElicitationResponse(
 }
 
 /**
- * Build an elicitation form for ExitPlanMode (approve/reject).
+ * Build an elicitation form for ExitPlanMode.
  *
- * Uses a single required boolean-style enum so the client renders a clear
- * approve/reject choice in the form UI.
+ * Single `feedback` text field — no approve/reject dropdown. The ACP client
+ * always renders its own submit/cancel controls, so:
+ *   - submit with feedback empty   → approve (proceed with the plan)
+ *   - submit with feedback filled  → reject, and the text becomes the decline
+ *                                    `reason` the agent sees when re-planning
+ *   - cancel/decline button        → plain reject (no reason)
+ *
+ * Typing into the field IS the reject signal — a separate dropdown would be
+ * redundant (its value is forced by whether feedback is present).
  */
 export function buildExitPlanModeElicitationForm(
   params: ZcodeInteractionUserInputParams,
@@ -441,7 +448,10 @@ export function buildExitPlanModeElicitationForm(
     params.input && typeof params.input === "object"
       ? ((params.input as { plan?: string }).plan ?? "")
       : "";
-  const message = planText ? `Ready to code?\n\n${planText}` : "Ready to code?";
+  const suffix = "Leave the box empty and submit to approve; type feedback to reject and redirect.";
+  const message = planText
+    ? `Ready to code?\n\n${planText}\n\n${suffix}`
+    : `Ready to code?\n\n${suffix}`;
   const form: {
     mode: "form";
     sessionId: string;
@@ -459,34 +469,44 @@ export function buildExitPlanModeElicitationForm(
     requestedSchema: {
       type: "object",
       properties: {
-        decision: {
+        feedback: {
           type: "string",
-          enum: ["approve", "reject"],
-          title: "Decision",
-          description: "Approve to exit plan mode and start coding, or reject to keep planning.",
+          title: "Feedback",
+          description:
+            "Empty = approve the plan. Anything typed = reject and use this text as the redirection.",
         },
       },
-      required: ["decision"],
+      // Not required: an empty submit is a valid "approve".
+      required: [],
     },
   };
   if (toolCallId) form.toolCallId = toolCallId;
   return form;
 }
 
-/** Parse an ExitPlanMode elicitation response → zcode accept/decline. */
+/**
+ * Parse an ExitPlanMode elicitation response → zcode accept/decline.
+ *
+ * Accept with non-empty feedback → decline carrying the feedback as `reason`
+ * (the user typed a redirection). Accept with empty feedback → approve.
+ * Decline/cancel from the client → plain decline.
+ */
 export function parseExitPlanModeElicitationResponse(acpResp: unknown): {
   action: "accept" | "decline";
   reason?: string;
+  content?: unknown;
 } {
   if (!acpResp || typeof acpResp !== "object") {
     return { action: "decline", reason: "invalid client response" };
   }
-  const resp = acpResp as { action?: string; content?: { decision?: string } | null };
-  if (resp.action !== "accept" || !resp.content) {
+  const resp = acpResp as { action?: string; content?: { feedback?: string } | null };
+  if (resp.action !== "accept") {
     return { action: "decline", reason: "cancelled" };
   }
-  if (resp.content.decision === "approve") {
-    return { action: "accept", content: { answer_0: "approve" } } as never;
+  const feedback = typeof resp.content?.feedback === "string" ? resp.content.feedback.trim() : "";
+  if (feedback) {
+    return { action: "decline", reason: feedback };
   }
-  return { action: "decline", reason: "rejected" };
+  // content must be an object with answer_0 (zcode reads content.answer_0).
+  return { action: "accept", content: { answer_0: "approve" } };
 }

--- a/tests/interaction.test.ts
+++ b/tests/interaction.test.ts
@@ -286,14 +286,34 @@ describe("elicitation form: AskUserQuestion", () => {
     ],
   };
 
-  it("single-select enum includes a trailing Skip option", () => {
+  it("single-select: enum dropdown + companion free-text field", () => {
     const form = buildAskUserElicitationForm(baseParams, "acp_1");
-    const prop = form.requestedSchema.properties.q_0 as { enum: string[] };
-    expect(prop.enum).toEqual(["Red", "Blue", "__skip__"]);
-    expect(form.requestedSchema.required).toEqual(["q_0"]);
+    const prop = form.requestedSchema.properties.q_0 as {
+      type: string;
+      oneOf?: Array<{ const: string; title: string }>;
+    };
+    expect(prop.type).toBe("string");
+    expect(prop.oneOf).toEqual([
+      { const: "Red", title: "Red" },
+      { const: "Blue", title: "Blue" },
+      { const: "__skip__", title: "Skip this question" },
+    ]);
+    // Companion free-text override field — "↳" + padding marks it as a
+    // continuation of the question above; self-contained title, no description.
+    const other = form.requestedSchema.properties.q_0_other as {
+      type: string;
+      title: string;
+      description?: string;
+    };
+    expect(other.type).toBe("string");
+    expect(other.title).toMatch(/^↳\s+/);
+    expect(other.title).toContain("custom value");
+    expect(other.title).toContain("overrides");
+    expect(other.description).toBeUndefined();
+    expect(form.requestedSchema.required).toEqual([]);
   });
 
-  it("multi-select fields are arrays and not required", () => {
+  it("multi-select: array enum (anyOf titled) + companion free-text field", () => {
     const params = {
       ...baseParams,
       questions: [
@@ -310,12 +330,15 @@ describe("elicitation form: AskUserQuestion", () => {
     const form = buildAskUserElicitationForm(params, "acp_1");
     const prop = form.requestedSchema.properties.q_0 as {
       type: string;
-      items: { type: string; enum: string[] };
+      items: { anyOf: Array<{ const: string; title: string }> };
     };
     expect(prop.type).toBe("array");
-    expect(prop.items.type).toBe("string");
-    expect(prop.items.enum).toEqual(["a.ts", "b.ts"]);
-    expect(form.requestedSchema.required).not.toContain("q_0");
+    expect(prop.items.anyOf).toEqual([
+      { const: "a.ts", title: "a.ts" },
+      { const: "b.ts", title: "b.ts" },
+    ]);
+    expect(form.requestedSchema.properties.q_0_other).toBeDefined();
+    expect(form.requestedSchema.required).toEqual([]);
   });
 
   it("attaches toolCallId scope when provided", () => {
@@ -329,7 +352,7 @@ describe("elicitation form: AskUserQuestion", () => {
     expect(form.toolCallId).toBeUndefined();
   });
 
-  it("parse maps answers back by question text", () => {
+  it("parse: dropdown selection maps back by question text", () => {
     const answers = parseAskUserElicitationResponse(
       { action: "accept", content: { q_0: "Red" } },
       baseParams,
@@ -337,7 +360,31 @@ describe("elicitation form: AskUserQuestion", () => {
     expect(answers).toEqual({ "Pick a color": "Red" });
   });
 
-  it("parse multi-select joins with ', '", () => {
+  it("parse: free-text override wins over dropdown (single-select)", () => {
+    const answers = parseAskUserElicitationResponse(
+      { action: "accept", content: { q_0: "Red", q_0_other: "magenta" } },
+      baseParams,
+    );
+    expect(answers).toEqual({ "Pick a color": "magenta" });
+  });
+
+  it("parse: skip sentinel omitted (single-select)", () => {
+    const answers = parseAskUserElicitationResponse(
+      { action: "accept", content: { q_0: "__skip__" } },
+      baseParams,
+    );
+    expect(answers).toEqual({});
+  });
+
+  it("parse: empty dropdown + empty free-text = skipped (single-select)", () => {
+    const answers = parseAskUserElicitationResponse(
+      { action: "accept", content: { q_0: "", q_0_other: "   " } },
+      baseParams,
+    );
+    expect(answers).toEqual({});
+  });
+
+  it("parse: multi-select merges dropdown picks + free-text (deduped)", () => {
     const params = {
       ...baseParams,
       questions: [
@@ -352,19 +399,63 @@ describe("elicitation form: AskUserQuestion", () => {
       ],
     };
     const answers = parseAskUserElicitationResponse(
-      { action: "accept", content: { q_0: ["a.ts", "b.ts"] } },
+      { action: "accept", content: { q_0: ["a.ts", "b.ts"], q_0_other: "c.ts" } },
       params,
     );
-    expect(answers).toEqual({ "Pick files": "a.ts, b.ts" });
+    expect(answers).toEqual({ "Pick files": "a.ts, b.ts, c.ts" });
   });
 
-  it("parse skips the __skip__ sentinel (single-select)", () => {
+  it("parse: multi-select dedupes when free-text repeats a pick", () => {
+    const params = {
+      ...baseParams,
+      questions: [
+        {
+          question: "Pick files",
+          multiSelect: true,
+          options: [{ label: "a.ts", value: "a" }],
+        },
+      ],
+    };
     const answers = parseAskUserElicitationResponse(
-      { action: "accept", content: { q_0: "__skip__" } },
-      baseParams,
+      { action: "accept", content: { q_0: ["a.ts"], q_0_other: "a.ts" } },
+      params,
     );
-    // Skipped question is omitted from the answers map (parity with
-    // request_permission path leaving it unanswered on Skip).
+    expect(answers).toEqual({ "Pick files": "a.ts" });
+  });
+
+  it("parse: multi-select with only free-text", () => {
+    const params = {
+      ...baseParams,
+      questions: [
+        {
+          question: "Pick files",
+          multiSelect: true,
+          options: [{ label: "a.ts", value: "a" }],
+        },
+      ],
+    };
+    const answers = parseAskUserElicitationResponse(
+      { action: "accept", content: { q_0: [], q_0_other: "custom.ts" } },
+      params,
+    );
+    expect(answers).toEqual({ "Pick files": "custom.ts" });
+  });
+
+  it("parse: empty multi-select + empty free-text = skipped", () => {
+    const params = {
+      ...baseParams,
+      questions: [
+        {
+          question: "Pick files",
+          multiSelect: true,
+          options: [{ label: "a.ts", value: "a" }],
+        },
+      ],
+    };
+    const answers = parseAskUserElicitationResponse(
+      { action: "accept", content: { q_0: [], q_0_other: "" } },
+      params,
+    );
     expect(answers).toEqual({});
   });
 

--- a/tests/interaction.test.ts
+++ b/tests/interaction.test.ts
@@ -474,10 +474,11 @@ describe("elicitation form: ExitPlanMode", () => {
     input: { plan: "Step 1\nStep 2" },
   };
 
-  it("embeds the plan text in the message", () => {
+  it("embeds the plan text + approve/reject hint in the message", () => {
     const form = buildExitPlanModeElicitationForm(epmParams, "acp_1");
     expect(form.message).toContain("Step 1");
     expect(form.message).toContain("Ready to code?");
+    expect(form.message).toContain("Leave the box empty and submit to approve");
   });
 
   it("attaches toolCallId scope when provided", () => {
@@ -485,20 +486,40 @@ describe("elicitation form: ExitPlanMode", () => {
     expect(form.toolCallId).toBe("tc_2");
   });
 
-  it("approve → accept with answer_0", () => {
+  it("has only a feedback field, not required (empty submit = approve)", () => {
+    const form = buildExitPlanModeElicitationForm(epmParams, "acp_1");
+    const keys = Object.keys(form.requestedSchema.properties);
+    expect(keys).toEqual(["feedback"]);
+    expect(form.requestedSchema.required).toEqual([]);
+  });
+
+  it("accept with empty feedback → approve", () => {
     const resp = parseExitPlanModeElicitationResponse({
       action: "accept",
-      content: { decision: "approve" },
+      content: { feedback: "" },
     });
     expect(resp).toEqual({ action: "accept", content: { answer_0: "approve" } });
   });
 
-  it("reject → decline", () => {
+  it("accept with whitespace-only feedback → approve (trimmed to empty)", () => {
     const resp = parseExitPlanModeElicitationResponse({
       action: "accept",
-      content: { decision: "reject" },
+      content: { feedback: "   " },
     });
-    expect(resp.action).toBe("decline");
+    expect(resp).toEqual({ action: "accept", content: { answer_0: "approve" } });
+  });
+
+  it("accept with feedback → decline carrying the feedback as reason", () => {
+    const resp = parseExitPlanModeElicitationResponse({
+      action: "accept",
+      content: { feedback: "  do login first  " },
+    });
+    expect(resp).toEqual({ action: "decline", reason: "do login first" });
+  });
+
+  it("accept with missing content → approve (treated as empty)", () => {
+    const resp = parseExitPlanModeElicitationResponse({ action: "accept", content: null });
+    expect(resp).toEqual({ action: "accept", content: { answer_0: "approve" } });
   });
 
   it("cancel → decline", () => {


### PR DESCRIPTION
## Summary

Reworks the elicitation form rendering so users can enter custom free-text
answers alongside the model-suggested dropdown, instead of being restricted
to enum-only options.

## Problem

ACP/MCP elicitation string fields are EITHER an enum (restricted dropdown) OR
free text — the spec forbids a single field that is both. The previous
rendering used a plain `enum` for each question, so users could only pick
from the model's suggestions with no way to type their own answer.

## Changes

### AskUserQuestion — dual-field rendering

Each question becomes two fields:
- `q_<i>`: enum dropdown (now `oneOf`/`anyOf` with {const, title}) + a
  trailing "Skip this question" option (sentinel `__skip__`).
- `q_<i>_other`: free-text companion. Non-empty value overrides the dropdown
  (single-select) or is appended to the picks (multi-select, deduped).

No field is required; blank = skip just that question.

### ExitPlanMode — single feedback field

Replaced approve/reject enum with one `feedback` text field:
- submit empty → approve
- submit with text → reject, text becomes the decline reason
- cancel button → plain reject

### Docs & tests

- docs/PROTOCOL.md updated with the new form shapes.
- tests/interaction.test.ts expanded (free-text override,