### PR TITLE
chore: turn-state docs and tests, release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-18
+
+### Added
+
+- Turn running state for re-attached clients: `session/load`'s `replayMeta`
+  now carries `turnActive` (snapshot at attach time), and every prompt emits a
+  `$/zcode/turnState` notification (`{ sessionId, running }`) at turn start and
+  end (failures included) — so remote clients that did not send the prompt
+  (re-attached mobile, second editor) can show and restore the running
+  indicator. A preempted turn's exit reports `running: true` while the
+  preempting turn is in flight. Clients that ignore the notification (Zed) are
+  unaffected. Contract: `docs/REPLAY-GUIDE.md`.
+
 ## [0.4.0] - 2026-08-17
 
 ### Added

--- a/docs/REPLAY-GUIDE.md
+++ b/docs/REPLAY-GUIDE.md
@@ -98,6 +98,26 @@ carry a top-level `_meta` on the `session/update` notification:
 - Unknown `kind`s: render collapsed too (or fall back to plain text). Ignoring
   `_meta` entirely is always safe — the text is complete without it.
 
+## Turn running state (`replayMeta.turnActive` + `$/zcode/turnState`)
+
+A turn may already be in flight when you attach — started by the editor or
+another remote client (the bridge runs it to completion regardless of who
+prompted). Two signals cover it:
+
+- **Attach snapshot**: `session/load`'s `replayMeta.turnActive` (boolean) —
+  `true` when any turn for this session is running at attach time. Seed your
+  spinner/running state from it.
+- **Out-of-band updates**: the notification `$/zcode/turnState` with params
+  `{ sessionId: string, running: boolean }` — emitted when a turn starts and
+  when it ends (including failures, e.g. a failed subscribe). On preemption (a
+  new prompt interrupts an in-flight one) the old turn's exit reports
+  `running: true`: the preempting turn took over, so the session is still busy.
+
+The client that sent `session/prompt` already knows its own turn via the
+request/response; these signals exist for the OTHER attached clients
+(re-attached mobile, second editor). Unknown notifications are ignorable —
+clients that don't handle `$/zcode/turnState` lose nothing (Zed ignores it).
+
 ## Scroll-up pagination
 
 ```
@@ -152,6 +172,8 @@ Never parse the cursor — it is opaque. (For the curious it round-trips
 - [ ] `session/load` params include `cwd` and `mcpServers` (even `[]`).
 - [ ] Message list keyed/deduped by `messageId`; tool cards by `toolCallId`.
 - [ ] Pagination pages prepended, live updates appended.
+- [ ] Running state seeded from `replayMeta.turnActive` and updated from
+      `$/zcode/turnState` notifications (covers other clients' turns).
 - [ ] `"cursor expired"` handled by full re-attach.
 - [ ] Cursor stored per session, never parsed, never persisted across app
       runs (it is only meaningful to the bridge that minted it).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zcode-acp-server",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Agent Client Protocol (ACP) server bridging headless ZCode to editors like Zed and JetBrains.",
   "type": "module",
   "license": "Apache-2.0",

--- a/registry/zcode-acp-server/agent.json
+++ b/registry/zcode-acp-server/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "zcode-acp-server",
   "name": "ZCode",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Standalone ACP server bridging the headless ZCode app-server (GLM-5.2) to editors like Zed and JetBrains. Supports streaming, tool calls, session fork/resume, mode switching, and reads GLM credentials locally — no editor-side API key required.",
   "repository": "https://github.com/william0wang/zcode-acp",
   "website": "https://github.com/william0wang/zcode-acp",

--- a/tests/turn-state.test.ts
+++ b/tests/turn-state.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for the `$/zcode/turnState` out-of-band running indicator emitted by
+ * prompt(): running:true when a turn starts, running:false when it ends, and
+ * running:true from a preempted turn's finally while the preempting turn is
+ * still in flight.
+ *
+ * The fake backend drives prompt() end-to-end: `session/send` accepts the
+ * prompt and synchronously delivers scripted events to every registered
+ * listener (mirroring the real backend's per-session fan-out).
+ */
+
+import type * as acp from "@agentclientprotocol/sdk";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ZcodeBackend } from "../src/backend/client.js";
+import type { ZcodeEvent } from "../src/backend/types.js";
+import { prompt } from "../src/handlers/session.js";
+import { ZcodeAcpServer } from "../src/server.js";
+
+vi.mock("../src/tasks-index.js", () => ({
+  upsertSessionTask: async () => true,
+  updateSessionTitle: async () => true,
+}));
+
+/** cx that records every $/zcode/turnState notification payload. */
+function collectCx(): {
+  cx: acp.AgentContext;
+  turnStates: Array<{ sessionId: string; running: boolean }>;
+} {
+  const turnStates: Array<{ sessionId: string; running: boolean }> = [];
+  const cx = {
+    notify: async (method: string, params: Record<string, unknown>) => {
+      if (method === "$/zcode/turnState") {
+        turnStates.push(params as { sessionId: string; running: boolean });
+      }
+    },
+    request: async () => ({}),
+  } as unknown as acp.AgentContext;
+  return { cx, turnStates };
+}
+
+/** Fake backend whose session/send delivers `events()` to all listeners. */
+function scriptedBackend(events: () => ZcodeEvent[]): ZcodeBackend {
+  const listeners: Array<{ handleEvent: (e: ZcodeEvent) => void }> = [];
+  return {
+    isDead: false,
+    request: async (_id: number, method: string) => {
+      switch (method) {
+        case "workspace/updateProviderRegistry":
+        case "session/resume":
+        case "session/subscribe":
+          return { result: {} };
+        case "session/read":
+          return { result: { projection: { status: "idle", contextUsed: 0 }, settings: {} } };
+        case "session/messages":
+          return { result: { messages: [] } };
+        case "session/send": {
+          for (const e of events()) {
+            for (const l of listeners) l.handleEvent(e);
+          }
+          return { result: { accepted: true } };
+        }
+        default:
+          return { error: { message: `unhandled ${method}` } };
+      }
+    },
+    send: () => {},
+    pollServerRequests: () => [],
+    registerEventListener: (_sid: string, l: { handleEvent: (e: ZcodeEvent) => void }) => {
+      listeners.push(l);
+    },
+    unregisterEventListener: () => {},
+  } as unknown as ZcodeBackend;
+}
+
+/** Server with a pre-registered, backend-loaded session (no create/resume). */
+function setup(backend: ZcodeBackend): ZcodeAcpServer {
+  const server = new ZcodeAcpServer();
+  server.backend = backend;
+  server.registerSession("sess_ts", "zs_ts");
+  server.backendLoadedSessions.add("sess_ts");
+  return server;
+}
+
+function promptParams(): acp.PromptRequest {
+  return { sessionId: "sess_ts", prompt: [{ type: "text", text: "hello" }] } as acp.PromptRequest;
+}
+
+describe("$/zcode/turnState emission", () => {
+  it("emits running:true at turn start and running:false at completion", async () => {
+    const server = setup(
+      scriptedBackend(() => [
+        { type: "turn.started" },
+        {
+          type: "model.streaming",
+          payload: { kind: "text_delta", delta: "hi", assistantMessageId: "m1" },
+        },
+        { type: "turn.completed", payload: { resultType: "success" } },
+      ]),
+    );
+    const { cx, turnStates } = collectCx();
+
+    const result = await prompt(server, promptParams(), cx, 1);
+
+    expect(result).toEqual({ stopReason: "end_turn" });
+    expect(turnStates).toEqual([
+      { sessionId: "sess_ts", running: true },
+      { sessionId: "sess_ts", running: false },
+    ]);
+  });
+
+  it("emits running:false when the turn fails before starting (subscribe error)", async () => {
+    const backend = scriptedBackend(() => []);
+    // Force session/subscribe to fail — prompt() must clean up the pending
+    // turn and emit running:false before rethrowing.
+    (backend as { request: unknown }).request = async (_id: number, method: string) =>
+      method === "session/subscribe"
+        ? { error: { code: -32000, message: "boom" } }
+        : { result: {} };
+    const server = setup(backend);
+    const { cx, turnStates } = collectCx();
+
+    await expect(prompt(server, promptParams(), cx, 2)).rejects.toThrow();
+
+    expect(turnStates).toEqual([
+      { sessionId: "sess_ts", running: true },
+      { sessionId: "sess_ts", running: false },
+    ]);
+    expect(server.pendingTurns.size).toBe(0);
+  });
+
+  it("preempted turn's exit reports running:true while the preemptor is in flight", async () => {
+    let sendCount = 0;
+    const server = setup(
+      scriptedBackend(() => {
+        sendCount++;
+        if (sendCount === 1) {
+          // Turn 1 starts but never completes on its own — it stays parked in
+          // its event loop until turn 2's events (fan-out to all listeners)
+          // carry the terminal event.
+          return [{ type: "turn.started" }];
+        }
+        return [
+          { type: "turn.started" },
+          {
+            type: "model.streaming",
+            payload: { kind: "text_delta", delta: "two", assistantMessageId: "m2" },
+          },
+          { type: "turn.completed", payload: { resultType: "success" } },
+        ];
+      }),
+    );
+    const { cx, turnStates } = collectCx();
+
+    const p1 = prompt(server, promptParams(), cx, 101);
+    // Wait until turn 1 has been accepted and parked in its event loop (its
+    // turn.started is consumed on the first poll after send accepts).
+    await vi.waitFor(() => expect(sendCount).toBe(1));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const p2 = prompt(server, promptParams(), cx, 102);
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(r1).toEqual({ stopReason: "cancelled" });
+    expect(r2).toEqual({ stopReason: "end_turn" });
+    expect(turnStates).toEqual([
+      { sessionId: "sess_ts", running: true }, // turn 1 starts
+      { sessionId: "sess_ts", running: true }, // turn 2 starts (preemptor)
+      { sessionId: "sess_ts", running: true }, // turn 1 exits, still busy
+      { sessionId: "sess_ts", running: false }, // turn 2 completes
+    ]);
+  });
+});


### PR DESCRIPTION
Completes the turn running-state feature landed in d5d866f:

- Tests: full prompt()-driven coverage of the `$/zcode/turnState` notification (running:true at start / false on subscribe failure / true from a preempted turn's exit while the preemptor is in flight) — 5x rerun stable.
- Docs: `docs/REPLAY-GUIDE.md` — contract for `replayMeta.turnActive` (attach-time snapshot) + `$/zcode/turnState` params `{ sessionId, running }`, preempt semantics, checklist entry.
- Changelog: [0.5.0] Added entry.
- Version bump 0.5.0 (package.json + registry agent.json).

typecheck clean, 592 tests green.