### PR TITLE
feat: HTTP quota and session-status endpoints for remote clients

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -197,13 +197,14 @@ API only because the ZCode backend itself sends them for inference.
 
 ### `remote/` — Remote access (opt-in via `ZCODE_ACP_REMOTE=1`)
 
-| File               | Responsibility                                                                                                                                               |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `broadcast.ts`     | ClientRegistry + broadcast proxy: notify fans out to all clients; request is first-response-wins with loser `$/cancel_request`                               |
-| `config.ts`        | ENV parsing (gate, mandatory token, hub/bridge ports)                                                                                                        |
-| `endpoint.ts`      | Loopback ACP endpoint (SDK AcpServer transport, port auto-increment) + hub registration/heartbeat                                                            |
-| `file-endpoint.ts` | Read-only `GET /fs/list` + `GET /fs/file` on the loopback server (ADR-0004): Session Root scoping, byte/line windows, streaming                              |
-| `hub-server.ts`    | The hub singleton: token auth, instance discovery, byte-level WS proxying, heartbeat pruning, on-demand `?probe=1` liveness, idle exit, version self-upgrade |
+| File                 | Responsibility                                                                                                                                                                                         |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `broadcast.ts`       | ClientRegistry + broadcast proxy: notify fans out to all clients; request is first-response-wins with loser `$/cancel_request`                                                                         |
+| `config.ts`          | ENV parsing (gate, mandatory token, hub/bridge ports)                                                                                                                                                  |
+| `endpoint.ts`        | Loopback ACP endpoint (SDK AcpServer transport, port auto-increment) + hub registration/heartbeat                                                                                                      |
+| `file-endpoint.ts`   | Read-only `GET /fs/list` + `GET /fs/file` on the loopback server (ADR-0004): Session Root scoping, byte/line windows, streaming                                                                        |
+| `status-endpoint.ts` | `GET /status` on the loopback server (ADR-0005): in-memory per-session running state (`pendingTurns` derivation), zero backend RPC                                                                     |
+| `hub-server.ts`      | The hub singleton: token auth, instance discovery, byte-level WS proxying, heartbeat pruning, on-demand `?probe=1` liveness, idle exit, version self-upgrade, `GET /api/quota` direct query (ADR-0005) |
 
 When enabled, the same `AgentApp` serves the stdio editor and a loopback
 WebSocket endpoint. Every connection (editor or remote) joins the broadcast
@@ -231,6 +232,13 @@ Session file access (ADR-0004) rides the same loopback server: the bridge
 serves read-only `GET /fs/list` + `GET /fs/file` scoped to each session's cwd,
 and the hub byte-proxies them at `/api/instances/{id}/fs/*` — no new port, and
 the hub still holds no path semantics.
+
+Running status and quota also have plain-HTTP channels (ADR-0005) so clients
+can poll without an ACP connection: the bridge's `GET /status` (pure in-memory
+assembly) is proxied at `/api/instances/{id}/status` and echoed coarsely in
+each heartbeat (`sessions[].status`), while `GET /api/quota` is queried by the
+hub itself — quota belongs to the machine's credentials, not to any instance,
+so it works with zero bridges registered.
 
 ## Key State Machines
 

--- a/docs/REMOTE-CLIENTS.md
+++ b/docs/REMOTE-CLIENTS.md
@@ -46,10 +46,12 @@ ACP editor ────── stdio ──────────┘
 
 ## Discovery API
 
-| Endpoint             | Auth     | Purpose                                                      |
-| -------------------- | -------- | ------------------------------------------------------------ |
-| `GET /api/health`    | none     | Liveness probe; `200` body `ok`.                             |
-| `GET /api/instances` | required | Registered bridge instances. Add `?probe=1` to verify first. |
+| Endpoint                         | Auth     | Purpose                                                                                      |
+| -------------------------------- | -------- | -------------------------------------------------------------------------------------------- |
+| `GET /api/health`                | none     | Liveness probe; `200` body `ok`.                                                             |
+| `GET /api/instances`             | required | Registered bridge instances. Add `?probe=1` to verify first.                                 |
+| `GET /api/instances/{id}/status` | required | Real-time per-session running status of one bridge.                                          |
+| `GET /api/quota`                 | required | Account-level usage stats — same payload as `account/usage_stats`, no ACP connection needed. |
 
 HTTP auth: `Authorization: Bearer <token>` or `?token=<token>`.
 
@@ -63,7 +65,14 @@ HTTP auth: `Authorization: Bearer <token>` or `?token=<token>`.
     "pid": 72341,
     "startedAt": 1723800000000,
     "workspace": "/Users/me/proj",
-    "sessions": [{ "sessionId": "5f0c…", "title": "Fix login bug", "updatedAt": 1723800012000 }]
+    "sessions": [
+      {
+        "sessionId": "5f0c…",
+        "title": "Fix login bug",
+        "status": "running",
+        "updatedAt": 1723800012000
+      }
+    ]
   }
 ]
 ```
@@ -83,6 +92,9 @@ HTTP auth: `Authorization: Bearer <token>` or `?token=<token>`.
   id (`sess_…`), still loadable via pass-through resume. `title` comes from
   the backend session store once the backend has titled it; sessions whose
   first turn is still running carry the provisional prompt-derived title.
+- `sessions[].status` is a coarse `"running" | "idle"` indicator riding the
+  heartbeat (up to ~10s stale; absent on older bridges — treat as unknown).
+  For the live value poll [`/api/instances/{id}/status`](#session-running-status).
 - **Prompt echo**: when any client sends `session/prompt`, the bridge
   broadcasts the user's text to every OTHER attached client as a
   `user_message_chunk` (messageId prefixed `uprompt_`). Your own prompts are
@@ -145,16 +157,28 @@ ws(s)://<hub-host>/acp?instance=<id>&token=<token>
    (model / mode / thought level), slash commands in the prompt text —
    see [PROTOCOL.md](PROTOCOL.md).
 
-## Account quota (`account/usage_stats`)
+## Account quota
 
-Non-standard, additive (Proposal 0002). Plan quota is **account-level**, so it
-is a pull-only request — callable any time after `initialize`, no session
-required. Fetch once after attach and on demand; quota changes are slow, there
-is no push.
+Two equivalent channels; prefer plain HTTP — it needs no ACP connection:
 
-The response mirrors the `zcode-quota` CLI card's data model — one GLM section
-plus one Opencode Go section — so clients can reproduce the CLI layout
-exactly:
+```text
+GET {hub}/api/quota → 200, the JSON body documented below (Cache-Control: no-store)
+```
+
+The hub queries the usage APIs directly — quota belongs to the machine's
+configured credentials, not to any bridge instance (ADR-0005) — and caches the
+result ~30s server-side, so polling is cheap. A `502` means the upstream query
+failed; retry later.
+
+The ACP method is `account/usage_stats` (Proposal 0002), useful when a
+conversation is already attached. Plan quota is **account-level**, so it is a
+pull-only request — callable any time after `initialize`, no session required.
+Fetch once after attach and on demand; quota changes are slow, there is no
+push.
+
+Both channels return the same payload, mirroring the `zcode-quota` CLI card's
+data model — one GLM section plus one Opencode Go section — so clients can
+reproduce the CLI layout exactly:
 
 ```json
 → { "id": 7, "method": "account/usage_stats", "params": {} }
@@ -197,6 +221,41 @@ exactly:
   render the same status line the CLI would (e.g. auth expired) and retry
   later. Only transport-level failures reject the request.
 - Cached ~10s server-side (same caches as the `/quota` command).
+
+## Session running status
+
+Two layers (ADR-0005), both plain HTTP — no ACP connection needed:
+
+- **Heartbeat**: every `sessions[]` entry in `/api/instances` carries
+  `status: "running" | "idle"`. Free with the list you already poll, but up
+  to ~10s stale (the bridge re-registers every 10s).
+- **Real-time**: `GET {hub}/api/instances/{id}/status` proxies the bridge's
+  in-memory view — assembled without any backend RPC, safe to poll
+  aggressively (1–2s) for a task board or detail view:
+
+```json
+{
+  "sessions": [
+    {
+      "sessionId": "5f0c…",
+      "title": "Fix login bug",
+      "status": "running",
+      "updatedAt": 1723800012000
+    }
+  ]
+}
+```
+
+- Membership matches discovery: live, accessible sessions only (`hasActivity`
+  and a backend mapping). An empty `sessions` array means the bridge holds no
+  live conversation.
+- A cancelled turn still counts as `running` until its loop unwinds — the
+  conversation is busy; treat `idle` as the only "finished" signal.
+- `status` is the real-time field. `title` and `updatedAt` come from the
+  bridge's in-memory summary, so the heartbeat's store-enriched values in
+  `/api/instances` may be fresher for cross-bridge conversations.
+- Errors: `401` bad token, `404` unknown instance, `502` bridge unreachable.
+  `HEAD` is supported.
 
 ## Session files (read-only)
 
@@ -301,12 +360,13 @@ The stdio editor and every remote client are peers on the same sessions:
 
 ## Failure & recovery
 
-| Symptom                                | Cause                                                                                                                                                                                                                                                                    | Client action                                                                                       |
-| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
-| WS closes                              | bridge exited (editor closed) or network drop                                                                                                                                                                                                                            | Poll `/api/instances`; if the instance is gone, its sessions are gone too — drop it from the UI.    |
-| Instance missing from `/api/instances` | Heartbeats stopped >30s, or `?probe=1` found the bridge port unreachable                                                                                                                                                                                                 | Remove the instance from the UI.                                                                    |
-| Connect fails for a while              | Hub process died; a bridge re-spawns it on the next heartbeat (typically ≤10s, worst case ~1min under the spawn throttle). Also expected for a few seconds after a bridge upgrade: the hub notices a newer bridge, restarts, and is re-spawned from the upgraded install | Retry with backoff.                                                                                 |
-| Disconnect mid-turn                    | Mobile network flap, background suspension                                                                                                                                                                                                                               | The turn continues server-side. Reconnect and `session/load` — history replay is the recovery path. |
+| Symptom                                  | Cause                                                                                                                                                                                                                                                                    | Client action                                                                                       |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| WS closes                                | bridge exited (editor closed) or network drop                                                                                                                                                                                                                            | Poll `/api/instances`; if the instance is gone, its sessions are gone too — drop it from the UI.    |
+| Instance missing from `/api/instances`   | Heartbeats stopped >30s, or `?probe=1` found the bridge port unreachable                                                                                                                                                                                                 | Remove the instance from the UI.                                                                    |
+| `/api/instances/{id}/status` answers 502 | The instance is registered but its bridge port is unreachable — it is dying; the heartbeat TTL or your next `?probe=1` refresh will drop it                                                                                                                              | Fall back to the heartbeat `status` field, then re-discover.                                        |
+| Connect fails for a while                | Hub process died; a bridge re-spawns it on the next heartbeat (typically ≤10s, worst case ~1min under the spawn throttle). Also expected for a few seconds after a bridge upgrade: the hub notices a newer bridge, restarts, and is re-spawned from the upgraded install | Retry with backoff.                                                                                 |
+| Disconnect mid-turn                      | Mobile network flap, background suspension                                                                                                                                                                                                                               | The turn continues server-side. Reconnect and `session/load` — history replay is the recovery path. |
 
 Updates emitted while you are disconnected are not individually re-delivered;
 `session/load` replay is the catch-up mechanism.

--- a/docs/adr/0005-http-quota-and-status-endpoints.md
+++ b/docs/adr/0005-http-quota-and-status-endpoints.md
@@ -1,0 +1,39 @@
+# Plain-HTTP quota and session-status endpoints
+
+Remote clients (the mobile app) needed two things that forced a full ACP
+WebSocket round-trip — connect, `initialize`, request, disconnect: account
+quota and per-session running status. Both are poor fits for the session
+protocol: quota is account-level (it belongs to the machine's configured
+credentials, not to any session or bridge instance), and running status is a
+polling concern, not a stream. We decided to expose both as plain HTTP on the
+hub (ADR-0002's auth + discovery surface), leaving ACP for what it is good at
+— driving turns and streaming updates.
+
+`GET /api/quota` breaks ADR-0002's "the hub understands no business" rule
+deliberately and narrowly: the hub imports `accountUsageStats()` (the same
+function behind the `/quota` command and the `account/usage_stats` ACP method)
+and queries the usage APIs itself, with a ~30s TTL cache plus a single
+in-flight slot so polling clients cannot hammer the upstream. The alternative
+— proxying some bridge's `/quota` loopback route — was rejected because quota
+is machine-level, not instance-level: it must answer when every editor is
+closed (the hub outlives bridges until its idle exit), and making the client
+first pick a live instance to ask an account-level question is ceremony.
+Version drift is covered by the existing self-upgrade handshake: a hub older
+than a registering bridge restarts into the new code, so the direct query
+cannot go stale relative to the bridges it serves.
+
+Session status stays bridge-owned, on the pattern ADR-0004 set for `/fs`:
+the bridge serves `GET /status` on its loopback server — pure in-memory
+assembly (`sessionSummaries` membership + `pendingTurns` derivation, the same
+`turnActive` logic `session/load` uses, no backend RPC) — and the hub
+byte-proxies it at `GET /api/instances/{id}/status`. A coarse
+`sessions[].status` also rides the heartbeat so `/api/instances` renders a
+running indicator for free, at up to 10s staleness; the proxied endpoint is
+the fresh one. Both layers are additive: an older hub drops the heartbeat
+field, an older bridge just omits it.
+
+Deliberately out of scope for now: a `waiting_permission` status (the backend
+holds pending permission/AskUserQuestion requests, but not per-session
+indexed) and background-task details (the bridge tracks them per session for
+card rendering). Either can be added as a field on `/status` without a breaking
+change — clients are told to ignore unknown fields.

--- a/src/remote/endpoint.ts
+++ b/src/remote/endpoint.ts
@@ -29,7 +29,16 @@ import { WebSocketServer } from "ws";
 import type { ZcodeAcpServer } from "../server.js";
 import { AGENT_INFO, log, warn } from "../utils.js";
 import { createFileHandler } from "./file-endpoint.js";
+import { createStatusHandler, runningZcodeSids, type SessionRunStatus } from "./status-endpoint.js";
 import type { RemoteConfig } from "./config.js";
+
+/** One heartbeat/discovery session entry (ADR-0005 adds `status`). */
+interface AdvertisedSession {
+  sessionId: string;
+  title?: string;
+  updatedAt: number;
+  status: SessionRunStatus;
+}
 
 /** How often the bridge re-registers with the hub (also the heartbeat). */
 const HEARTBEAT_MS = 10_000;
@@ -85,12 +94,11 @@ function tryListen(server: Server, port: number): Promise<boolean> {
  * A failed `session/list` degrades to summaries-only so a backend hiccup
  * never blanks the discovery list.
  */
-export async function collectSessions(
-  server: ZcodeAcpServer,
-): Promise<Array<{ sessionId: string; title?: string; updatedAt: number }>> {
+export async function collectSessions(server: ZcodeAcpServer): Promise<AdvertisedSession[]> {
   // zcodeSid → freshest live entry (an editor tab and a remote attachment
   // can hold two acpSids for the same conversation).
   const live = new Map<string, { sessionId: string; title?: string; updatedAt: number }>();
+  const running = runningZcodeSids(server);
   for (const [acpSid, summary] of server.sessionSummaries) {
     if (!summary.hasActivity) continue;
     const zcodeSid = server.resolveSid(acpSid);
@@ -148,7 +156,12 @@ export async function collectSessions(
     }
   }
 
-  return Array.from(live.values()).sort((a, b) => b.updatedAt - a.updatedAt);
+  // `status` rides along on every heartbeat so /api/instances carries a
+  // coarse running indicator without a per-instance status round-trip
+  // (heartbeat granularity: up to 10s stale; /status serves it live).
+  return Array.from(live.entries())
+    .sort(([, a], [, b]) => b.updatedAt - a.updatedAt)
+    .map(([zcodeSid, s]) => ({ ...s, status: running.has(zcodeSid) ? "running" : "idle" }));
 }
 
 /** session/list timestamps: ms epoch (observed) or ISO string (defensive). */
@@ -184,11 +197,13 @@ export async function startRemoteEndpoint(
   const wss = new WebSocketServer({ noServer: true });
   const upgradeHandler = createNodeWebSocketUpgradeHandler(acpServer, wss);
   const fileHandler = createFileHandler(server);
+  const statusHandler = createStatusHandler(server);
 
   const httpServer = createServer((req, res) => {
     const path = new URL(req.url ?? "/", "http://127.0.0.1").pathname;
     if (path === "/acp") acpHttpHandler(req, res);
     else if (path.startsWith("/fs/")) fileHandler(req, res);
+    else if (path === "/status") statusHandler(req, res);
     else {
       res.writeHead(404, { "Content-Type": "text/plain" });
       res.end("not found");
@@ -228,7 +243,7 @@ export async function startRemoteEndpoint(
   let authRejected = false;
   let spawnThrottledUntil = 0;
 
-  const payload = (sessions: Array<{ sessionId: string; title?: string; updatedAt: number }>) => ({
+  const payload = (sessions: AdvertisedSession[]) => ({
     token: config.token,
     id: instanceId,
     port,
@@ -275,7 +290,7 @@ export async function startRemoteEndpoint(
 
   // Last-good session list: an unexpected collectSessions failure must not
   // blank the discovery payload, so we keep advertising the previous one.
-  let lastSessions: Array<{ sessionId: string; title?: string; updatedAt: number }> = [];
+  let lastSessions: AdvertisedSession[] = [];
 
   const registerOnce = async (): Promise<void> => {
     if (stopped || authRejected) return;

--- a/src/remote/hub-server.ts
+++ b/src/remote/hub-server.ts
@@ -2,10 +2,13 @@
  * zcode-acp-hub — machine-level singleton for remote access.
  *
  * The hub is the ONLY public entry point (the port a tunnel maps). It does
- * exactly three things (ADR-0002): token auth, instance discovery, and
- * byte-level WebSocket proxying from a remote client to one bridge's loopback
- * ACP endpoint. It holds no session state and understands no ACP — a proxied
- * connection stays bound to one instance for its whole lifetime.
+ * token auth, instance discovery, and byte-level WebSocket proxying from a
+ * remote client to one bridge's loopback ACP endpoint (ADR-0002), plus two
+ * plain-HTTP conveniences that spare clients a full ACP round-trip (ADR-0005):
+ * a proxied per-instance /status, and an account-level /api/quota queried
+ * directly (quota belongs to the machine's credentials, not to any instance).
+ * It holds no session state and understands no ACP — a proxied connection
+ * stays bound to one instance for its whole lifetime.
  *
  * Bridges register via POST /api/register every 10s (the registration doubles
  * as the heartbeat; entries older than the heartbeat TTL are pruned). A client
@@ -30,6 +33,7 @@ import net from "node:net";
 import { WebSocket, WebSocketServer, type RawData } from "ws";
 
 import { AGENT_INFO, compareVersions, log, warn } from "../utils.js";
+import { accountUsageStats, type UsageStatsResult } from "../handlers/account.js";
 
 export interface HubOptions {
   port: number;
@@ -52,6 +56,8 @@ interface SessionSummary {
   sessionId: string;
   title?: string;
   updatedAt: number;
+  /** Coarse running indicator from the bridge heartbeat (ADR-0005); absent on older bridges. */
+  status?: "running" | "idle";
 }
 
 interface InstanceEntry {
@@ -116,15 +122,55 @@ function validSessions(raw: unknown): SessionSummary[] | null {
   if (!Array.isArray(raw)) return null;
   const out: SessionSummary[] = [];
   for (const s of raw) {
-    const rec = s as { sessionId?: unknown; title?: unknown; updatedAt?: unknown };
+    const rec = s as {
+      sessionId?: unknown;
+      title?: unknown;
+      updatedAt?: unknown;
+      status?: unknown;
+    };
     if (typeof rec?.sessionId !== "string") return null;
     out.push({
       sessionId: rec.sessionId,
       ...(typeof rec.title === "string" ? { title: rec.title } : {}),
       updatedAt: typeof rec.updatedAt === "number" ? rec.updatedAt : Date.now(),
+      // Unknown values drop the field entirely (older bridges send none).
+      ...(rec.status === "running" || rec.status === "idle" ? { status: rec.status } : {}),
     });
   }
   return out;
+}
+
+/**
+ * Cached quota for GET /api/quota. Quota is account-level — it belongs to the
+ * machine's configured credentials, not to any bridge instance — so the hub
+ * queries it directly (ADR-0005) instead of proxying an ACP round-trip. The
+ * TTL + single in-flight slot keep polling clients from hammering the
+ * upstream usage APIs.
+ */
+const QUOTA_TTL_MS = 30_000;
+let quotaCache: { result: UsageStatsResult; at: number } | null = null;
+let quotaInflight: Promise<UsageStatsResult> | null = null;
+
+function getQuota(): Promise<UsageStatsResult> {
+  if (quotaCache && Date.now() - quotaCache.at < QUOTA_TTL_MS)
+    return Promise.resolve(quotaCache.result);
+  if (!quotaInflight) {
+    quotaInflight = accountUsageStats()
+      .then((result) => {
+        quotaCache = { result, at: Date.now() };
+        return result;
+      })
+      .finally(() => {
+        quotaInflight = null;
+      });
+  }
+  return quotaInflight;
+}
+
+/** Reset the quota cache (test helper). */
+export function resetQuotaCacheForTest(): void {
+  quotaCache = null;
+  quotaInflight = null;
 }
 
 /**
@@ -280,10 +326,31 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
       res.end(JSON.stringify(list));
       return;
     }
-    // /api/instances/{id}/fs/... — byte-level proxy to the instance's
-    // loopback file endpoint (ADR-0004). The hub routes by instance id only;
-    // sessionId, path semantics, and scope checks stay in the bridge.
-    const fsMatch = url.pathname.match(/^\/api\/instances\/([^/]+)(\/fs\/.*)$/);
+    if (url.pathname === "/api/quota" && req.method === "GET") {
+      if (!authorized(req, url, token)) {
+        res.writeHead(401, { "Content-Type": "text/plain" });
+        res.end("unauthorized");
+        return;
+      }
+      try {
+        const result = await getQuota();
+        res.writeHead(200, {
+          "Content-Type": "application/json",
+          // The hub-side TTL is the only caching layer; clients must not see stale copies.
+          "Cache-Control": "no-store",
+        });
+        res.end(JSON.stringify(result));
+      } catch {
+        res.writeHead(502, { "Content-Type": "text/plain" });
+        res.end("quota query failed");
+      }
+      return;
+    }
+    // /api/instances/{id}/fs/... and /status — byte-level proxy to the
+    // instance's loopback file/status endpoint (ADR-0004, ADR-0005). The hub
+    // routes by instance id only; sessionId, path semantics, and scope checks
+    // stay in the bridge.
+    const fsMatch = url.pathname.match(/^\/api\/instances\/([^/]+)(\/fs\/.*|\/status)$/);
     if (fsMatch && (req.method === "GET" || req.method === "HEAD")) {
       if (!authorized(req, url, token)) {
         res.writeHead(401, { "Content-Type": "text/plain" });

--- a/src/remote/status-endpoint.ts
+++ b/src/remote/status-endpoint.ts
@@ -1,0 +1,97 @@
+/**
+ * Live session status endpoint, served on the bridge's loopback HTTP server
+ * next to /acp and /fs, byte-proxied by the hub at
+ * /api/instances/{id}/status (ADR-0005).
+ *
+ *   GET /status — every live session with its running state
+ *
+ * Assembled purely from in-memory state (session summaries + pending turns):
+ * no backend RPC, so polling clients cost nothing. Title freshness stays the
+ * heartbeat's job (collectSessions enriches via session/list); the running
+ * state is the real-time part this endpoint exists for. Like /fs, the
+ * endpoint is loopback-only and unauthenticated — the hub is the single
+ * public entry and enforces the token.
+ */
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+import type { ZcodeAcpServer } from "../server.js";
+
+export type SessionRunStatus = "running" | "idle";
+
+export interface SessionStatusEntry {
+  sessionId: string;
+  title?: string;
+  status: SessionRunStatus;
+  updatedAt: number;
+}
+
+function sendText(res: ServerResponse, code: number, message: string): void {
+  if (res.writableEnded) return;
+  res.writeHead(code, { "Content-Type": "text/plain" });
+  res.end(message);
+}
+
+/**
+ * zcode session ids with a turn still in flight. Matches the `turnActive`
+ * derivation in `session/load`: a cancelled-but-finalising turn counts as
+ * running — the conversation is still busy until its loop unwinds.
+ */
+export function runningZcodeSids(server: ZcodeAcpServer): Set<string> {
+  const running = new Set<string>();
+  for (const turn of server.pendingTurns.values()) running.add(turn.zcodeSid);
+  return running;
+}
+
+/**
+ * Live sessions with their running state. Membership matches collectSessions:
+ * `hasActivity` summaries that resolve to a backend session — lazy
+ * placeholders that never ran a turn stay invisible.
+ */
+export function collectStatus(server: ZcodeAcpServer): { sessions: SessionStatusEntry[] } {
+  const running = runningZcodeSids(server);
+  const sessions: SessionStatusEntry[] = [];
+  for (const [acpSid, summary] of server.sessionSummaries) {
+    if (!summary.hasActivity) continue;
+    const zcodeSid = server.resolveSid(acpSid);
+    if (!zcodeSid) continue; // pure placeholder — no backend session behind it
+    sessions.push({
+      sessionId: acpSid,
+      ...(summary.title !== undefined ? { title: summary.title } : {}),
+      status: running.has(zcodeSid) ? "running" : "idle",
+      updatedAt: summary.updatedAt,
+    });
+  }
+  sessions.sort((a, b) => b.updatedAt - a.updatedAt);
+  return { sessions };
+}
+
+/**
+ * Build the /status request handler for the loopback endpoint. Synchronous
+ * assembly means the only failure paths are serialization — still answered
+ * with a status code, never thrown into the event loop.
+ */
+export function createStatusHandler(
+  server: ZcodeAcpServer,
+): (req: IncomingMessage, res: ServerResponse) => void {
+  return (req, res) => {
+    if (req.method !== "GET" && req.method !== "HEAD") {
+      sendText(res, 405, "method not allowed");
+      return;
+    }
+    let body: string;
+    try {
+      body = JSON.stringify(collectStatus(server));
+    } catch {
+      sendText(res, 500, "internal error");
+      return;
+    }
+    res.writeHead(200, {
+      "Content-Type": "application/json",
+      "Content-Length": Buffer.byteLength(body),
+      // Polling clients must always see the freshest state.
+      "Cache-Control": "no-store",
+    });
+    res.end(req.method === "HEAD" ? undefined : body);
+  };
+}

--- a/tests/hub.test.ts
+++ b/tests/hub.test.ts
@@ -4,13 +4,22 @@
  * idle-exit policy.
  */
 
+import { createServer, type Server } from "node:http";
 import net from "node:net";
 
 import { WebSocket, WebSocketServer } from "ws";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { startHub, type HubHandle } from "../src/remote/hub-server.js";
+// The quota endpoint must not touch the real usage APIs in tests.
+const { accountUsageStatsMock } = vi.hoisted(() => ({
+  accountUsageStatsMock: vi.fn(),
+}));
+vi.mock("../src/handlers/account.js", () => ({
+  accountUsageStats: accountUsageStatsMock,
+}));
+
+import { resetQuotaCacheForTest, startHub, type HubHandle } from "../src/remote/hub-server.js";
 
 const TOKEN = "test-hub-token";
 const BASE_PORT = 18400; // bridge ports start here; ephemeral hub uses port 0
@@ -61,6 +70,11 @@ function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise
     new Promise<T>((_, reject) => setTimeout(() => reject(new Error(`${label} timed out`)), ms)),
   ]);
 }
+
+const QUOTA_FIXTURE = {
+  glm: { kind: "success", level: "Max", items: [] },
+  opencode: { kind: "not_configured" },
+};
 
 describe("hub discovery API", () => {
   it("answers health without auth", async () => {
@@ -322,6 +336,161 @@ describe("hub WS proxy", () => {
       await withTimeout(closed, 3000, "ws reject");
       expect(client.readyState).not.toBe(WebSocket.OPEN);
     }
+  });
+});
+
+describe("hub quota endpoint", () => {
+  const quotaUrl = (hub: HubHandle) => `http://127.0.0.1:${hub.port}/api/quota`;
+
+  beforeEach(() => {
+    accountUsageStatsMock.mockReset();
+    resetQuotaCacheForTest();
+  });
+
+  it("rejects /api/quota without or with a wrong token", async () => {
+    const hub = await startTestHub();
+    expect((await fetch(quotaUrl(hub))).status).toBe(401);
+    expect(
+      (await fetch(quotaUrl(hub), { headers: { Authorization: "Bearer wrong" } })).status,
+    ).toBe(401);
+    expect(accountUsageStatsMock).not.toHaveBeenCalled();
+  });
+
+  it("returns the usage-stats payload verbatim", async () => {
+    const hub = await startTestHub();
+    accountUsageStatsMock.mockResolvedValueOnce(QUOTA_FIXTURE);
+    const res = await fetch(quotaUrl(hub), { headers: { Authorization: `Bearer ${TOKEN}` } });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/json");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(await res.json()).toEqual(QUOTA_FIXTURE);
+    expect(accountUsageStatsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("serves the cached copy within the TTL", async () => {
+    const hub = await startTestHub();
+    accountUsageStatsMock.mockResolvedValue(QUOTA_FIXTURE);
+    const headers = { Authorization: `Bearer ${TOKEN}` };
+    const first = await fetch(quotaUrl(hub), { headers });
+    const second = await fetch(quotaUrl(hub), { headers });
+    expect(await first.json()).toEqual(QUOTA_FIXTURE);
+    expect(await second.json()).toEqual(QUOTA_FIXTURE);
+    expect(accountUsageStatsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("answers 502 when the quota query fails, without caching the failure", async () => {
+    const hub = await startTestHub();
+    accountUsageStatsMock.mockRejectedValueOnce(new Error("upstream down"));
+    const res = await fetch(quotaUrl(hub), { headers: { Authorization: `Bearer ${TOKEN}` } });
+    expect(res.status).toBe(502);
+
+    accountUsageStatsMock.mockResolvedValueOnce(QUOTA_FIXTURE);
+    const retry = await fetch(quotaUrl(hub), { headers: { Authorization: `Bearer ${TOKEN}` } });
+    expect(retry.status).toBe(200);
+  });
+
+  it("falls through to 404 for non-GET methods", async () => {
+    const hub = await startTestHub();
+    const res = await fetch(quotaUrl(hub), {
+      method: "POST",
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    expect(res.status).toBe(404);
+    expect(accountUsageStatsMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("hub status proxy", () => {
+  /** Fake bridge loopback HTTP server serving GET /status. */
+  function startStatusBridge(body: string): Promise<{ server: Server; port: number }> {
+    return new Promise((resolve) => {
+      const server = createServer((req, res) => {
+        if (req.method === "GET" && req.url === "/status") {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(body);
+        } else {
+          res.writeHead(404, { "Content-Type": "text/plain" });
+          res.end("not found");
+        }
+      });
+      server.listen(0, "127.0.0.1", () => {
+        const addr = server.address();
+        resolve({ server, port: typeof addr === "object" && addr ? addr.port : 0 });
+      });
+    });
+  }
+
+  async function registerBridge(hub: HubHandle, port: number): Promise<void> {
+    const res = await fetch(`http://127.0.0.1:${hub.port}/api/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(registerBody({ port })),
+    });
+    expect(res.status).toBe(200);
+  }
+
+  it("byte-proxies /api/instances/{id}/status to the bridge", async () => {
+    const hub = await startTestHub();
+    const bridge = track(
+      await startStatusBridge(
+        JSON.stringify({ sessions: [{ sessionId: "s1", status: "running" }] }),
+      ),
+      ({ server }) => new Promise<void>((resolve) => server.close(() => resolve())),
+    );
+    await registerBridge(hub, bridge.port);
+
+    const res = await fetch(`http://127.0.0.1:${hub.port}/api/instances/inst-1/status`, {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/json");
+    expect(await res.json()).toEqual({ sessions: [{ sessionId: "s1", status: "running" }] });
+  });
+
+  it("rejects the status proxy without a token", async () => {
+    const hub = await startTestHub();
+    expect((await fetch(`http://127.0.0.1:${hub.port}/api/instances/inst-1/status`)).status).toBe(
+      401,
+    );
+  });
+
+  it("answers 404 for an unknown instance", async () => {
+    const hub = await startTestHub();
+    const res = await fetch(`http://127.0.0.1:${hub.port}/api/instances/nope/status`, {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("answers 502 when the bridge is unreachable", async () => {
+    const hub = await startTestHub();
+    await registerBridge(hub, BASE_PORT); // nothing listens there
+    const res = await fetch(`http://127.0.0.1:${hub.port}/api/instances/inst-1/status`, {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    expect(res.status).toBe(502);
+  });
+});
+
+describe("hub discovery status field", () => {
+  it("passes a valid session status through and strips an invalid one", async () => {
+    const hub = await startTestHub();
+    const post = (sessions: unknown) =>
+      fetch(`http://127.0.0.1:${hub.port}/api/register`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(registerBody({ sessions })),
+      });
+
+    await post([{ sessionId: "s1", title: "hello", updatedAt: 1, status: "running" }]);
+    const list = () =>
+      listInstances(hub).then(
+        (r) => r.json() as Promise<Array<{ sessions: Array<Record<string, unknown>> }>>,
+      );
+    expect((await list())[0]!.sessions[0]).toMatchObject({ sessionId: "s1", status: "running" });
+
+    await post([{ sessionId: "s1", title: "hello", updatedAt: 1, status: "bogus" }]);
+    expect((await list())[0]!.sessions[0]!["status"]).toBeUndefined();
   });
 });
 

--- a/tests/remote-endpoint.test.ts
+++ b/tests/remote-endpoint.test.ts
@@ -355,10 +355,9 @@ describe("running-scoped discovery payload (collectSessions)", () => {
     server.registerSession("s", "zc");
     server.markSessionActive("s");
 
-    expect(Object.keys((await collectSessions(server))[0]!).sort()).toEqual([
-      "sessionId",
-      "updatedAt",
-    ]);
+    const [entry] = await collectSessions(server);
+    expect(Object.keys(entry!).sort()).toEqual(["sessionId", "status", "updatedAt"]);
+    expect(entry!.status).toBe("idle"); // no pending turn
   });
 });
 

--- a/tests/remote-status-endpoint.test.ts
+++ b/tests/remote-status-endpoint.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Session status endpoint (ADR-0005): the bridge-side /status handler,
+ * exercised through a real loopback HTTP server backed by an in-memory
+ * ZcodeAcpServer. Proves the running/idle derivation from pendingTurns and
+ * the membership gates (hasActivity, resolvable sid), plus the handler's
+ * method handling.
+ */
+
+import { randomUUID } from "node:crypto";
+import { createServer, type Server } from "node:http";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createStatusHandler } from "../src/remote/status-endpoint.js";
+import { ZcodeAcpServer } from "../src/server.js";
+
+const cleanups: Array<() => Promise<void> | void> = [];
+
+function trackStop(stop: () => Promise<void> | void): void {
+  cleanups.push(stop);
+}
+
+afterEach(async () => {
+  while (cleanups.length) {
+    const stop = cleanups.pop()!;
+    await stop();
+  }
+});
+
+/** Boot the status handler on an ephemeral port; returns its base URL. */
+async function bootStatus(server: ZcodeAcpServer): Promise<string> {
+  const handler = createStatusHandler(server);
+  const httpServer: Server = createServer((req, res) => handler(req, res));
+  await new Promise<void>((resolve) => httpServer.listen(0, "127.0.0.1", resolve));
+  trackStop(() => new Promise<void>((resolve) => httpServer.close(() => resolve())));
+  const addr = httpServer.address();
+  return `http://127.0.0.1:${typeof addr === "object" && addr ? addr.port : 0}`;
+}
+
+/** Seed one live session; returns both ids so tests can drive pendingTurns. */
+function seedSession(
+  server: ZcodeAcpServer,
+  opts: { title?: string; updatedAt?: number } = {},
+): { acpSid: string; zcodeSid: string } {
+  const acpSid = randomUUID();
+  const zcodeSid = `zc-${randomUUID().slice(0, 8)}`;
+  server.registerSession(acpSid, zcodeSid);
+  server.markSessionActive(acpSid);
+  if (opts.title !== undefined) server.touchSessionSummary(acpSid, opts.title);
+  if (opts.updatedAt !== undefined) {
+    const summary = server.sessionSummaries.get(acpSid)!;
+    server.sessionSummaries.set(acpSid, { ...summary, updatedAt: opts.updatedAt });
+  }
+  return { acpSid, zcodeSid };
+}
+
+interface StatusBody {
+  sessions: Array<{ sessionId: string; title?: string; status: string; updatedAt: number }>;
+}
+
+async function getStatus(base: string): Promise<StatusBody> {
+  const res = await fetch(base + "/status");
+  expect(res.status).toBe(200);
+  expect(res.headers.get("Content-Type")).toContain("application/json");
+  expect(res.headers.get("Cache-Control")).toBe("no-store");
+  return (await res.json()) as StatusBody;
+}
+
+describe("status endpoint derivation", () => {
+  it("reports idle for a live session with no in-flight turn", async () => {
+    const server = new ZcodeAcpServer();
+    const { acpSid } = seedSession(server, { title: "hello" });
+    const base = await bootStatus(server);
+
+    const body = await getStatus(base);
+    expect(body.sessions).toHaveLength(1);
+    expect(body.sessions[0]).toMatchObject({ sessionId: acpSid, title: "hello", status: "idle" });
+  });
+
+  it("reports running while a turn is pending for the session", async () => {
+    const server = new ZcodeAcpServer();
+    const { zcodeSid } = seedSession(server);
+    server.pendingTurns.set(42, { zcodeSid, cancelled: false });
+    const base = await bootStatus(server);
+
+    expect((await getStatus(base)).sessions[0]!.status).toBe("running");
+  });
+
+  it("counts a cancelled-but-finalising turn as running (turnActive parity)", async () => {
+    const server = new ZcodeAcpServer();
+    const { zcodeSid } = seedSession(server);
+    server.pendingTurns.set(42, { zcodeSid, cancelled: true, stopSent: true });
+    const base = await bootStatus(server);
+
+    expect((await getStatus(base)).sessions[0]!.status).toBe("running");
+  });
+
+  it("hides sessions without activity or without a backend mapping", async () => {
+    const server = new ZcodeAcpServer();
+    seedSession(server, { title: "live" });
+    // Registered but never used: hasActivity stays false.
+    const unused = randomUUID();
+    server.registerSession(unused, "zc-unused");
+    // Active summary with no acp→zcode mapping (pure placeholder).
+    const placeholder = randomUUID();
+    server.sessionSummaries.set(placeholder, { title: "ghost", updatedAt: 1, hasActivity: true });
+    const base = await bootStatus(server);
+
+    const body = await getStatus(base);
+    expect(body.sessions.map((s) => s.title)).toEqual(["live"]);
+  });
+
+  it("lists newest-updated sessions first and omits an unset title", async () => {
+    const server = new ZcodeAcpServer();
+    seedSession(server, { title: "older", updatedAt: 1000 });
+    seedSession(server, { updatedAt: 2000 }); // no title
+    const base = await bootStatus(server);
+
+    const body = await getStatus(base);
+    expect(body.sessions).toHaveLength(2);
+    expect(body.sessions[0]!.updatedAt).toBeGreaterThanOrEqual(body.sessions[1]!.updatedAt);
+    expect(body.sessions.find((s) => s.updatedAt === 2000)).not.toHaveProperty("title");
+  });
+
+  it("answers an empty list when nothing is live", async () => {
+    const base = await bootStatus(new ZcodeAcpServer());
+    expect(await getStatus(base)).toEqual({ sessions: [] });
+  });
+});
+
+describe("status endpoint HTTP handling", () => {
+  it("serves HEAD with headers but no body", async () => {
+    const server = new ZcodeAcpServer();
+    seedSession(server, { title: "x" });
+    const base = await bootStatus(server);
+
+    const res = await fetch(base + "/status", { method: "HEAD" });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/json");
+    expect(await res.text()).toBe("");
+  });
+
+  it("rejects non-GET methods with 405", async () => {
+    const base = await bootStatus(new ZcodeAcpServer());
+
+    const res = await fetch(base + "/status", { method: "POST" });
+    expect(res.status).toBe(405);
+  });
+});


### PR DESCRIPTION
## Background

Remote clients (the mobile app) had to open a full ACP WebSocket — connect, `initialize`, request, disconnect — to read account quota or per-session running status. Both are poor fits for the session protocol: quota is account-level (the machine's credentials, not any session/instance), and running status is a polling concern, not a stream.

## Changes

- **`GET /api/quota`** (hub): queries `accountUsageStats()` directly — the same function behind the `/quota` command and the `account/usage_stats` ACP method — with a ~30s TTL cache plus a single in-flight slot so polling can't hammer the upstream. Response body is identical to the ACP method's result, so clients reuse one parser. The ACP method stays for attached editors.
- **`GET /status`** (bridge loopback, new `src/remote/status-endpoint.ts`): pure in-memory assembly — `sessionSummaries` membership + `pendingTurns` derivation (same `turnActive` logic as `session/load`), no backend RPC, safe to poll at 1–2s.
- **`GET /api/instances/{id}/status`** (hub): byte-level proxy to the bridge route, same pattern and error semantics as `/fs` (401 / 404 unknown instance / 502 unreachable).
- **Heartbeat `status` field**: `sessions[]` entries carry a coarse `running | idle`; hub `validSessions` passes valid values through and strips invalid ones. Compatible both directions (older hub drops the field; older bridge omits it).
- **Docs**: new endpoint chapters + 502 troubleshooting row in `REMOTE-CLIENTS.md`, architecture summary, and `docs/adr/0005-http-quota-and-status-endpoints.md` recording why the hub queries quota directly (machine-level concern, must answer with zero bridges alive; version drift covered by the existing self-upgrade handshake).

Out of scope (noted in the ADR as additive extensions): `waiting_permission` status, background-task details.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, full suite green (644 tests, +17 new)
- [x] hub quota: 401, payload passthrough, TTL cache hit, 502 without caching the failure, non-GET falls through to 404
- [x] hub status proxy: byte passthrough, 401, 404 unknown instance, 502 dead bridge
- [x] discovery status field: valid passes through, invalid stripped
- [x] bridge /status: running/idle derivation incl. cancelled-but-finalising parity, membership gates, ordering, HEAD/405