### PR TITLE
chore: release 0.3.0 — docs sync and version bump

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ src/
 │   ├── account.ts        account/usage_stats — plan quota for remote clients
 │   ├── extensions.ts     ZCode extensions (fork, rewind, compact, steer, …)
 │   ├── dispatch.ts       InternalEvent → ACP session/update dispatch
+│   ├── replay.ts         Tail replay: load limit, load_earlier pagination
 │   ├── io.ts             Client notification helpers
 │   └── server-requests.ts  Server→client requests (permission, elicitation)
 ├── config/               Discovery + runtime config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-17
+
+### Added
+
+- Remote access (opt-in via `ZCODE_ACP_REMOTE=1`): the bridge serves the same
+  `AgentApp` on a loopback WebSocket endpoint alongside stdio. A multi-client
+  broadcast registry fans notifications out to every attached client; requests
+  are first-response-wins with loser cancellation. The bridge's lifetime still
+  follows the stdio editor (ADR-0001).
+- `zcode-acp-hub` daemon: machine-level singleton providing token auth,
+  instance discovery, and byte-level WebSocket proxying — no session state,
+  no ACP semantics (ADR-0002). Bridges register every 10s as a heartbeat;
+  entries prune after a 30s heartbeat TTL or immediately on
+  `GET /api/instances?probe=1` (on-demand liveness). The hub idle-exits after
+  10 minutes and is re-spawned on demand; a version handshake restarts a stale
+  hub when a newer bridge registers.
+- Tail replay: `session/load` accepts `_meta.zcode.limit` and returns
+  `replayMeta`; `session/load_earlier` pages backwards with an opaque cursor
+  (Proposal 0001 / ADR-0003). Client UI guide: `docs/REPLAY-GUIDE.md`.
+- `account/usage_stats` non-standard ACP method exposing plan quota
+  (GLM Coding Plan + Opencode Go) to remote clients; failures degrade
+  gracefully so clients can hide the quota UI (Proposal 0002).
+- Remote client integration contract: `docs/REMOTE-CLIENTS.md`.
+
+### Fixed
+
+- Slash-leading prompts that are not advertised commands (e.g. `/Users/me`)
+  are neutralized and sent as plain text instead of hard-failing the backend
+  turn and wedging the session.
+- Replayed user messages strip harness `<system-reminder>` blocks (and drop
+  reminder-only messages), so clients never render them as user input.
+- Stored session titles are adopted on load/resume so hub discovery lists the
+  backend's titles.
+
 ## [0.2.0] - 2026-08-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ The server launches the ZCode headless app-server (`zcode app-server --stdio`) a
 
 ## Status
 
-Early in-development. Core scaffolding is in place; features are landing incrementally. See the project board for progress.
+In active development. Core bridging, slash commands and ZCode extensions,
+auto-compaction, remote access for mobile/web clients, and the quota APIs are
+in place; see the project board for what's next.
 
 ## Requirements
 
@@ -137,13 +139,15 @@ every 10s as a heartbeat and drops out of discovery ~30s after it stops.
 ```text
 GET /api/instances              → [{"id","port","pid","startedAt","workspace",
                                     "sessions":[{"sessionId","title?","updatedAt"}]}]
+GET /api/instances?probe=1      → same list, but unreachable bridges are pruned first
 WS   /acp?instance=<id>         → proxied to that bridge's endpoint
 ```
 
 Auth is `Authorization: Bearer <token>` or `?token=` (browsers cannot set WS
 headers); `/api/*` sends `Access-Control-Allow-Origin: *` — the token is the
 security boundary. A proxied connection stays bound to one instance; switching
-instances means reconnecting.
+instances means reconnecting. Remote clients can also pull plan quota via the
+non-standard `account/usage_stats` ACP method (no session required).
 
 Building a remote client — web, mobile, or CLI? The full integration contract
 (endpoints, framing, lifecycle timings, failure recovery, platform notes)
@@ -279,6 +283,8 @@ The server is organised in layers that mirror the ACP protocol:
 - `interaction/` — bridge ZCode `interaction/*` server requests to ACP, preferring `elicitation/create` and falling back to `session/request_permission` (tool auth, ExitPlanMode, AskUserQuestion)
 - `handlers/` — ACP method handlers (`session/new`, `session/prompt`, ...) and the turn engine
 - `config/` — model / mode / thought-level configOptions and runtime model switching
+- `remote/` — opt-in remote access: loopback ACP endpoint, multi-client broadcast, `zcode-acp-hub` registration
+- `quota/` — GLM Coding Plan / Opencode Go usage API client (`/quota` command, `zcode-quota` bin)
 - `server.ts` — shared state and handler registration
 - `index.ts` — stdio wiring via the ACP SDK
 
@@ -296,6 +302,8 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full architecture docum
 
 - [Architecture](docs/ARCHITECTURE.md) — event stream, dual-path deduplication, module responsibilities
 - [Protocol](docs/PROTOCOL.md) — ZCode JSON-RPC protocol details
+- [Remote Clients](docs/REMOTE-CLIENTS.md) — remote access integration contract (discovery, transport, recovery)
+- [Replay Guide](docs/REPLAY-GUIDE.md) — building a client UI on tail replay
 - [Development](docs/DEVELOPMENT.md) — local development, debugging, adding extension methods
 - [Troubleshooting](docs/TROUBLESHOOTING.md) — common-issue troubleshooting
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -78,14 +78,69 @@ ZCode CLI 内置于桌面应用中，默认不会加到 `PATH`。用 `ZCODE_BIN`
 
 ## 环境变量
 
-| 变量              | 默认值           | 用途                                                                                                                                                                                                  |
-| ----------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ZCODE_BIN`       | `zcode`          | ZCode CLI 二进制文件路径或其 `.cjs` 入口                                                                                                                                                              |
-| `ZCODE_NODE`      | _（自动发现）_   | 显式指定运行 `ZCODE_BIN` 的 Node 二进制（必须支持 `node:sqlite`）                                                                                                                                     |
-| `ZCODE_MODEL`     | _（来自 config） | 覆盖当前使用的模型 id                                                                                                                                                                                 |
-| `ZCODE_BASE_URL`  | _（来自 config） | 覆盖 provider 的 base URL                                                                                                                                                                             |
-| `ZCODE_ACP_AUTO_COMPACT_THRESHOLD` | _（未设置）  | 触发自动压缩的绝对 token 阈值。每次回合成功完成后（`end_turn`），若 `contextUsed >= 阈值`，服务端会自动调用 `session/compact` 压缩上下文，为下一个 prompt 腾出空间。设为 `0` 或不设置则禁用（默认）。例如 `240000` 表示上下文达 24 万 token 时触发压缩。压缩目标由 ZCode 后端决定。 |
-| `ZCODE_ACP_DEBUG` | _（未设置）      | 设为 `1` 可开启详细诊断日志（事件流、探测循环、状态更新）。默认安静——只输出警告类日志（后端管道错误、命令/权限失败、锁等待超时）。诊断桥接问题时开启；日志出现在 `Zed.log` 中，前缀为 `[zcode-acp]`。 |
+| 变量                               | 默认值           | 用途                                                                                                                                                                                                                                                                                |
+| ---------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ZCODE_BIN`                        | `zcode`          | ZCode CLI 二进制文件路径或其 `.cjs` 入口                                                                                                                                                                                                                                            |
+| `ZCODE_NODE`                       | _（自动发现）_   | 显式指定运行 `ZCODE_BIN` 的 Node 二进制（必须支持 `node:sqlite`）                                                                                                                                                                                                                   |
+| `ZCODE_MODEL`                      | _（来自 config） | 覆盖当前使用的模型 id                                                                                                                                                                                                                                                               |
+| `ZCODE_BASE_URL`                   | _（来自 config） | 覆盖 provider 的 base URL                                                                                                                                                                                                                                                           |
+| `ZCODE_ACP_AUTO_COMPACT_THRESHOLD` | _（未设置）      | 触发自动压缩的绝对 token 阈值。每次回合成功完成后（`end_turn`），若 `contextUsed >= 阈值`，服务端会自动调用 `session/compact` 压缩上下文，为下一个 prompt 腾出空间。设为 `0` 或不设置则禁用（默认）。例如 `240000` 表示上下文达 24 万 token 时触发压缩。压缩目标由 ZCode 后端决定。 |
+| `ZCODE_ACP_DEBUG`                  | _（未设置）      | 设为 `1` 可开启详细诊断日志（事件流、探测循环、状态更新）。默认安静——只输出警告类日志（后端管道错误、命令/权限失败、锁等待超时）。诊断桥接问题时开启；日志出现在 `Zed.log` 中，前缀为 `[zcode-acp]`。                                                                               |
+| `ZCODE_ACP_REMOTE`                 | _（未设置）_     | 设为 `1` 启用[远程访问](#远程访问)——通过 WebSocket 向更多 ACP 客户端提供相同会话。                                                                                                                                                                                                  |
+| `ZCODE_ACP_REMOTE_TOKEN`           | _（未设置）_     | 远程访问的鉴权 token。启用 `ZCODE_ACP_REMOTE=1` 时**必填**；缺失则远程保持禁用。                                                                                                                                                                                                    |
+| `ZCODE_ACP_HUB_PORT`               | `8377`           | 机器级 `zcode-acp-hub` 的端口。隧道只映射这一个端口。                                                                                                                                                                                                                               |
+| `ZCODE_ACP_HUB_HOST`               | `127.0.0.1`      | hub 绑定地址。`0.0.0.0` 会暴露仅 token 保护的明文面——只用于容器化隧道 agent 所在的私网接口（见[远程访问](#远程访问)）。                                                                                                                                                             |
+| `ZCODE_ACP_REMOTE_PORT`            | `8378`           | bridge ACP 端点的起始回环端口。每个 bridge（每个编辑器窗口）自动递增取下一个空闲端口。                                                                                                                                                                                              |
+
+## 远程访问
+
+设置 `ZCODE_ACP_REMOTE=1` 后，bridge 会额外通过 WebSocket 接收 ACP 连接，
+手机或浏览器即可观看并驱动与编辑器**相同的会话**。Zed（或任何 stdio ACP
+编辑器）仍是主客户端并拥有进程：编辑器断开时，bridge 连同所有远程连接
+一起退出。
+
+```text
+phone / browser ──WS── 隧道 ── hub (127.0.0.1:8377, 唯一入口)
+                                │ 字节级代理
+                                ▼
+                  bridge ACP 端点 (127.0.0.1:8378+n)
+                                │ 与 stdio 同一个 AgentApp
+Zed ──────── stdio ────────────┘
+```
+
+启用方式：在上文「配置 Zed」的 `env` 里追加（Zed 会把这些合并进 agent
+的环境变量）：
+
+```json
+"ZCODE_ACP_REMOTE": "1",
+"ZCODE_ACP_REMOTE_TOKEN": "<一段足够长的随机密钥>"
+```
+
+相关环境变量（详见上文表格）：`ZCODE_ACP_REMOTE`（开关）、
+`ZCODE_ACP_REMOTE_TOKEN`（必填 token）、`ZCODE_ACP_HUB_PORT`（hub 端口，
+默认 8377）、`ZCODE_ACP_HUB_HOST`（hub 绑定地址）、
+`ZCODE_ACP_REMOTE_PORT`（bridge 端点起始端口，默认 8378）。
+
+**Hub。** 第一个启用远程的 bridge 会以 detached 方式拉起机器级单例
+`zcode-acp-hub`（监听 `ZCODE_ACP_HUB_PORT`，也可手动运行）。它只做三件事：
+token 鉴权、实例发现、字节级 WebSocket 代理——不保存会话状态、不解析 ACP。
+空闲约 10 分钟后退出，需要时再被拉起。每个 bridge 每 10 秒注册一次作为
+心跳，心跳停止约 30 秒后从发现列表移除；客户端刷新时也可调用
+`GET /api/instances?probe=1` 主动探测，立即清理不可达的实例。
+
+**语义。** 所有 agent 通知广播给每个已连接客户端；权限 / elicitation 请求
+发给所有客户端，**先应答者生效**，其余客户端收到 `$/cancel_request` 关闭
+对话框。同一会话的并发 prompt 与单编辑器一样串行化。任一客户端声明的能力
+按 OR 合并。
+
+**隧道。** 面向单端口隧道（Cloudflare Tunnel、frp）设计：只映射 hub 端口。
+frp 的 `tcp` 模式原样透传 WebSocket；Cloudflare Tunnel 会断开空闲连接，
+hub 因此在两段链路上每 30 秒发送 keepalive ping。bridge 端点本身只监听
+回环地址，永不直接暴露。
+
+要构建远程客户端（Web、移动端或 CLI）？完整的集成契约（端点、帧格式、
+生命周期时序、故障恢复、平台注意事项）见
+[docs/REMOTE-CLIENTS.md](docs/REMOTE-CLIENTS.md)。
 
 ## 独立配额查询 CLI（zcode-quota）
 
@@ -227,12 +282,12 @@ commit 约定和 PR 检查清单。重要变更记录在 [CHANGELOG.md](CHANGELO
 你的提示词、代码、文件内容通过**本地管道**在编辑器与 ZCode 后端之间中转；这些数据会到达
 GLM 云端 API，仅因 ZCode 后端本身为推理而发送——本服务端不增加任何额外去向。
 
-| 方面 | 做什么 & 为什么 |
-| ---- | --------------- |
-| 网络 | 全代码库仅一处对外请求：配额 GET（`open.bigmodel.cn` / `api.z.ai`），只带 API key —— 为查询用量数字，不发送用户内容 |
-| 凭据 | API key 从 `~/.zcode/v2/config.json` 读取，用于认证 ZCode 子进程和配额请求。从不记录日志、从不写入别处。OAuth 完全由 ZCode 子进程处理 |
+| 方面 | 做什么 & 为什么                                                                                                                                               |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 网络 | 全代码库仅一处对外请求：配额 GET（`open.bigmodel.cn` / `api.z.ai`），只带 API key —— 为查询用量数字，不发送用户内容                                           |
+| 凭据 | API key 从 `~/.zcode/v2/config.json` 读取，用于认证 ZCode 子进程和配额请求。从不记录日志、从不写入别处。OAuth 完全由 ZCode 子进程处理                         |
 | 磁盘 | 不创建任何新文件。只写入已存在的 `~/.zcode/v2/tasks-index.sqlite` —— 这是**将会话同步到 ZCode App**，使其出现在历史列表和全文搜索中（存会话标题和首条提示词） |
-| 日志 | 诊断信息输出到 stderr，用于排查桥接问题。即使开启 `ZCODE_ACP_DEBUG=1`，也绝不记录提示词/代码/密钥 |
+| 日志 | 诊断信息输出到 stderr，用于排查桥接问题。即使开启 `ZCODE_ACP_DEBUG=1`，也绝不记录提示词/代码/密钥                                                             |
 
 ## 许可证
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -90,6 +90,32 @@ describe("backend", () => {
 });
 ```
 
+### Method 4: Remote access (hub + endpoint)
+
+Run the bridge with the remote env vars on scratch ports (keep stdin open —
+the bridge exits when its stdio client disconnects):
+
+```bash
+ZCODE_ACP_REMOTE=1 \
+ZCODE_ACP_REMOTE_TOKEN=dev-token \
+ZCODE_ACP_HUB_PORT=18377 \
+ZCODE_ACP_REMOTE_PORT=18378 \
+ZCODE_ACP_DEBUG=1 \
+tail -f /dev/null | node dist/index.js
+```
+
+The first bridge spawns `dist/bin/hub.js` on its own. Verify discovery:
+
+```bash
+curl -H "Authorization: Bearer dev-token" http://127.0.0.1:18377/api/instances
+curl -H "Authorization: Bearer dev-token" "http://127.0.0.1:18377/api/instances?probe=1"
+```
+
+Integration tests live in `tests/hub.test.ts` (hub API, probe, proxy, idle
+exit) and `tests/remote-endpoint.test.ts` (registration + end-to-end proxied
+initialize). The remote features are opt-in and self-contained — remote
+failures warn and disable remote only, so stdio testing works without them.
+
 ## Debugging Tips
 
 ### Enable verbose logging

--- a/docs/REPLAY-GUIDE.md
+++ b/docs/REPLAY-GUIDE.md
@@ -24,6 +24,13 @@ session, `limit: 30`):
 Everything is additive: omit `_meta.zcode.limit` and you get the old
 full-replay behavior unchanged.
 
+One more replay-only behavior: harness-injected `<system-reminder>` blocks
+(TodoWrite nudges, context handoffs) that the runtime appends to user turns
+are stripped before replay, and user messages that contained nothing else are
+dropped entirely. You never receive them as `user_message_chunk`, so there is
+nothing to filter client-side — the user's transcript shows only what they
+actually typed.
+
 ## Attach strategy
 
 Pick the limit from your UI budget, not from the history size:

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -67,13 +67,13 @@ a hardcoded version string — read the message text to identify the root cause.
 
 **Common causes:**
 
-| Message fragment                 | Cause                                                                      |
-| -------------------------------- | -------------------------------------------------------------------------- |
-| `reader exited (backend dead)`   | The zcode subprocess crashed/exited. Restart the editor session.           |
+| Message fragment                 | Cause                                                                                                                                                                                                                                                      |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `reader exited (backend dead)`   | The zcode subprocess crashed/exited. Restart the editor session.                                                                                                                                                                                           |
 | `timeout`                        | The per-attempt 10s subscribe deadline elapsed. The bridge retries transient timeouts up to 3× (the backend can be briefly busy finalising a cancelled turn after a preempt / `session/stop`); if all retries fail, the backend was unresponsive for ~30s. |
-| `pipe broken`                    | The stdin pipe to the zcode subprocess broke (process died mid-write).     |
-| `method not found (code -32601)` | The CLI genuinely is too old (< 0.14.8). Upgrade.                          |
-| session-level business error     | The target session no longer exists or was evicted.                        |
+| `pipe broken`                    | The stdin pipe to the zcode subprocess broke (process died mid-write).                                                                                                                                                                                     |
+| `method not found (code -32601)` | The CLI genuinely is too old (< 0.14.8). Upgrade.                                                                                                                                                                                                          |
+| session-level business error     | The target session no longer exists or was evicted.                                                                                                                                                                                                        |
 
 **Troubleshooting steps:**
 
@@ -307,6 +307,39 @@ and check the provider endpoint reachability).
 3. Check whether the tasks-index table schema matches:
    - Table name: `tasks`
    - Fields: workspace_key, task_id, title, task_status, ...
+
+### Remote access: hub unreachable / 401
+
+**Symptom:** A remote client cannot list instances or connect; `curl
+http://127.0.0.1:<hub-port>/api/health` fails, or `/api/*` returns 401.
+
+**Troubleshooting steps:**
+
+1. 401 means a token mismatch — `ZCODE_ACP_REMOTE_TOKEN` must be identical in
+   the bridge env, the hub env (if run manually), and the client request.
+2. A dead hub self-heals: the next bridge heartbeat (≤10s; worst ~1min under
+   the spawn throttle) re-spawns `zcode-acp-hub`. Retry with backoff rather
+   than restarting anything by hand.
+3. Confirm the ports match: the client must reach `ZCODE_ACP_HUB_PORT`
+   (default 8377) through the tunnel, and the tunnel maps exactly that one
+   port.
+4. Remote silently disabled? `ZCODE_ACP_REMOTE=1` without a token logs a
+   warning and leaves the bridge stdio-only by design.
+
+### Remote access: stale instance in the list / connect fails
+
+**Symptom:** `/api/instances` lists a workspace whose editor is already gone,
+or a WS connect to it fails.
+
+**Troubleshooting steps:**
+
+1. Hard-killed bridges (Zed force-kill, crash) never unregister — the hub's
+   heartbeat TTL drops them within ~30s.
+2. For an immediately-honest list, call `GET /api/instances?probe=1`: the hub
+   TCP-probes each registered port and prunes unreachable bridges first.
+   Clients should use this on refresh.
+3. A few-seconds outage after upgrading the package is expected: a newer
+   bridge triggers the hub's version-handshake restart, then re-spawns it.
 
 ## Log Debugging
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zcode-acp-server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Agent Client Protocol (ACP) server bridging headless ZCode to editors like Zed and JetBrains.",
   "type": "module",
   "license": "Apache-2.0",

--- a/registry/zcode-acp-server/agent.json
+++ b/registry/zcode-acp-server/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "zcode-acp-server",
   "name": "ZCode",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "description": "Standalone ACP server bridging the headless ZCode app-server (GLM-5.2) to editors like Zed and JetBrains. Supports streaming, tool calls, session fork/resume, mode switching, and reads GLM credentials locally — no editor-side API key required.",
   "repository": "https://github.com/william0wang/zcode-acp",
   "website": "https://github.com/william0wang/zcode-acp",


### PR DESCRIPTION
## Summary

Post-merge documentation sync for the remote-access feature set, plus the
0.3.0 version bump.

## What's in here

- **CHANGELOG**: `[Unreleased]` → `[0.3.0] - 2026-08-17` (remote access, hub
  daemon, tail replay, `account/usage_stats`, slash/reminder fixes)
- **README** (en): refreshed Status; architecture layer list + `remote/` +
  `quota/`; Discovery API block gains `?probe=1` and `account/usage_stats`;
  docs index links Remote Clients + Replay Guide
- **README.zh-CN**: adds the entire 远程访问 section (was missing) and the
  five remote env-var rows
- **DEVELOPMENT**: Method 4 — local remote-access testing commands
- **TROUBLESHOOTING**: hub unreachable/401 and stale-instance entries
- **AGENTS.md**: `handlers/replay.ts` tree row; **REPLAY-GUIDE**: note that
  replayed user messages strip `<system-reminder>` blocks
- **Version**: package.json 0.2.0 → 0.3.0; registry agent.json 0.1.0 → 0.3.0

## Verification

568 tests passing, typecheck/lint/build clean; `AGENT_INFO.version` reads
0.3.0 from package.json after build.