### PR TITLE
Keep command metadata current across ZCode model releases

### DIFF
--- a/src/config/options.ts
+++ b/src/config/options.ts
@@ -189,8 +189,10 @@ export async function buildConfigOptions(
   server: ZcodeAcpServer,
   zcodeSid: string | null,
 ): Promise<acp.SessionConfigOption[]> {
-  let currentProviderId = "";
-  let currentModelId = "GLM-5.2";
+  const configuredModels = loadAllModels();
+  const defaultModel = configuredModels[0];
+  let currentProviderId = defaultModel?.providerId ?? "";
+  let currentModelId = defaultModel?.modelId ?? "GLM-5.2";
   let currentMode = zcodeSid === null ? "yolo" : "build";
   let currentThought = "high";
   let thoughtOptions: Array<{ value: string; name: string }> | null = null;
@@ -222,14 +224,14 @@ export async function buildConfigOptions(
   // right provider (and its apiKey). Fall back to the first enabled provider
   // when settings omits providerId (legacy sessions).
   const currentModel = formatModelValue(
-    currentProviderId || loadAllModels()[0]?.providerId || "builtin:bigmodel-coding-plan",
+    currentProviderId || defaultModel?.providerId || "builtin:bigmodel-coding-plan",
     currentModelId,
   );
 
   // Model options: config.json enabled providers are authoritative. Builtin
   // models show as the bare modelId (clean dropdown for the common case);
   // third-party models prefix the provider name so they're distinguishable.
-  let modelOptions = loadAllModels().map((m) => ({
+  let modelOptions = configuredModels.map((m) => ({
     value: formatModelValue(m.providerId, m.modelId),
     name: isBuiltinProvider(m.providerId) ? m.modelId : `${m.providerName} › ${m.modelId}`,
   }));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -60,12 +60,12 @@ export const SLASH_COMMANDS = [
   {
     name: "model",
     description: "Switch the session model",
-    input: { hint: "GLM-5.2|GLM-5-Turbo" },
+    input: { hint: "model id" },
   },
   {
     name: "thought",
     description: "Set the reasoning effort",
-    input: { hint: "max|high|nothink" },
+    input: { hint: "reasoning effort" },
   },
   { name: "quota", description: "Show remaining usage quota (5h / weekly / MCP)" },
   { name: "mcp", description: "List available MCP servers" },

--- a/tests/bugfixes.test.ts
+++ b/tests/bugfixes.test.ts
@@ -14,7 +14,7 @@ import { EventStreamListener } from "../src/backend/listener.js";
 import { ZcodeBackend } from "../src/backend/client.js";
 import { ProjectionDiffer } from "../src/translators/projection-differ.js";
 import { flattenTodos } from "../src/handlers/session.js";
-import { CONFIG_META } from "../src/utils.js";
+import { CONFIG_META, SLASH_COMMANDS } from "../src/utils.js";
 import type { ZcodeEvent, ZcodeResponse } from "../src/backend/types.js";
 
 /** Build a listener over a fake backend (no subprocess; we drive handleEvent). */
@@ -243,6 +243,16 @@ describe("Bug 3: thought configOption metadata matches Python", () => {
   it("uses lowercase mode option names", () => {
     const names = CONFIG_META.mode.options.map((o) => o.name);
     expect(names).toEqual(["plan", "build", "edit", "yolo", "auto"]);
+  });
+});
+
+describe("slash command argument hints survive ZCode catalog updates", () => {
+  it("does not hardcode model ids or reasoning variants", () => {
+    const modelCommand = SLASH_COMMANDS.find((command) => command.name === "model");
+    const thoughtCommand = SLASH_COMMANDS.find((command) => command.name === "thought");
+
+    expect(modelCommand?.input?.hint).toBe("model id");
+    expect(thoughtCommand?.input?.hint).toBe("reasoning effort");
   });
 });
 

--- a/tests/runtime-model.test.ts
+++ b/tests/runtime-model.test.ts
@@ -80,12 +80,18 @@ vi.mock("node:fs", async () => {
 });
 
 // Import AFTER vi.mock is set up.
-const { loadAllModels, modelContextWindow, parseModelValue, formatModelValue, buildRuntimeModel } =
-  await import("../src/config/options.js").then(async () => {
-    const opts = await import("../src/config/options.js");
-    const rm = await import("../src/config/runtime-model.js");
-    return { ...opts, buildRuntimeModel: rm.buildRuntimeModel };
-  });
+const {
+  buildConfigOptions,
+  loadAllModels,
+  modelContextWindow,
+  parseModelValue,
+  formatModelValue,
+  buildRuntimeModel,
+} = await import("../src/config/options.js").then(async () => {
+  const opts = await import("../src/config/options.js");
+  const rm = await import("../src/config/runtime-model.js");
+  return { ...opts, buildRuntimeModel: rm.buildRuntimeModel };
+});
 
 describe("loadAllModels", () => {
   it("collects enabled builtins + active custom providers", () => {
@@ -116,6 +122,16 @@ describe("loadAllModels", () => {
     const alpha = models.find((m) => m.modelId === "alpha-1");
     expect(alpha?.providerName).toBe("Alpha");
     expect(alpha?.providerId).toBe("custom-provider-alpha");
+  });
+});
+
+describe("pending session config", () => {
+  it("uses the first configured model instead of a version-pinned fallback", async () => {
+    const options = await buildConfigOptions({} as Parameters<typeof buildConfigOptions>[0], null);
+
+    expect(options.find((option) => option.id === "model")).toMatchObject({
+      currentValue: "model-a",
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- derive a pending ACP session's current model from the first enabled ZCode config entry
- replace release-specific `/model` and `/thought` hints with stable argument descriptions
- add regressions covering dynamic pending-session selection and durable command metadata

## Problem

The bridge still selected `GLM-5.2` for pending sessions and advertised `GLM-5.2|GLM-5-Turbo` in `/model` metadata. ZCode 0.16.1 now puts GLM-5.3 first, so the ACP surface drifted as soon as the model catalog changed.

## Verification

- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm test` (463 tests)
- source-built package installed and exercised through an isolated Paseo daemon: GLM-5.3 returned 78 core, skill, and plugin commands
