### PR TITLE
fix: heartbeat-probe session availability, release 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-08-18
+
+### Fixed
+
+- Remote discovery no longer lists sessions the bridge cannot serve. When a
+  project window restarts, the editor can leak the old bridge process; the new
+  bridge takes the session over via the durable alias store, but the leaked one
+  kept advertising it in every heartbeat — remote clients saw the same session
+  twice, and the stale copy opened empty. Before each 10s heartbeat the bridge
+  now probes its idle advertised sessions with a `session/messages` RPC: an
+  error or empty answer hides the session from discovery (and clears the stale
+  backend-loaded stamp so a later `session/load` re-runs the resume RPC), and a
+  non-empty answer restores it. Freshly-active sessions and sessions with an
+  in-flight turn are trusted without a probe. List membership now means
+  "openable" (`docs/REMOTE-CLIENTS.md`).
+
 ## [0.5.0] - 2026-08-18
 
 ### Added

--- a/docs/REMOTE-CLIENTS.md
+++ b/docs/REMOTE-CLIENTS.md
@@ -82,6 +82,12 @@ HTTP auth: `Authorization: Bearer <token>` or `?token=<token>`.
   stored placeholder and materialize an empty backend session — those stay
   hidden and appear within one heartbeat (~10s) after their first prompt (or
   a titled resume/load).
+- `sessions` is also **availability-verified**: before every heartbeat the
+  bridge probes its idle sessions against its own backend, and a session it
+  can no longer serve (e.g. the project restarted under a newer bridge while
+  the old process leaked) is dropped from the list within one heartbeat
+  (~10s) instead of lingering as an entry that opens empty. It reappears if
+  the bridge can serve it again. Treat list membership as "openable".
 - Poll every 3–5s. There is no push notification for registry changes yet.
 - Fields are **additive-only** across releases — ignore fields you don't know.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zcode-acp-server",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Agent Client Protocol (ACP) server bridging headless ZCode to editors like Zed and JetBrains.",
   "type": "module",
   "license": "Apache-2.0",

--- a/registry/zcode-acp-server/agent.json
+++ b/registry/zcode-acp-server/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "zcode-acp-server",
   "name": "ZCode",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Standalone ACP server bridging the headless ZCode app-server (GLM-5.2) to editors like Zed and JetBrains. Supports streaming, tool calls, session fork/resume, mode switching, and reads GLM credentials locally — no editor-side API key required.",
   "repository": "https://github.com/william0wang/zcode-acp",
   "website": "https://github.com/william0wang/zcode-acp",

--- a/src/remote/endpoint.ts
+++ b/src/remote/endpoint.ts
@@ -29,6 +29,7 @@ import { WebSocketServer } from "ws";
 import type { ZcodeAcpServer } from "../server.js";
 import { AGENT_INFO, log, warn } from "../utils.js";
 import type { RemoteConfig } from "./config.js";
+import { verifySessionAvailability } from "./session-liveness.js";
 
 /** How often the bridge re-registers with the hub (also the heartbeat). */
 const HEARTBEAT_MS = 10_000;
@@ -54,17 +55,20 @@ function tryListen(server: Server, port: number): Promise<boolean> {
 
 /**
  * Session summaries for the hub's discovery API. Only sessions with real
- * interaction (`hasActivity`) are pushed: an editor restart auto-resumes its
- * stored placeholder, materializing an empty backend session — pushing that
- * would make remote clients list (and open) a conversation that never
- * happened. The hub replaces the whole list on every register, so a session
- * that gains activity shows up within one heartbeat (~10s).
+ * interaction (`hasActivity`) that this backend can still serve (not
+ * `unavailable`) are pushed: an editor restart auto-resumes its stored
+ * placeholder, materializing an empty backend session — pushing that would
+ * make remote clients list (and open) a conversation that never happened —
+ * and a leaked bridge whose backend lost a session to a newer bridge must
+ * not keep advertising a copy that opens empty. The hub replaces the whole
+ * list on every register, so both gaining activity and becoming serveable
+ * again show up within one heartbeat (~10s); see session-liveness.ts.
  */
 export function sessionsPayload(
   server: ZcodeAcpServer,
 ): Array<{ sessionId: string; title?: string; updatedAt: number }> {
   return Array.from(server.sessionSummaries.entries())
-    .filter(([, s]) => s.hasActivity)
+    .filter(([, s]) => s.hasActivity && !s.unavailable)
     .map(([sessionId, s]) => ({
       sessionId,
       ...(s.title !== undefined ? { title: s.title } : {}),
@@ -184,6 +188,16 @@ export async function startRemoteEndpoint(
 
   const registerOnce = async (): Promise<void> => {
     if (stopped || authRejected) return;
+    // Availability check before every heartbeat: sessions this backend can no
+    // longer serve (leaked-bridge scenario) are dropped from the payload, and
+    // previously-dropped ones that answer again are restored. Never throws;
+    // wrapped anyway so a surprise failure can't fall into the hub-spawn
+    // catch below (which would misread it as "hub unreachable").
+    try {
+      await verifySessionAvailability(server);
+    } catch {
+      /* best-effort */
+    }
     try {
       const res = await postJson(`http://127.0.0.1:${config.hubPort}/api/register`, payload());
       if (res.status === 401) {

--- a/src/remote/session-liveness.ts
+++ b/src/remote/session-liveness.ts
@@ -1,0 +1,78 @@
+/**
+ * Heartbeat-time session availability verification.
+ *
+ * A bridge can outlive a session's ownership: restarting a project window
+ * leaks the old bridge process (Zed keeps it alive), and the new bridge takes
+ * over the session via the durable alias store. The old bridge keeps
+ * advertising the session in every heartbeat while its own backend subprocess
+ * can no longer serve it — remote clients then see the same session twice,
+ * and the stale copy opens empty. Before each hub heartbeat we probe idle
+ * advertised sessions with a cheap `session/messages` RPC: an error or empty
+ * answer marks the summary unavailable (dropped from the discovery payload,
+ * and the backend-loaded stamp cleared so a later session/load re-runs the
+ * resume RPC instead of skipping it); a non-empty answer restores it.
+ * Freshly-active sessions and sessions with an in-flight turn are trusted
+ * without a probe.
+ */
+
+import type { ZcodeAcpServer } from "../server.js";
+import { log, warn } from "../utils.js";
+
+/** Sessions touched within this window are trusted without a probe. */
+const FRESH_MS = 60_000;
+/** Per-probe cap — a hung backend must not stall the heartbeat loop. */
+const PROBE_TIMEOUT_MS = 3000;
+
+export async function verifySessionAvailability(server: ZcodeAcpServer): Promise<void> {
+  const backend = server.backend;
+  if (!backend || backend.isDead) return;
+
+  const busyZcodeSids = new Set([...server.pendingTurns.values()].map((t) => t.zcodeSid));
+  const now = Date.now();
+  for (const [acpSid, summary] of server.sessionSummaries.entries()) {
+    if (!summary.hasActivity) continue;
+    // Fresh summaries are trusted; unavailable ones are re-probed so a session
+    // that becomes serveable again returns to the discovery list.
+    if (summary.unavailable !== true && now - summary.updatedAt < FRESH_MS) continue;
+    const zcodeSid = server.resolveSid(acpSid);
+    if (!zcodeSid || busyZcodeSids.has(zcodeSid)) continue;
+
+    let serveable = false;
+    try {
+      const timer = new Promise<null>((resolve) => {
+        const t = setTimeout(() => resolve(null), PROBE_TIMEOUT_MS);
+        t.unref();
+      });
+      const resp = await Promise.race([
+        backend.request(
+          server.nextId(),
+          "session/messages",
+          { sessionId: zcodeSid },
+          PROBE_TIMEOUT_MS,
+        ),
+        timer,
+      ]);
+      const messages = ((resp?.result ?? {}) as { messages?: Array<unknown> }).messages ?? [];
+      serveable = resp !== null && !resp.error && messages.length > 0;
+    } catch {
+      serveable = false;
+    }
+
+    if (serveable) {
+      if (summary.unavailable) {
+        summary.unavailable = false;
+        log(`remote: session ${acpSid.slice(0, 8)} serves messages again - restored to discovery`);
+      }
+      continue;
+    }
+    if (!summary.unavailable) {
+      summary.unavailable = true;
+      // The loaded-in-this-subprocess stamp went stale (another backend took
+      // the session over): a later session/load must re-run the resume RPC.
+      server.backendLoadedSessions.delete(acpSid);
+      warn(
+        `remote: session ${acpSid.slice(0, 8)} not serveable by this backend - hidden from discovery`,
+      );
+    }
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -109,17 +109,20 @@ export class ZcodeAcpServer {
   readonly clients = new ClientRegistry();
   /**
    * Lightweight session summaries for the remote hub's discovery API
-   * (acp_sid → { title, updatedAt, hasActivity }). In-memory only — the hub
-   * holds no business state and the bridge dies with its editor, so persistence
-   * would buy nothing. Maintained by `touchSessionSummary` at session
-   * registration, title set, and turn completion. `hasActivity` gates the
-   * discovery payload: an editor restart auto-resumes its stored placeholder,
-   * materializing an empty backend session — never-used sessions stay invisible
-   * to remote clients until first real use.
+   * (acp_sid → { title, updatedAt, hasActivity, unavailable }). In-memory only
+   * — the hub holds no business state and the bridge dies with its editor, so
+   * persistence would buy nothing. Maintained by `touchSessionSummary` at
+   * session registration, title set, and turn completion. `hasActivity` gates
+   * the discovery payload: an editor restart auto-resumes its stored
+   * placeholder, materializing an empty backend session — never-used sessions
+   * stay invisible to remote clients until first real use. `unavailable` is
+   * set by the heartbeat's availability probe (session-liveness.ts) when this
+   * backend can no longer serve the session (e.g. a restarted project took it
+   * over via a new bridge) and clears when it answers messages again.
    */
   readonly sessionSummaries = new Map<
     string,
-    { title?: string; updatedAt: number; hasActivity?: boolean }
+    { title?: string; updatedAt: number; hasActivity?: boolean; unavailable?: boolean }
   >();
   /** Session titles already set, to enforce set-once (acp_sid → title). */
   readonly sessionTitles = new Map<string, string>();
@@ -216,6 +219,8 @@ export class ZcodeAcpServer {
       // A title only exists once the session produced content (auto-title on
       // first end_turn, or a stored title adopted on resume/load).
       hasActivity: existing?.hasActivity || title !== undefined,
+      // Keep the heartbeat-liveness verdict across mapping/title touches.
+      unavailable: existing?.unavailable,
     });
   }
 

--- a/tests/remote-endpoint.test.ts
+++ b/tests/remote-endpoint.test.ts
@@ -13,8 +13,10 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import type { RemoteConfig } from "../src/remote/config.js";
 import { trackConnections } from "../src/remote/broadcast.js";
+import type { ZcodeBackend } from "../src/backend/client.js";
 import { sessionsPayload, startRemoteEndpoint } from "../src/remote/endpoint.js";
 import { startHub } from "../src/remote/hub-server.js";
+import { verifySessionAvailability } from "../src/remote/session-liveness.js";
 import { ZcodeAcpServer } from "../src/server.js";
 import { AGENT_INFO } from "../src/utils.js";
 
@@ -266,6 +268,17 @@ describe("discovery payload gating", () => {
     expect(sessionsPayload(server).map((s) => s.sessionId)).toEqual(["s-live"]);
   });
 
+  it("excludes sessions the heartbeat marked unavailable", () => {
+    const server = new ZcodeAcpServer();
+    server.registerSession("s-stale", "zc1");
+    server.markSessionActive("s-stale");
+    server.registerSession("s-live", "zc2");
+    server.markSessionActive("s-live");
+    server.sessionSummaries.get("s-stale")!.unavailable = true;
+
+    expect(sessionsPayload(server).map((s) => s.sessionId)).toEqual(["s-live"]);
+  });
+
   it("includes sessions that gained a title (stored title adopted on resume)", () => {
     const server = new ZcodeAcpServer();
     server.registerSession("s", "zc");
@@ -282,5 +295,87 @@ describe("discovery payload gating", () => {
     server.markSessionActive("s");
 
     expect(Object.keys(sessionsPayload(server)[0]!).sort()).toEqual(["sessionId", "updatedAt"]);
+  });
+});
+
+describe("session availability verification (heartbeat probe)", () => {
+  /** Fake backend recording probed sids; `answer` decides per-session results. */
+  function probeBackend(
+    answer: (sid: string) => { result?: { messages?: unknown[] }; error?: { message: string } },
+  ): { backend: ZcodeBackend; probed: string[] } {
+    const probed: string[] = [];
+    const backend = {
+      isDead: false,
+      request: async (_id: number, method: string, params: { sessionId: string }) => {
+        if (method !== "session/messages") return { error: { message: "unhandled" } };
+        probed.push(params.sessionId);
+        return answer(params.sessionId);
+      },
+    } as unknown as ZcodeBackend;
+    return { backend, probed };
+  }
+
+  /** Active session with an aged summary so it is no longer trusted-fresh. */
+  function agedActive(server: ZcodeAcpServer, acpSid: string, zcodeSid: string): void {
+    server.registerSession(acpSid, zcodeSid);
+    server.markSessionActive(acpSid);
+    server.backendLoadedSessions.add(acpSid);
+    server.sessionSummaries.get(acpSid)!.updatedAt = Date.now() - 120_000;
+  }
+
+  it("hides sessions that answer with an error or no messages, and clears the loaded stamp", async () => {
+    const { backend } = probeBackend((sid) =>
+      sid === "zc-err"
+        ? { error: { message: "session not found" } }
+        : sid === "zc-empty"
+          ? { result: { messages: [] } }
+          : { result: { messages: [{ info: { id: "m1" } }] } },
+    );
+    const server = new ZcodeAcpServer();
+    server.backend = backend;
+    agedActive(server, "s-err", "zc-err");
+    agedActive(server, "s-empty", "zc-empty");
+    agedActive(server, "s-ok", "zc-ok");
+
+    await verifySessionAvailability(server);
+
+    expect(server.sessionSummaries.get("s-err")!.unavailable).toBe(true);
+    expect(server.sessionSummaries.get("s-empty")!.unavailable).toBe(true);
+    expect(server.sessionSummaries.get("s-ok")!.unavailable).toBeFalsy();
+    expect(server.backendLoadedSessions.has("s-err")).toBe(false);
+    expect(server.backendLoadedSessions.has("s-ok")).toBe(true);
+    expect(sessionsPayload(server).map((s) => s.sessionId)).toEqual(["s-ok"]);
+  });
+
+  it("restores a previously unavailable session once it serves messages again", async () => {
+    const { backend } = probeBackend(() => ({ result: { messages: [{ info: { id: "m1" } }] } }));
+    const server = new ZcodeAcpServer();
+    server.backend = backend;
+    agedActive(server, "s-back", "zc-back");
+    server.sessionSummaries.get("s-back")!.unavailable = true;
+
+    await verifySessionAvailability(server);
+
+    expect(server.sessionSummaries.get("s-back")!.unavailable).toBe(false);
+    expect(sessionsPayload(server).map((s) => s.sessionId)).toEqual(["s-back"]);
+  });
+
+  it("skips trusted-fresh sessions and sessions with an in-flight turn", async () => {
+    const { backend, probed } = probeBackend(() => ({ error: { message: "gone" } }));
+    const server = new ZcodeAcpServer();
+    server.backend = backend;
+    // Fresh: active just now — trusted without a probe.
+    server.registerSession("s-fresh", "zc-fresh");
+    server.markSessionActive("s-fresh");
+    // In-flight: aged but a turn is running for its zcode session.
+    agedActive(server, "s-busy", "zc-busy");
+    server.pendingTurns.set(1, { zcodeSid: "zc-busy", cancelled: false });
+
+    await verifySessionAvailability(server);
+
+    expect(probed).toEqual([]);
+    expect(server.sessionSummaries.get("s-fresh")!.unavailable).toBeFalsy();
+    expect(server.sessionSummaries.get("s-busy")!.unavailable).toBeFalsy();
+    expect(sessionsPayload(server).map((s) => s.sessionId)).toEqual(["s-fresh", "s-busy"]);
   });
 });


### PR DESCRIPTION
## Problem

Restarting a Zed project window leaks the old bridge process (Zed keeps it alive). The new bridge takes the session over via the durable alias store, but the leaked bridge keeps advertising the same session in every hub heartbeat:

- the remote session list shows the **same session twice**
- the stale copy (old bridge) **opens empty** — its backend can no longer serve the session, and the `backendLoadedSessions` stamp wrongly skips the resume RPC
- after a project closes, its sessions can linger the same way

Verified live: instances 80799 (5h old, leaked) and 56585 (post-restart) both advertised `5e00a962…`.

## Fix (as suggested: check availability at list time)

Before every 10s heartbeat, the bridge probes its idle advertised sessions with a `session/messages` RPC against its own backend (`src/remote/session-liveness.ts`):

- error / empty answer → summary marked `unavailable`, dropped from the discovery payload, and the stale backend-loaded stamp is cleared so a later `session/load` re-runs the resume RPC
- non-empty answer → restored to discovery
- trusted without probe: sessions active within 60s, sessions with an in-flight turn

The hub stays stateless (ADR-0002 untouched). List membership now means "openable" — documented in `docs/REMOTE-CLIENTS.md`.

## Tests

4 new cases (probe hides error/empty + clears stamp, restores when serveable, skips fresh/busy). Full suite: 596 green, typecheck clean.