### PR TITLE
chore: release 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-08-18
+
 ### Fixed
 
 - New sessions appear in remote discovery within one heartbeat of their

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zcode-acp-server",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Agent Client Protocol (ACP) server bridging headless ZCode to editors like Zed and JetBrains.",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
Version bump to **0.7.1** for the turn-start session discovery fix merged in #57.

- `package.json`: 0.7.0 → 0.7.1
- `CHANGELOG.md`: `[Unreleased]` Fixed entry moved into `[0.7.1] - 2026-08-18`

0.7.0 is already published on npm; this releases the fix as 0.7.1.