### PR TITLE
fix: advertise new sessions at first turn start, not after it completes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- New sessions appear in remote discovery within one heartbeat of their
+  first prompt instead of only after the first turn completes: the turn
+  start now marks the session active (previously the activity flag was set
+  only in the prompt's finally, so a minutes-long first turn kept the
+  conversation invisible in remote lists the whole time). Until the
+  backend's auto-title lands, the entry carries a provisional title from
+  the first line of the prompt.
+
 ## [0.7.0] - 2026-08-18
 
 ### Added

--- a/docs/REMOTE-CLIENTS.md
+++ b/docs/REMOTE-CLIENTS.md
@@ -81,8 +81,8 @@ HTTP auth: `Authorization: Bearer <token>` or `?token=<token>`.
   the editor tab: turns driven from either side stream live to both. A
   conversation with no editor placeholder is advertised under its backend
   id (`sess_…`), still loadable via pass-through resume. `title` comes from
-  the backend session store; sessions that never completed a turn have no
-  title and are not listed.
+  the backend session store once the backend has titled it; sessions whose
+  first turn is still running carry the provisional prompt-derived title.
 - **Prompt echo**: when any client sends `session/prompt`, the bridge
   broadcasts the user's text to every OTHER attached client as a
   `user_message_chunk` (messageId prefixed `uprompt_`). Your own prompts are
@@ -91,11 +91,14 @@ HTTP auth: `Authorization: Bearer <token>` or `?token=<token>`.
   message that started it.
 - `sessions` is gated on two rules: the conversation must be **currently
   running** (a live registration in the advertising bridge — an open editor
-  tab, or a remote attachment that ran a turn) and **accessible** (every
-  listed id resolves and resumes through that bridge). Retired conversations
-  of the project are NOT listed even though the backend store still has them
-  — the store only enriches live entries with the authoritative title and a
-  cross-bridge `updatedAt`.
+  tab, or a remote attachment that ran a turn; a brand-new conversation
+  counts from the moment its FIRST turn starts, not after it completes) and
+  **accessible** (every listed id resolves and resumes through that bridge).
+  Retired conversations of the project are NOT listed even though the
+  backend store still has them — the store only enriches live entries with
+  the authoritative title and a cross-bridge `updatedAt`. Entries may carry
+  a provisional title (first line of the first prompt, capped at 60 chars)
+  until the backend's own auto-title lands.
 - Entries are **deduped across instances**: several bridges of the same
   project (e.g. a leaked old process plus the current one) can all hold the
   same live conversation under the same id; the hub keeps one copy per

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -518,6 +518,22 @@ export async function prompt(
     server.pendingTurns.set(requestId, turn);
     preempted = preemptInFlightTurn(server, zcodeSid, requestId);
   });
+  // Discovery: the session is live the moment its turn STARTS — mark it active
+  // here instead of only at turn end, so a freshly created conversation shows
+  // up in remote lists within one heartbeat even while its first (possibly
+  // minutes-long) turn is still running. Until the backend's auto-title lands
+  // at end_turn, seed a provisional title from the prompt text (auto-title
+  // stays authoritative — its set-once gate is the separate sessionTitles).
+  server.markSessionActive(params.sessionId);
+  if (server.sessionSummaries.get(params.sessionId)?.title === undefined) {
+    const firstLine = text.trim().split(/\r\n|\r|\n/)[0] ?? "";
+    if (firstLine) {
+      server.touchSessionSummary(
+        params.sessionId,
+        firstLine.length > 60 ? firstLine.slice(0, 57) + "…" : firstLine,
+      );
+    }
+  }
   // Out-of-band running indicator: clients that did not send this prompt
   // (re-attached mobile, second editor) learn the turn started here — the
   // session/load replayMeta only snapshots attach time. Best-effort: a dead


### PR DESCRIPTION
## Problem

A brand-new conversation only became visible to remote clients (phone app, second editor) after its **first turn fully completed** — `markSessionActive` fired only in `prompt()`'s `finally` block. A minutes-long first turn meant the session was invisible in remote discovery lists for minutes.

## Fix

- Mark the session active at turn **start** (right after the preempt-lock registration), so it appears in remote lists within one heartbeat of the first prompt — even while that turn is still running.
- Seed a **provisional title** (first line of the prompt, capped at 60 chars) so the list entry isn't titleless. The backend's end-turn auto-title stays authoritative — its set-once gate is the separate `server.sessionTitles` set, so provisional titles never conflict with it.

## Verification

- Live-tested with an isolated-ports discovery probe: new session appeared in the discovery list at **8.0s while its first turn was still running** (turn settled at 8.9s); the backend auto-title then won via heartbeat enrichment.
- `pnpm typecheck`, `pnpm lint`, `pnpm test` all green (626/626).

## Docs

- `docs/REMOTE-CLIENTS.md`: discovery contract updated (first turn start + provisional titles)
- `CHANGELOG.md`: `[Unreleased]` Fixed entry