### PR TITLE
fix: forward ACP session mcpServers to the backend's session create/resume

### DIFF
--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -158,9 +158,9 @@ export async function ensureRealSession(server: ZcodeAcpServer, acpSid: string):
     const backend = server.ensureBackend();
     // Client-provided MCP servers (ACP session/new mcpServers) ride along
     // when the lazy session materializes. The backend accepts the ACP array
-    // shape verbatim and merges the servers alongside its own local config
-    // (client entries winning on name clash is the backend's rule; entries
-    // here are only ever additive from this side).
+    // shape verbatim; the verified merge behaviour is additive (client
+    // entries appear next to the runtime's own local config). Same-name
+    // clash behaviour is the backend's own and unasserted here.
     const createParams: Record<string, unknown> = {
       workspace: workspaceFor(pending.cwd),
       mode: "yolo",

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -102,7 +102,7 @@ export async function newSession(
   // Placeholder id — the client addresses this session with it until the
   // backend session materializes; never shown in session/list.
   const acpSid = randomUUID();
-  server.pendingSessions.set(acpSid, { cwd });
+  server.pendingSessions.set(acpSid, { cwd, mcpServers: params.mcpServers });
   // Durable alias so the placeholder survives a bridge restart and session/
   // resume can still resolve it (best-effort; failures are swallowed inside
   // the store).
@@ -156,10 +156,23 @@ export async function ensureRealSession(server: ZcodeAcpServer, acpSid: string):
   // promise is stored before any concurrent caller can observe the entry.
   const creating = (async () => {
     const backend = server.ensureBackend();
+    // Client-provided MCP servers (ACP session/new mcpServers) ride along
+    // when the lazy session materializes. The backend accepts the ACP array
+    // shape verbatim and merges the servers alongside its own local config
+    // (client entries winning on name clash is the backend's rule; entries
+    // here are only ever additive from this side).
+    const createParams: Record<string, unknown> = {
+      workspace: workspaceFor(pending.cwd),
+      mode: "yolo",
+    };
+    if (pending.mcpServers && pending.mcpServers.length > 0) {
+      createParams.mcpServers = pending.mcpServers;
+      log(`session/create carrying ${pending.mcpServers.length} client MCP server(s)`);
+    }
     const resp = await backend.request(
       server.nextId(),
       "session/create",
-      { workspace: workspaceFor(pending.cwd), mode: "yolo" },
+      createParams,
       15000,
     );
     if (resp.error) {
@@ -292,6 +305,12 @@ export async function resumeSession(
       sessionId: zcodeSid,
       workspace: workspaceFor(cwd),
     };
+    // ACP session/resume may also carry mcpServers; the backend's resume
+    // schema accepts the same array shape (verified: an unknown key would be
+    // rejected before the session lookup).
+    if (params.mcpServers && params.mcpServers.length > 0) {
+      zcParams.mcpServers = params.mcpServers;
+    }
     const runtimeModel = buildResumeRuntimeModel();
     if (runtimeModel !== null) zcParams.runtimeModel = runtimeModel;
     // Push the provider registry BEFORE resume: a resumed session may carry a

--- a/src/server.ts
+++ b/src/server.ts
@@ -67,7 +67,16 @@ export class ZcodeAcpServer {
    * create is running, so concurrent first-uses (e.g. a raced double prompt)
    * share one `session/create` instead of creating two backend sessions.
    */
-  readonly pendingSessions = new Map<string, { cwd: string; creating?: Promise<string> }>();
+  readonly pendingSessions = new Map<string, {
+    cwd: string;
+    creating?: Promise<string>;
+    /** Client-provided MCP servers from session/new, replayed verbatim into
+     * the backend's session/create when the lazy session materializes. The
+     * backend's mcpServers schema matches the ACP array shape (stdio entries
+     * carry command/args/env; remote entries carry type/url), so entries are
+     * passed through unchanged. */
+    mcpServers?: unknown[];
+  }>();
   /** Currently running turns, keyed by the ACP request id. */
   readonly pendingTurns = new Map<number, PendingTurn>();
   /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -75,7 +75,7 @@ export class ZcodeAcpServer {
      * backend's mcpServers schema matches the ACP array shape (stdio entries
      * carry command/args/env; remote entries carry type/url), so entries are
      * passed through unchanged. */
-    mcpServers?: unknown[];
+    mcpServers?: acp.McpServer[];
   }>();
   /** Currently running turns, keyed by the ACP request id. */
   readonly pendingTurns = new Map<number, PendingTurn>();

--- a/tests/session-lazy.test.ts
+++ b/tests/session-lazy.test.ts
@@ -225,6 +225,59 @@ describe("resumeSession with lazy placeholders", () => {
     expect(out.modes.currentModeId).toBe("yolo");
   });
 
+  it("replays client-provided mcpServers into the backend session/create", async () => {
+    // Regression: session/new accepted an mcpServers parameter but never read
+    // it, so client-configured stdio servers were silently dropped. The lazy
+    // placeholder must carry them into session/create verbatim.
+    const server = new ZcodeAcpServer();
+    const mcpServers = [
+      { name: "echo", command: "node", args: ["/tmp/mcp-echo.mjs"], env: [] },
+    ];
+    const resp = await newSession(
+      server,
+      { cwd: "/tmp/ws", mcpServers } as acp.NewSessionRequest,
+    );
+    expect(server.pendingSessions.get(resp.sessionId)).toMatchObject({ mcpServers });
+
+    const { backend, calls } = fakeBackend();
+    server.backend = backend;
+    await ensureRealSession(server, resp.sessionId);
+
+    const creates = calls.filter((c) => c.method === "session/create");
+    expect(creates).toHaveLength(1);
+    expect(creates[0].params).toMatchObject({ mode: "yolo", mcpServers });
+  });
+
+  it("omits mcpServers from session/create when the client provided none", async () => {
+    const server = new ZcodeAcpServer();
+    const resp = await newSession(server, newSessionParams("/tmp/ws"));
+    const { backend, calls } = fakeBackend();
+    server.backend = backend;
+    await ensureRealSession(server, resp.sessionId);
+
+    const creates = calls.filter((c) => c.method === "session/create");
+    expect(creates[0].params).not.toHaveProperty("mcpServers");
+  });
+
+  it("forwards resume-provided mcpServers to the backend session/resume", async () => {
+    // Regression companion: ACP session/resume also carries mcpServers; the
+    // backend re-connects them as part of the resume.
+    const server = new ZcodeAcpServer();
+    const { backend, calls } = fakeBackend();
+    server.backend = backend;
+    const mcpServers = [{ name: "echo", command: "node", args: [], env: [] }];
+
+    await resumeSession(
+      server,
+      { sessionId: "sess_real_1", cwd: "/tmp/ws", mcpServers } as acp.ResumeSessionRequest,
+      {} as acp.AgentContext,
+    );
+
+    const resumes = calls.filter((c) => c.method === "session/resume");
+    expect(resumes).toHaveLength(1);
+    expect(resumes[0].params).toMatchObject({ sessionId: "sess_real_1", mcpServers });
+  });
+
   it("resumes an already-materialized placeholder without backend resume", async () => {
     const server = new ZcodeAcpServer();
     const resp = await newSession(server, newSessionParams("/tmp/ws"));


### PR DESCRIPTION
Closes #42 (option 1 from there).

## What

`session/new` and `session/resume` accepted an `mcpServers` parameter but never read it, so client-provided stdio servers were silently dropped — a session only ever saw the local `~/.zcode`-configured servers.

This PR:

- stores `params.mcpServers` on the lazy pending session in `session/new` and replays it into `session/create` when the session materializes,
- forwards `params.mcpServers` on `session/resume`.

Entries are passed through **verbatim**: the backend's schema accepts the ACP mcpServers array shape as-is (stdio entries carry `command`/`args`/`env` as `[{name,value}]` pairs; remote entries carry `type`/`url`). One subtlety found while probing: the stdio union branch **rejects a `type` key**, so no field renaming or `type: "stdio"` injection is done anywhere.

The `session/resume` schema was verified to accept the key (an unknown key is rejected by zod before the session lookup, and `mcpServers` is not).

## Verification

- `vitest run`: 461/461 green.
- End-to-end through **Multica** (daemon → bridge → ZCode CLI 0.16.3, real GLM turn): an agent configured with a trivial stdio echo server (`node mcp-echo.mjs`, one `mcp_echo` tool) now reports:
  - the injected tool working: `mcp_echo` called with `message=fixed-via-forwarding` returned `MCP-ECHO-SAID: fixed-via-forwarding`;
  - the merge is **additive**: the session lists `echo` alongside the runtime's own local servers (`4_5v_mcp`, `node_repl`, `web_reader`, …) — local config untouched.

Context: this unblocks Multica-side agent MCP configuration for the ZCode runtime family (the integration I mentioned in #41/#42).