### PR TITLE
fix: route the spec-spelled session/set_mode request

### DIFF
--- a/src/handlers/extensions.ts
+++ b/src/handlers/extensions.ts
@@ -270,7 +270,11 @@ export async function setMode(
 ): Promise<Result> {
   const acpSid = params.sessionId;
   const zcodeSid = await resolveSidOrThrow(server, params);
-  const mode = params.mode;
+  // Two spellings reach this handler: the bridge's camelCase extension
+  // (`session/setMode` with `mode`) and the spec's `session/set_mode` with
+  // `modeId`. Clients like Paseo only send the spec spelling and failed with
+  // -32601 when it wasn't routed, so both normalize here.
+  const mode = params.mode ?? params.modeId;
   if (!mode) throw new Error("setMode requires mode");
   const resp = await server
     .ensureBackend()

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,6 +145,11 @@ async function main(): Promise<void> {
     )
     .onRequest("session/setModel", extParams, (ctx) => setModel(server, ctx.params))
     .onRequest("session/setMode", extParams, (ctx) => setMode(server, ctx.params, ctx.client))
+    // Spec spelling of the same call (ACP session-modes uses snake_case with
+    // `modeId`); the handler normalizes the param. Without this route, spec-only
+    // clients (e.g. Paseo) get -32601 and cannot create agents in a non-default
+    // mode.
+    .onRequest("session/set_mode", extParams, (ctx) => setMode(server, ctx.params, ctx.client))
     .onNotification("session/cancel", (ctx) => cancel(server, ctx.params))
     .connect(stream);
 

--- a/tests/set-mode-alias.test.ts
+++ b/tests/set-mode-alias.test.ts
@@ -1,0 +1,125 @@
+/**
+ * session/set_mode (spec spelling) regression tests.
+ *
+ * The session-modes spec spells the request `session/set_mode` with a
+ * `modeId` param; the bridge historically exposed only a camelCase extension
+ * `session/setMode` with `mode`. Paseo sends the spec spelling and agent
+ * creation in any non-default mode failed with -32601 before the alias
+ * existed. These tests lock both spellings onto the same backend call.
+ */
+
+import type * as acp from "@agentclientprotocol/sdk";
+import { describe, expect, it, vi } from "vitest";
+
+import { ZCODE_CREDS_PATH } from "../src/utils.js";
+import { setMode } from "../src/handlers/extensions.js";
+import { ZcodeAcpServer } from "../src/server.js";
+
+// Minimal fake config so buildConfigOptions' loadAllModels() never touches
+// the real ~/.zcode/v2/config.json (keeps the test deterministic).
+const FAKE_CONFIG = {
+  provider: {
+    "builtin:bigmodel-coding-plan": {
+      name: "GLM Coding Plan",
+      kind: "anthropic",
+      enabled: true,
+      options: { baseURL: "https://example.test/api" },
+      models: {
+        "GLM-5.3": { limit: { context: 1000000 }, reasoning: { variants: ["low", "high", "max"] } },
+      },
+    },
+  },
+};
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    readFileSync: (p: string) => {
+      if (p === ZCODE_CREDS_PATH) return JSON.stringify(FAKE_CONFIG);
+      return actual.readFileSync(p);
+    },
+  };
+});
+
+/** Fake backend: records every request; answers reads and setters. */
+class FakeBackend {
+  isDead = false;
+  calls: Array<{ method: string; params?: Record<string, unknown> }> = [];
+  modeNow = "yolo";
+
+  async request(
+    id: number,
+    method: string,
+    params?: Record<string, unknown>,
+  ): Promise<{ id: number; result?: unknown; error?: unknown }> {
+    this.calls.push({ method, params });
+    if (method === "session/read") {
+      return {
+        id,
+        result: {
+          projection: { status: "idle" },
+          settings: { mode: { current: this.modeNow } },
+        },
+      };
+    }
+    if (method === "session/setMode") {
+      this.modeNow = String(params?.mode);
+      return { id, result: {} };
+    }
+    return { id, result: {} };
+  }
+}
+
+/** Mock AgentContext that records every session/update notification. */
+function mockContext(): { cx: acp.AgentContext; sent: acp.SessionUpdate[] } {
+  const sent: acp.SessionUpdate[] = [];
+  const cx = {
+    notify(method: string, params: { sessionId: string; update: acp.SessionUpdate }) {
+      expect(method).toBe("session/update");
+      sent.push(params.update);
+      return Promise.resolve();
+    },
+  } as unknown as acp.AgentContext;
+  return { cx, sent };
+}
+
+function makeServer(): { server: ZcodeAcpServer; backend: FakeBackend } {
+  const server = new ZcodeAcpServer();
+  server.registerSession("sess_acp", "sess_zcode");
+  const backend = new FakeBackend();
+  server.backend = backend as unknown as ZcodeAcpServer["backend"];
+  return { server, backend };
+}
+
+describe("setMode param normalization", () => {
+  it("spec spelling session/set_mode with modeId reaches the backend as mode", async () => {
+    const { server, backend } = makeServer();
+    const { cx } = mockContext();
+    await setMode(server, { sessionId: "sess_acp", modeId: "build" }, cx);
+    const call = backend.calls.find((c) => c.method === "session/setMode");
+    expect(call?.params).toEqual({ sessionId: "sess_zcode", mode: "build" });
+  });
+
+  it("camelCase extension spelling (mode) keeps working unchanged", async () => {
+    const { server, backend } = makeServer();
+    const { cx } = mockContext();
+    await setMode(server, { sessionId: "sess_acp", mode: "plan" }, cx);
+    const call = backend.calls.find((c) => c.method === "session/setMode");
+    expect(call?.params).toEqual({ sessionId: "sess_zcode", mode: "plan" });
+  });
+
+  it("spec spelling emits current_mode_update so the client UI follows", async () => {
+    const { server } = makeServer();
+    const { cx, sent } = mockContext();
+    await setMode(server, { sessionId: "sess_acp", modeId: "build" }, cx);
+    const modeUpdate = sent.find((u) => u.sessionUpdate === "current_mode_update");
+    expect(modeUpdate).toMatchObject({ sessionUpdate: "current_mode_update", currentModeId: "build" });
+  });
+
+  it("missing both mode and modeId is rejected", async () => {
+    const { server } = makeServer();
+    const { cx } = mockContext();
+    await expect(setMode(server, { sessionId: "sess_acp" }, cx)).rejects.toThrow(/mode/);
+  });
+});


### PR DESCRIPTION
I've been driving this adapter from [Paseo](https://github.com/getpaseo/paseo) and every agent created with a non-default mode failed with:

```
Error: "Method not found": session/set_mode (code -32601)
```

The session-modes spec spells the request `session/set_mode` with a `modeId` param, while this bridge exposed the mode switch only as the camelCase extension `session/setMode` with `mode`. Spec-only clients (Paseo is the one I hit; any editor following the spec spelling would be affected the same way) never get a non-default mode applied.

Fix: register the spec method name next to the extension and normalize both param spellings in the handler. The camelCase path is untouched — one of the new tests locks it so existing callers keep working.

**Fail-before / pass-after:** with the change stashed, 2 of the 4 new tests fail (modeId not read); with it applied, 4/4 pass. Full suite: 27 files / 465 tests green.

**End-to-end on the real backend (zcode CLI 0.16.3):** `paseo run --mode build` now creates the agent, the permission request surfaces through `paseo permit`, and after allowing it the task completes with the file written. Same for `--mode plan`/`edit`.

- `src/index.ts` — route `session/set_mode` (comment explains why both spellings exist)
- `src/handlers/extensions.ts` — `params.mode ?? params.modeId`
- `tests/set-mode-alias.test.ts` — fake backend + recorded session/update notifications; asserts the backend receives `{sessionId, mode}` for both spellings, the `current_mode_update` notification fires, and a request with neither param is rejected