### PR TITLE
feat: remote session close via HTTP with running guard and self-healing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-08-20
+
+### Added
+
+- Remote session close (ADR-0006): `POST /api/instances/{id}/sessions/{sessionId}/close`
+  retires a conversation from remote discovery once the editor tab that owned it
+  is gone. The hub byte-proxies to the bridge's loopback
+  `POST /sessions/{id}/close`, which drops the in-memory summary so the session
+  vanishes from `/status` and the next heartbeat. A session with a running turn
+  answers `409` (cancel the turn first); an unknown session answers `404`. The
+  bridge cannot observe which sessions still exist on the editor side, so close
+  is self-healing instead of destructive: any later prompt or `session/load`
+  that touches the conversation re-arms the entry and it reappears in discovery
+  — an editor-side tab that is actually alive cannot be closed out from under
+  it.
+
 ## [0.8.0] - 2026-08-20
 
 ### Added

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -197,14 +197,15 @@ API only because the ZCode backend itself sends them for inference.
 
 ### `remote/` — Remote access (opt-in via `ZCODE_ACP_REMOTE=1`)
 
-| File                 | Responsibility                                                                                                                                                                                         |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `broadcast.ts`       | ClientRegistry + broadcast proxy: notify fans out to all clients; request is first-response-wins with loser `$/cancel_request`                                                                         |
-| `config.ts`          | ENV parsing (gate, mandatory token, hub/bridge ports)                                                                                                                                                  |
-| `endpoint.ts`        | Loopback ACP endpoint (SDK AcpServer transport, port auto-increment) + hub registration/heartbeat                                                                                                      |
-| `file-endpoint.ts`   | Read-only `GET /fs/list` + `GET /fs/file` on the loopback server (ADR-0004): Session Root scoping, byte/line windows, streaming                                                                        |
-| `status-endpoint.ts` | `GET /status` on the loopback server (ADR-0005): in-memory per-session running state (`pendingTurns` derivation), zero backend RPC                                                                     |
-| `hub-server.ts`      | The hub singleton: token auth, instance discovery, byte-level WS proxying, heartbeat pruning, on-demand `?probe=1` liveness, idle exit, version self-upgrade, `GET /api/quota` direct query (ADR-0005) |
+| File                        | Responsibility                                                                                                                                                                                                                      |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `broadcast.ts`              | ClientRegistry + broadcast proxy: notify fans out to all clients; request is first-response-wins with loser `$/cancel_request`                                                                                                      |
+| `config.ts`                 | ENV parsing (gate, mandatory token, hub/bridge ports)                                                                                                                                                                               |
+| `endpoint.ts`               | Loopback ACP endpoint (SDK AcpServer transport, port auto-increment) + hub registration/heartbeat                                                                                                                                   |
+| `file-endpoint.ts`          | Read-only `GET /fs/list` + `GET /fs/file` on the loopback server (ADR-0004): Session Root scoping, byte/line windows, streaming                                                                                                     |
+| `status-endpoint.ts`        | `GET /status` on the loopback server (ADR-0005): in-memory per-session running state (`pendingTurns` derivation), zero backend RPC                                                                                                  |
+| `session-close-endpoint.ts` | `POST /sessions/{id}/close` on the loopback server (ADR-0006): running-guarded discovery retirement with self-healing re-appearance                                                                                                 |
+| `hub-server.ts`             | The hub singleton: token auth, instance discovery, byte-level WS proxying, heartbeat pruning, on-demand `?probe=1` liveness, idle exit, version self-upgrade, `GET /api/quota` direct query (ADR-0005), POST close proxy (ADR-0006) |
 
 When enabled, the same `AgentApp` serves the stdio editor and a loopback
 WebSocket endpoint. Every connection (editor or remote) joins the broadcast
@@ -238,7 +239,10 @@ can poll without an ACP connection: the bridge's `GET /status` (pure in-memory
 assembly) is proxied at `/api/instances/{id}/status` and echoed coarsely in
 each heartbeat (`sessions[].status`), while `GET /api/quota` is queried by the
 hub itself — quota belongs to the machine's credentials, not to any instance,
-so it works with zero bridges registered.
+so it works with zero bridges registered. Session close (ADR-0006) is the
+surface's first write op: `POST /api/instances/{id}/sessions/{sid}/close`
+retires a conversation from discovery (running-guarded, self-healing if the
+editor still has it open).
 
 ## Key State Machines
 

--- a/docs/REMOTE-CLIENTS.md
+++ b/docs/REMOTE-CLIENTS.md
@@ -46,12 +46,13 @@ ACP editor ────── stdio ──────────┘
 
 ## Discovery API
 
-| Endpoint                         | Auth     | Purpose                                                                                      |
-| -------------------------------- | -------- | -------------------------------------------------------------------------------------------- |
-| `GET /api/health`                | none     | Liveness probe; `200` body `ok`.                                                             |
-| `GET /api/instances`             | required | Registered bridge instances. Add `?probe=1` to verify first.                                 |
-| `GET /api/instances/{id}/status` | required | Real-time per-session running status of one bridge.                                          |
-| `GET /api/quota`                 | required | Account-level usage stats — same payload as `account/usage_stats`, no ACP connection needed. |
+| Endpoint                                              | Auth     | Purpose                                                                                      |
+| ----------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------- |
+| `GET /api/health`                                     | none     | Liveness probe; `200` body `ok`.                                                             |
+| `GET /api/instances`                                  | required | Registered bridge instances. Add `?probe=1` to verify first.                                 |
+| `GET /api/instances/{id}/status`                      | required | Real-time per-session running status of one bridge.                                          |
+| `POST /api/instances/{id}/sessions/{sessionId}/close` | required | Retire a session from remote discovery — see [Closing a session](#closing-a-session).        |
+| `GET /api/quota`                                      | required | Account-level usage stats — same payload as `account/usage_stats`, no ACP connection needed. |
 
 HTTP auth: `Authorization: Bearer <token>` or `?token=<token>`.
 
@@ -256,6 +257,39 @@ Two layers (ADR-0005), both plain HTTP — no ACP connection needed:
   `/api/instances` may be fresher for cross-bridge conversations.
 - Errors: `401` bad token, `404` unknown instance, `502` bridge unreachable.
   `HEAD` is supported.
+
+## Closing a session
+
+```text
+POST {hub}/api/instances/{id}/sessions/{sessionId}/close   → 200 { "ok": true }
+```
+
+Retires a conversation from remote discovery. This addresses a protocol gap:
+ACP has no editor→agent "tab closed" notification, so a conversation retired
+on the editor side stays in this bridge's in-memory summary — and therefore
+in your list — until the bridge restarts. Closing clears the summary.
+
+**Closing is not deletion.** The backend session store, the editor's own
+conversation storage, and the App's tasks-index are untouched; only remote
+visibility changes. Two guards shape the semantics (ADR-0006):
+
+- A session with a **running turn is refused** (`409`) — cancel the turn
+  first.
+- **Self-healing**: if the editor side actually still has the conversation
+  open, its next activity there (any prompt, any load with history)
+  re-marks it active and it REAPPEARS in discovery within one heartbeat.
+  So a wrongly closed conversation recovers on its own, while an
+  editor-side-retired one stays gone. A bridge restart auto-resume alone
+  does NOT resurrect a closed session — real use does.
+
+Errors: `401` bad token, `404` unknown session (or instance), `409` running,
+`502` bridge unreachable. Takes effect immediately in
+`/api/instances/{id}/status` and within one heartbeat (≤10s) in
+`/api/instances`.
+
+Cross-instance note: if the same conversation is also registered by another
+bridge of the project, the hub's dedupe re-attaches it under that instance —
+close it there too.
 
 ## Session files (read-only)
 

--- a/docs/adr/0006-remote-session-close.md
+++ b/docs/adr/0006-remote-session-close.md
@@ -1,0 +1,36 @@
+# Remote session close: a write op on the discovery surface
+
+Remote lists accumulated conversations the editor side had long retired: ACP
+has no editor→agent "tab closed" notification, so the bridge's in-memory
+`sessionSummaries` (the only membership source for both the heartbeat and
+`/status`) never loses an entry once it gains activity. Until this decision
+the only cleanup was a bridge restart. We decided to expose
+`POST /api/instances/{id}/sessions/{sessionId}/close` — the remote HTTP
+surface's first WRITE operation — which deletes the session's summary and
+nothing else.
+
+The semantics are "close", not "delete": the backend session store, the
+editor's conversation storage, and the App's tasks-index are untouched. What
+makes this safe where ADR-0004 kept `/fs` read-only: retiring a summary only
+changes discovery visibility. Token holders can already drive arbitrary agent
+work through the permission flow; a visibility toggle adds no capability.
+
+The requested guard — "only close sessions the editor side no longer has" —
+cannot be a precondition check: tab open/closed is unobservable from the
+bridge (Zed sends nothing on close). It is instead enforced by the
+`hasActivity` gate's natural re-arm: a closed entry loses its summary, and
+`markSessionActive` — any prompt, any load with history — recreates it. A
+wrongly closed conversation reappears within one heartbeat of the editor
+touching it; an editor-side-retired one stays gone. The one observable
+in-use signal, a pending turn, is rejected outright (409). A bridge-restart
+auto-resume alone does not resurrect a closed session — `registerSession`
+writes a summary with `hasActivity` unset.
+
+The hub stays a router (ADR-0002): the POST is forwarded by instance id and
+session id only; the running guard and retirement semantics live in the
+bridge. One implementation note for future write proxies: aborting the
+upstream on the inbound request's `'close'` event resets the bridge socket —
+an empty POST body drains and closes before the relayed response finishes
+writing, so every proxied close died with ECONNRESET/502. Abort on the
+RESPONSE side closing early (`res` `'close'` with `writableEnded` false)
+instead.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zcode-acp-server",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Agent Client Protocol (ACP) server bridging headless ZCode to editors like Zed and JetBrains.",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/remote/endpoint.ts
+++ b/src/remote/endpoint.ts
@@ -29,6 +29,7 @@ import { WebSocketServer } from "ws";
 import type { ZcodeAcpServer } from "../server.js";
 import { AGENT_INFO, log, warn } from "../utils.js";
 import { createFileHandler } from "./file-endpoint.js";
+import { createSessionCloseHandler } from "./session-close-endpoint.js";
 import { createStatusHandler, runningZcodeSids, type SessionRunStatus } from "./status-endpoint.js";
 import type { RemoteConfig } from "./config.js";
 
@@ -198,12 +199,15 @@ export async function startRemoteEndpoint(
   const upgradeHandler = createNodeWebSocketUpgradeHandler(acpServer, wss);
   const fileHandler = createFileHandler(server);
   const statusHandler = createStatusHandler(server);
+  const sessionCloseHandler = createSessionCloseHandler(server);
 
   const httpServer = createServer((req, res) => {
     const path = new URL(req.url ?? "/", "http://127.0.0.1").pathname;
+    const closeMatch = path.match(/^\/sessions\/([^/]+)\/close$/);
     if (path === "/acp") acpHttpHandler(req, res);
     else if (path.startsWith("/fs/")) fileHandler(req, res);
     else if (path === "/status") statusHandler(req, res);
+    else if (closeMatch) sessionCloseHandler(req, res, closeMatch[1]!);
     else {
       res.writeHead(404, { "Content-Type": "text/plain" });
       res.end("not found");

--- a/src/remote/hub-server.ts
+++ b/src/remote/hub-server.ts
@@ -24,6 +24,7 @@ import { createHash, timingSafeEqual } from "node:crypto";
 import {
   createServer,
   get as httpGet,
+  request as httpRequest,
   type IncomingMessage,
   type Server,
   type ServerResponse,
@@ -382,6 +383,56 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
         }
       });
       req.on("close", () => upstream.destroy());
+      return;
+    }
+    // POST /api/instances/{id}/sessions/{sid}/close — the remote HTTP
+    // surface's first write op (ADR-0006): forward-and-relay to the bridge's
+    // loopback close route. The hub still routes by instance id only; close
+    // semantics (running guard, discovery retirement) stay in the bridge.
+    const closeMatch = url.pathname.match(/^\/api\/instances\/([^/]+)\/sessions\/([^/]+)\/close$/);
+    if (closeMatch && req.method === "POST") {
+      if (!authorized(req, url, token)) {
+        res.writeHead(401, { "Content-Type": "text/plain" });
+        res.end("unauthorized");
+        return;
+      }
+      const entry = instances.get(closeMatch[1]!);
+      if (!entry) {
+        res.writeHead(404, { "Content-Type": "text/plain" });
+        res.end("unknown instance");
+        return;
+      }
+      const upstream = httpRequest(
+        {
+          host: "127.0.0.1",
+          port: entry.port,
+          path: `/sessions/${closeMatch[2]}/close`,
+          method: "POST",
+        },
+        (up) => {
+          const headers = { ...up.headers };
+          delete headers["transfer-encoding"];
+          delete headers.connection;
+          res.writeHead(up.statusCode ?? 502, headers);
+          up.pipe(res);
+        },
+      );
+      upstream.on("error", () => {
+        if (res.headersSent) res.destroy();
+        else {
+          res.writeHead(502, { "Content-Type": "text/plain" });
+          res.end("bridge unreachable");
+        }
+      });
+      // Abort the upstream only when the CLIENT side dies mid-response.
+      // `req`'s own 'close' fires once the (usually empty) body is drained —
+      // typically BEFORE the relayed response finishes writing — so keying on
+      // it resets the bridge socket on every request (ECONNRESET → 502).
+      res.on("close", () => {
+        if (!res.writableEnded) upstream.destroy();
+      });
+      // Relay any request body through (clients normally send none).
+      req.pipe(upstream);
       return;
     }
     if (

--- a/src/remote/session-close-endpoint.ts
+++ b/src/remote/session-close-endpoint.ts
@@ -1,0 +1,80 @@
+/**
+ * Remote session close endpoint (ADR-0006), served on the bridge's loopback
+ * HTTP server and byte-proxied by the hub at
+ * POST /api/instances/{id}/sessions/{sessionId}/close.
+ *
+ * Closing RETIRES a session from remote discovery — it is not deletion. The
+ * backend store, the editor's own conversation storage, and the App's
+ * tasks-index are untouched. Why it exists: the ACP protocol has no
+ * editor→agent "tab closed" notification, so a conversation retired on the
+ * editor side stays advertised by this bridge's in-memory summary forever.
+ *
+ * The "editor side still has it open" guard cannot be a precondition check
+ * (unobservable); it is the hasActivity gate's natural re-arm instead: a
+ * closed entry loses its summary, and `markSessionActive` (any prompt, any
+ * load with history) recreates it — so a wrongly closed conversation
+ * reappears the moment the editor touches it, while an editor-side-retired
+ * one stays gone. A running turn is the one case we CAN observe and reject.
+ */
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+import type { ZcodeAcpServer } from "../server.js";
+import { log } from "../utils.js";
+
+function sendText(res: ServerResponse, code: number, message: string): void {
+  if (res.writableEnded) return;
+  res.writeHead(code, { "Content-Type": "text/plain" });
+  res.end(message);
+}
+
+function sendJson(res: ServerResponse, code: number, body: Record<string, unknown>): void {
+  const payload = JSON.stringify(body);
+  res.writeHead(code, {
+    "Content-Type": "application/json",
+    "Content-Length": Buffer.byteLength(payload),
+  });
+  res.end(payload);
+}
+
+async function handleClose(
+  server: ZcodeAcpServer,
+  req: IncomingMessage,
+  res: ServerResponse,
+  sessionId: string,
+): Promise<void> {
+  // Consume any request body so the client's connection drains cleanly.
+  req.resume();
+
+  if (!server.sessionSummaries.has(sessionId)) {
+    sendText(res, 404, "unknown session");
+    return;
+  }
+  const zcodeSid = server.resolveSid(sessionId);
+  if (zcodeSid && [...server.pendingTurns.values()].some((t) => t.zcodeSid === zcodeSid)) {
+    sendText(res, 409, "session is running — cancel the turn first");
+    return;
+  }
+  server.sessionSummaries.delete(sessionId);
+  log(`remote: session ${sessionId.slice(0, 8)} closed from remote (discovery retired)`);
+  sendJson(res, 200, { ok: true });
+}
+
+/**
+ * Build the /sessions/{id}/close request handler for the loopback endpoint.
+ * Async failures degrade to a status code, never into the event loop.
+ */
+export function createSessionCloseHandler(
+  server: ZcodeAcpServer,
+): (req: IncomingMessage, res: ServerResponse, sessionId: string) => void {
+  return (req, res, sessionId) => {
+    if (req.method !== "POST") {
+      sendText(res, 405, "method not allowed");
+      return;
+    }
+    void handleClose(server, req, res, sessionId).catch(() => {
+      if (res.headersSent) res.destroy();
+      else sendText(res, 500, "internal error");
+    });
+  };
+}

--- a/tests/hub.test.ts
+++ b/tests/hub.test.ts
@@ -494,6 +494,88 @@ describe("hub discovery status field", () => {
   });
 });
 
+describe("hub session close proxy", () => {
+  /** Fake bridge loopback HTTP server accepting POST /sessions/{id}/close. */
+  function startCloseBridge(): Promise<{ server: Server; port: number }> {
+    return new Promise((resolve) => {
+      const server = createServer((req, res) => {
+        const sid = new URL(req.url ?? "/", "http://127.0.0.1").pathname.split("/")[2];
+        if (req.method === "POST" && req.url === `/sessions/${sid}/close`) {
+          req.resume();
+          res.writeHead(sid === "s-busy" ? 409 : 200, { "Content-Type": "application/json" });
+          res.end(sid === "s-busy" ? "session is running" : '{"ok":true}');
+        } else {
+          res.writeHead(404, { "Content-Type": "text/plain" });
+          res.end("not found");
+        }
+      });
+      server.listen(0, "127.0.0.1", () => {
+        const addr = server.address();
+        resolve({ server, port: typeof addr === "object" && addr ? addr.port : 0 });
+      });
+    });
+  }
+
+  async function registerBridge(hub: HubHandle, port: number): Promise<void> {
+    const res = await fetch(`http://127.0.0.1:${hub.port}/api/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(registerBody({ port })),
+    });
+    expect(res.status).toBe(200);
+  }
+
+  it("forwards the close POST and relays the bridge's response", async () => {
+    const hub = await startTestHub();
+    const bridge = track(
+      await startCloseBridge(),
+      ({ server }) => new Promise<void>((resolve) => server.close(() => resolve())),
+    );
+    await registerBridge(hub, bridge.port);
+
+    const ok = await fetch(`http://127.0.0.1:${hub.port}/api/instances/inst-1/sessions/s1/close`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    expect(ok.status).toBe(200);
+    expect(await ok.json()).toEqual({ ok: true });
+
+    const busy = await fetch(
+      `http://127.0.0.1:${hub.port}/api/instances/inst-1/sessions/s-busy/close`,
+      { method: "POST", headers: { Authorization: `Bearer ${TOKEN}` } },
+    );
+    expect(busy.status).toBe(409);
+  });
+
+  it("guards the close proxy like the read routes", async () => {
+    const hub = await startTestHub();
+    const close = (sid: string, token: string | null) =>
+      fetch(`http://127.0.0.1:${hub.port}/api/instances/inst-1/sessions/${sid}/close`, {
+        method: "POST",
+        ...(token ? { headers: { Authorization: `Bearer ${token}` } } : {}),
+      });
+
+    expect((await close("s1", null)).status).toBe(401); // no token
+    expect((await close("s1", "wrong")).status).toBe(401); // bad token
+    expect((await close("s1", TOKEN)).status).toBe(404); // unknown instance
+    // Non-POST falls through to the catch-all 404.
+    const get = await fetch(`http://127.0.0.1:${hub.port}/api/instances/inst-1/sessions/s1/close`, {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    expect(get.status).toBe(404);
+  });
+
+  it("answers 502 when the bridge is unreachable", async () => {
+    const hub = await startTestHub();
+    await registerBridge(hub, BASE_PORT); // nothing listens there
+    const res = await fetch(`http://127.0.0.1:${hub.port}/api/instances/inst-1/sessions/s1/close`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    expect(res.status).toBe(502);
+  });
+});
+
 describe("hub idle exit", () => {
   it("exits after the idle window with no instances and no proxies", async () => {
     let exited = false;

--- a/tests/remote-session-close.test.ts
+++ b/tests/remote-session-close.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Session close endpoint (ADR-0006): the bridge-side POST
+ * /sessions/{id}/close handler through a real loopback HTTP server with an
+ * in-memory ZcodeAcpServer. Proves the running guard, discovery retirement,
+ * and the self-healing re-appearance when the editor touches a closed
+ * session again.
+ */
+
+import { randomUUID } from "node:crypto";
+import { createServer, type Server } from "node:http";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createSessionCloseHandler } from "../src/remote/session-close-endpoint.js";
+import { collectStatus } from "../src/remote/status-endpoint.js";
+import { collectSessions } from "../src/remote/endpoint.js";
+import { ZcodeAcpServer } from "../src/server.js";
+
+const cleanups: Array<() => Promise<void> | void> = [];
+
+function trackStop(stop: () => Promise<void> | void): void {
+  cleanups.push(stop);
+}
+
+afterEach(async () => {
+  while (cleanups.length) {
+    const stop = cleanups.pop()!;
+    await stop();
+  }
+});
+
+/** Boot the close handler on an ephemeral port; returns its base URL. */
+async function bootClose(server: ZcodeAcpServer): Promise<string> {
+  const handler = createSessionCloseHandler(server);
+  const httpServer: Server = createServer((req, res) => {
+    const sid = new URL(req.url ?? "/", "http://127.0.0.1").pathname.split("/")[2];
+    if (sid) handler(req, res, decodeURIComponent(sid));
+    else {
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end("not found");
+    }
+  });
+  await new Promise<void>((resolve) => httpServer.listen(0, "127.0.0.1", resolve));
+  trackStop(() => new Promise<void>((resolve) => httpServer.close(() => resolve())));
+  const addr = httpServer.address();
+  return `http://127.0.0.1:${typeof addr === "object" && addr ? addr.port : 0}`;
+}
+
+/** Seed one live session; returns both ids so tests can drive pendingTurns. */
+function seedSession(
+  server: ZcodeAcpServer,
+  opts: { title?: string } = {},
+): { acpSid: string; zcodeSid: string } {
+  const acpSid = randomUUID();
+  const zcodeSid = `zc-${randomUUID().slice(0, 8)}`;
+  server.registerSession(acpSid, zcodeSid);
+  server.markSessionActive(acpSid);
+  if (opts.title !== undefined) server.touchSessionSummary(acpSid, opts.title);
+  return { acpSid, zcodeSid };
+}
+
+describe("session close endpoint", () => {
+  it("retires an idle session from discovery and status", async () => {
+    const server = new ZcodeAcpServer();
+    const { acpSid } = seedSession(server, { title: "stale" });
+    const base = await bootClose(server);
+    expect(collectStatus(server).sessions.map((s) => s.sessionId)).toContain(acpSid);
+
+    const res = await fetch(`${base}/sessions/${acpSid}/close`, { method: "POST" });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+
+    expect(collectStatus(server).sessions.map((s) => s.sessionId)).not.toContain(acpSid);
+    expect((await collectSessions(server)).map((s) => s.sessionId)).not.toContain(acpSid);
+  });
+
+  it("rejects closing a session with a running turn", async () => {
+    const server = new ZcodeAcpServer();
+    const { acpSid, zcodeSid } = seedSession(server);
+    server.pendingTurns.set(7, { zcodeSid, cancelled: false });
+    const base = await bootClose(server);
+
+    const res = await fetch(`${base}/sessions/${acpSid}/close`, { method: "POST" });
+    expect(res.status).toBe(409);
+    // Still advertised — the close was refused.
+    expect(collectStatus(server).sessions.map((s) => s.sessionId)).toContain(acpSid);
+  });
+
+  it("answers 404 for an unknown session and 405 for non-POST", async () => {
+    const server = new ZcodeAcpServer();
+    const base = await bootClose(server);
+
+    expect((await fetch(`${base}/sessions/${randomUUID()}/close`, { method: "POST" })).status).toBe(
+      404,
+    );
+    expect((await fetch(`${base}/sessions/whatever/close`)).status).toBe(405);
+  });
+
+  it("a closed session reappears once the editor touches it again (self-healing)", async () => {
+    const server = new ZcodeAcpServer();
+    const { acpSid, zcodeSid } = seedSession(server, { title: "still open in editor" });
+    const base = await bootClose(server);
+
+    expect((await fetch(`${base}/sessions/${acpSid}/close`, { method: "POST" })).status).toBe(200);
+    expect(collectStatus(server).sessions).toHaveLength(0);
+
+    // Editor side was actually still open: the next prompt/load re-registers
+    // and marks active — the conversation returns to discovery.
+    server.registerSession(acpSid, zcodeSid);
+    server.markSessionActive(acpSid);
+    const sessions = collectStatus(server).sessions;
+    expect(sessions.map((s) => s.sessionId)).toContain(acpSid);
+    expect(sessions[0]!.status).toBe("idle");
+  });
+
+  it("a mere registration (editor restart auto-resume) does NOT resurrect a closed session", async () => {
+    const server = new ZcodeAcpServer();
+    const { acpSid, zcodeSid } = seedSession(server);
+    const base = await bootClose(server);
+
+    expect((await fetch(`${base}/sessions/${acpSid}/close`, { method: "POST" })).status).toBe(200);
+
+    // Zed restart re-opens the placeholder (registerSession → summary with
+    // hasActivity unset) — the session must stay hidden until real use.
+    server.registerSession(acpSid, zcodeSid);
+    expect(collectStatus(server).sessions).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Background

Remote lists accumulated conversations the editor side had long retired: ACP has no editor→agent "tab closed" notification, so the bridge's `sessionSummaries` (the membership source for both the heartbeat and `/status`) never loses an entry once it gains activity — the only cleanup was a bridge restart.

Requested semantics: sessions the editor still has open must NOT be closable; closing means retiring from the remote list, not deleting anything.

## Design (ADR-0006)

"Editor side still open" is unobservable from the bridge (Zed sends nothing on tab close), so the guard is two mechanisms instead of a precondition:

- **Running guard (409)** — a pending turn is the one reliable in-use signal; refuse and tell the client to cancel first.
- **Self-healing** — close deletes only the in-memory summary. If the editor still has the conversation open, its next activity (`markSessionActive`: any prompt, any load with history) recreates the summary and it reappears within one heartbeat. A wrongly closed conversation recovers on its own; an editor-retired one stays gone. A bridge-restart auto-resume alone does NOT resurrect a closed session (verified by test) — real use does.

Untouched by close: backend session store, editor conversation storage, App tasks-index.

## Changes

- `src/remote/session-close-endpoint.ts` (new): bridge loopback `POST /sessions/{id}/close` — 404 unknown, 409 running, 200 `{ok:true}`.
- `src/remote/endpoint.ts`: route wiring.
- `src/remote/hub-server.ts`: `POST /api/instances/{id}/sessions/{sid}/close` forward-and-relay proxy. Bug found en route: keying the upstream abort on the inbound request's `'close'` reset the bridge socket on every proxied close (empty-body POST drains and closes before the relayed response finishes writing → ECONNRESET → 502). The abort now keys on the response side closing early (`res` `'close'` with `writableEnded` false).
- Docs: REMOTE-CLIENTS "Closing a session" chapter, ARCHITECTURE summary, ADR-0006.

## Test plan

- [x] typecheck / lint / full suite green (652 tests, +8)
- [x] bridge: retire idle session (discovery + status), 409 running, 404 unknown, 405 non-POST
- [x] self-heal: closed session reappears after editor activity; mere re-registration (editor restart auto-resume) does not resurrect it
- [x] hub proxy: POST relay incl. 409 passthrough, 401/404/502, non-POST falls to 404