### PR TITLE
refactor: drop steer/rewind extensions removed in zcode 0.16+, release 0.10.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ src/
 │   ├── session.ts        session/new, session/prompt (turn loop), load, resume
 │   ├── slash.ts          Slash-command interception (/compact, /mcp, etc.)
 │   ├── account.ts        account/usage_stats — plan quota for remote clients
-│   ├── extensions.ts     ZCode extensions (fork, rewind, compact, steer, …)
+│   ├── extensions.ts     ZCode extensions (fork, compact, goal, model, mode, …)
 │   ├── dispatch.ts       InternalEvent → ACP session/update dispatch
 │   ├── replay.ts         Tail replay: load limit, load_earlier pagination
 │   ├── io.ts             Client notification helpers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-08-20
+
+### Removed
+
+- `session/steer`, `session/rewind`, `session/rewindCascade` ACP extensions
+  and the `/steer`, `/rewind` slash commands. The zcode app-server removed
+  these RPC methods in 0.16+ (verified live against 0.16.3: `-32601 Method
+not found`); steer/rewind moved to the v4 conversation API, which the
+  bridge does not speak. External usage was near zero (no standard ACP client
+  calls these non-standard methods), and on 0.16+ they only ever returned
+  errors. `session/fork` remains the checkpoint-branching alternative.
+  Docs refreshed to a 0.16.3 audit: PROTOCOL.md version table, BACKLOG.md
+  (new `session/send` params, `workspace/hooks/trustGrant`,
+  `interaction/browser*`, v4 protocol family), README compatibility matrix.
+
 ## [0.9.0] - 2026-08-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -304,11 +304,12 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full architecture docum
 
 ## Version Compatibility
 
-| ZCode CLI version |   Support    | Notes                                    |
-| :---------------: | :----------: | ---------------------------------------- |
-|   **>= 0.15.0**   |     Full     | All extension methods available          |
-|   **>= 0.14.8**   |     Full     | Event-stream push, all extension methods |
-|   **< 0.14.8**    | Incompatible | Event-stream subscription unavailable    |
+| ZCode CLI version |   Support    | Notes                                                                                                                                                                                                 |
+| :---------------: | :----------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|   **>= 0.16.0**   |     Full     | Steer/rewind removed upstream (moved to the v4 conversation API); bridge dropped the `session/steer`, `session/rewind`, `session/rewindCascade` extensions and the `/steer`, `/rewind` slash commands |
+|   **>= 0.15.0**   |     Full     | All extension methods available                                                                                                                                                                       |
+|   **>= 0.14.8**   |     Full     | Event-stream push, all extension methods                                                                                                                                                              |
+|   **< 0.14.8**    | Incompatible | Event-stream subscription unavailable                                                                                                                                                                 |
 
 ## Documentation
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,28 +3,76 @@
 Backend RPC methods and event types exposed by the ZCode CLI (`zcode app-server`)
 that are **not yet wired into the bridge**, tracked for potential future support.
 
-Last audited against **app-server 0.15.2** (bundled in ZCode desktop 3.4.2,
-2026-07-22). Method names were extracted from the bundled `zcode.cjs`.
+Last audited against **app-server 0.16.3** (bundled in ZCode desktop 3.8.1,
+2026-08-09). Method names were extracted from the bundled `zcode.cjs` dispatch
+switch and verified with live RPC calls.
+
+## Removed upstream in 0.16 (verified live: `-32601`)
+
+| Method                  | Replacement                                          | Bridge action                                       |
+| ----------------------- | ---------------------------------------------------- | --------------------------------------------------- |
+| `session/steer`         | v4 command/conversation API                          | Dropped the ACP extension + `/steer` slash command  |
+| `session/rewind`        | `v4/conversation/fileRewindPreview` + v4 rewind flow | Dropped the ACP extension + `/rewind` slash command |
+| `session/rewindCascade` | v4 rewind flow                                       | Dropped the ACP extension                           |
+
+`session/fork` (branch from checkpoint) is the remaining v3 alternative for
+rewind-like UX. The backend still emits `rewind.triggered` /
+`checkpoint.created` events, so a client can observe rewinds initiated
+elsewhere.
 
 ## Candidate methods (optional enhancements)
 
-These are available in the backend but have no ACP-side counterpart yet. Pick
-them up when a concrete ACP/editor need appears.
+Available in the backend but with no ACP-side counterpart yet. Pick them up
+when a concrete ACP/editor need appears.
 
-| Method | Purpose | Current bridge behavior |
-|--------|---------|-------------------------|
-| `session/subagents` | Query the list of sub-agents for a session | Sub-agent info is parsed from the `Agent` tool result (`_meta.subagent`); sufficient for now |
-| `session/events` | Pull-mode event history (complement to `session/subscribe`) | Not used; could support event replay/gap-fill |
-| `session/usage` | Per-session token usage | Context bar uses `session.updated` usage payload instead |
-| `session/close` | Explicitly close a session (vs `session/stop` which ends a turn) | Not used; sessions close on process exit |
+| Method                                                                          | Purpose                                                     | Current bridge behavior                                                                                                |
+| ------------------------------------------------------------------------------- | ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `session/subagents`                                                             | Query the list of sub-agents for a session                  | Sub-agent info is parsed from the `Agent` tool result (`_meta.subagent`); sufficient for now                           |
+| `session/events`                                                                | Pull-mode event history (complement to `session/subscribe`) | Not used; could support event replay/gap-fill                                                                          |
+| `session/usage`                                                                 | Per-session token usage                                     | Context bar uses `session.updated` usage payload instead                                                               |
+| `workspace/hooks/trustGrant`                                                    | Server→client request: approve hook trust                   | Not answered by the bridge (requeued, no owner); if the backend blocks a turn on it, turns could hang — watch for this |
+| `interaction/browserList` / `interaction/browserExecute`                        | Server→client requests: browser automation via the client   | Not answered; only meaningful once an ACP client has a browser surface                                                 |
+| `interaction/requestProviderRuntimeHeaders`                                     | Server→client request: provider runtime headers             | Not answered                                                                                                           |
+| `workspace/updateInteractionPreferences` / `workspace/updateModelIoPreferences` | Client preference updates                                   | Not used                                                                                                               |
+
+### New `session/send` params (0.16+, unwired)
+
+The `session/send` schema grew fields the bridge does not forward:
+
+- `attachments` — file/image attachments (`artifact://`, `data:` URLs,
+  browser screenshots via `node_repl_images`)
+- `toolDenylist` — per-message tool deny list
+- `runtimeModel` — per-message model override
+- `browserAmbientContext` — browser context for the turn
+- `expectedRevision` / `expectedProviderRevision` / `expectedModelRuntimeRevision`
+  — optimistic concurrency guards
+- `automationId` / `offPeakTaskId` / `offPeakRunType` — scheduled/off-peak tasks
 
 ### New event types (undocumented in PROTOCOL.md)
 
-| Event | Status field | Notes |
-|-------|--------------|-------|
-| `turn.steerQueued` | — | Emitted when a `session/steer` is queued behind a running turn. Enhances steer UI feedback |
-| `turn.steerDrained` | — | Emitted when queued steer instructions are drained into the turn |
-| `turn.terminal` | `status: success \| interrupted \| failed`, `resultType?`, `durationMs`, `...usage` | Terminal turn lifecycle event; currently the bridge relies on `turn.completed`/`turn.failed` |
+| Event                                    | Notes                                                                      |
+| ---------------------------------------- | -------------------------------------------------------------------------- |
+| `checkpoint.created`                     | Checkpoint lifecycle; pairs with `rewind.triggered`                        |
+| `rewind.triggered`                       | A rewind happened (e.g. initiated elsewhere)                               |
+| `streamRecovery.updated`                 | Stream recovery progress — potentially useful for the replay/gap-fill path |
+| `turn.attachments.resolved`              | Attachment resolution telemetry                                            |
+| `usage.delta`                            | Streaming usage updates                                                    |
+| `turn.steerQueued` / `turn.steerDrained` | Steer lifecycle (queue/drain of steered inputs)                            |
+| `turn.terminal`                          | Terminal turn lifecycle; bridge relies on `turn.completed`/`turn.failed`   |
+
+## v4 protocol family (strategic)
+
+0.16 ships a parallel **v4** API used by the desktop client, alongside the v3
+`session/*` surface this bridge speaks:
+
+`v4/connection/flow`, `v4/controller/{subscribe,resync,unsubscribe}`,
+`v4/conversation/{subscribe,resync,unsubscribe,rowsRange,plans,fileChanges,
+fileRewindPreview,usage}`, `v4/attachment/{begin,chunk,commit,abort,read}`,
+`v4/usage/stats`, `v4/commands/query`, `v4/command`.
+
+Steer/rewind now live here. If the bridge ever needs them back, implementing
+the minimal v4 conversation subset (or `v4/command`) is the path; expect the
+v3 surface to stay in maintenance mode.
 
 ## Not planned (client/config layer)
 
@@ -32,28 +80,36 @@ These methods belong to the desktop client or workspace configuration layer and
 have no ACP equivalent. Listed for completeness only — the bridge does not
 intend to surface them.
 
-`automation/create`, `automation/list`, `automation/delete` (scheduled tasks),
-`usage/stats` (token analytics; the account-level plan quota it does NOT cover
-is exposed via the bridge's own `account/usage_stats` — see Proposal 0002),
-`workspace/readState`, `workspace/upsertModelProvider`,
-`workspace/removeModelProvider`, `workspace/updateProviderRegistry`,
-`workspace/setDefaultModel`, `workspace/setDefaultThoughtLevel`,
-`workspace/setDefaultMode`, `workspace/generateText`, `mcp/list`,
-`plugins/list`, `plugins/setEnabled`, `plugins/overview`, `plugins/describe`,
-`plugins/marketplace/*`.
+`automation/*` (scheduled tasks), `usage/stats` (token analytics; the
+account-level plan quota it does NOT cover is exposed via the bridge's own
+`account/usage_stats` — see Proposal 0002), `workspace/readState`,
+`workspace/upsertModelProvider`, `workspace/removeModelProvider`,
+`workspace/updateProviderRegistry`, `workspace/setDefaultModel`,
+`workspace/setDefaultThoughtLevel`, `workspace/setDefaultMode`,
+`workspace/generateText`, `workspace/cancelGenerateText`, `mcp/list`,
+`plugins/*` (the bridge reads plugin commands from disk instead).
 
 ## Verification method
 
 The bundled CLI is minified, so a literal `grep "session/rewind"` returns 0
-hits even when the method is fully supported — method names are split across
-variable references. To audit reliably:
+hits even when the method is fully supported — and vice versa, string absence
+proves nothing. To audit reliably:
 
 ```sh
 cd /Applications/ZCode.app/Contents/Resources/glm
-# Full RPC enum: search for the method-dispatch table (Key:"ns/name" pairs)
-python3 -c "import re; ..."   # see commit that added this file
-# Word-level presence is more reliable for verifying a method still exists:
-grep -oiF "rewind" zcode.cjs | wc -l   # 357 → definitely present
+# 1. Extract the RPC dispatch switch (all `case XX.method:` labels).
+#    The `default:` branch throws -32601, so a method with no case is gone.
+python3 - <<'EOF'
+import re
+src = open('zcode.cjs', encoding='utf-8', errors='replace').read()
+i = src.find('case rr.sessionCreate')
+start = src.rfind('switch', 0, i)
+cases = re.findall(r'case (?:rr|Pc)\.([a-zA-Z]+)', src[start:start+20000])
+print(' '.join(dict.fromkeys(cases)))
+EOF
+# 2. Confirm with a live call — the envelope has NO `jsonrpc` field:
+#    {"id":1,"method":"session/steer","params":{...}} → -32601 means removed.
 ```
 
-Never conclude a method was removed from a single string-literal search.
+Never conclude a method was removed from a single string-literal search; a
+missing dispatch case plus a live `-32601` is the proof.

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -431,8 +431,8 @@ Session state update (usage, etc.).
 
 ### Steer lifecycle events
 
-When `session/steer` appends instructions to a running turn, the backend emits
-a pair of lifecycle events (available in app-server 0.15.2+). The bridge does
+When a user input is steered into (queued behind) a running turn, the backend
+emits a pair of lifecycle events (app-server 0.15.2+). The bridge does
 not currently translate these — they are tracked as a future enhancement (see
 [`BACKLOG.md`](./BACKLOG.md)).
 
@@ -661,23 +661,16 @@ Fork a new session from a checkpoint.
 }
 ```
 
-### `session/rewind`
+### `session/rewind` — removed in 0.16+
 
-Rewind to a checkpoint.
-
-**Request:**
-
-```json
-{
-  "id": 9,
-  "method": "session/rewind",
-  "params": {
-    "sessionId": "sess_abc123",
-    "target": { "kind": "latestCheckpoint" },
-    "expectedRevision": 42
-  }
-}
-```
+`session/rewind` (and `session/rewindCascade`) existed up to app-server
+0.15.x. The 0.16 app-server removed them from its RPC dispatch (verified
+against 0.16.3: `-32601 Method not found`) — rewind moved to the v4
+conversation API (`v4/conversation/fileRewindPreview` and friends), which the
+bridge does not speak. The bridge's `session/rewind` /
+`session/rewindCascade` ACP extensions and the `/rewind` slash command were
+removed accordingly. `session/fork` (branch from checkpoint) remains the
+bridge-side alternative.
 
 ### `session/goal`
 
@@ -715,22 +708,14 @@ Compact the conversation history.
 }
 ```
 
-### `session/steer`
+### `session/steer` — removed in 0.16+
 
-Append instructions to a running turn.
-
-**Request:**
-
-```json
-{
-  "id": 12,
-  "method": "session/steer",
-  "params": {
-    "sessionId": "sess_abc123",
-    "content": "Please use TypeScript instead of JavaScript"
-  }
-}
-```
+`session/steer` existed up to app-server 0.15.x. The 0.16 app-server removed
+it from its RPC dispatch (verified against 0.16.3: `-32601 Method not found`);
+steering moved to the v4 command/conversation API. The bridge's
+`session/steer` ACP extension and the `/steer` slash command were removed
+accordingly. Queued inputs still surface as `turn.steerQueued` /
+`turn.steerDrained` events (see above).
 
 ### `session/setMode`
 
@@ -921,11 +906,12 @@ UI closes on cancellation.
 Cancels a background task. The bridge additionally marks the corresponding ACP
 tool card as `failed` with `_meta.backgroundTask.cancelled = true`.
 
-| ZCode CLI version | session/subscribe | Extension methods   | Notes                          |
-| ----------------- | ----------------- | ------------------- | ------------------------------ |
-| >= 0.15.0         | Supported         | All supported       | Full functionality             |
-| >= 0.14.8         | Supported         | Partially supported | workspace/* unavailable        |
-| 0.14.5 ~ 0.14.7   | Not supported     | Not supported       | Incompatible with this project |
+| ZCode CLI version | session/subscribe | Extension methods       | Notes                                                                                                                                                        |
+| ----------------- | ----------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| >= 0.16.0         | Supported         | All except steer/rewind | `session/steer`, `session/rewind`, `session/rewindCascade` removed upstream (v4 API); bridge dropped its passthroughs and `/steer`, `/rewind` slash commands |
+| >= 0.15.0         | Supported         | All supported           | Full functionality                                                                                                                                           |
+| >= 0.14.8         | Supported         | Partially supported     | workspace/* unavailable                                                                                                                                      |
+| 0.14.5 ~ 0.14.7   | Not supported     | Not supported           | Incompatible with this project                                                                                                                               |
 
 ## Additional backend methods (not wired into the bridge)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zcode-acp-server",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Agent Client Protocol (ACP) server bridging headless ZCode to editors like Zed and JetBrains.",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/handlers/extensions.ts
+++ b/src/handlers/extensions.ts
@@ -2,8 +2,10 @@
  * ZCode-specific session method handlers (non-standard ACP extensions).
  *
  * Thin passthroughs for the extended session/* methods (0.14.8+):
- * fork/rewind/rewindCascade/goal/compact/steer/cancelBackgroundTask +
+ * fork/goal/compact/cancelBackgroundTask +
  * 0.15.0+: setThoughtLevel/updateRuntimeModelConfig/setModel/setMode.
+ * (rewind/rewindCascade/steer existed up to 0.15.x; app-server 0.16+ removed
+ * them in favor of the v4 conversation API, so the bridge dropped them.)
  *
  * These share a near-identical shape (resolve sid → build params → forward →
  * check error). Only the genuine per-method differences are spelled out:
@@ -67,42 +69,6 @@ export async function fork(server: ZcodeAcpServer, params: ExtensionParams): Pro
   }
   log(`session/fork → ${result.forkedSessionId ?? "?"}`);
   return result;
-}
-
-/** session/rewind → zcode session/rewind: restore workspace files to a checkpoint. */
-export async function rewind(server: ZcodeAcpServer, params: ExtensionParams): Promise<Result> {
-  const zcodeSid = await resolveSidOrThrow(server, params);
-  const zcParams: Record<string, unknown> = {
-    sessionId: zcodeSid,
-    target: buildCheckpointTarget(params),
-  };
-  if (params.expectedRevision !== undefined) zcParams.expectedRevision = params.expectedRevision;
-  const resp = await server
-    .ensureBackend()
-    .request(server.nextId(), "session/rewind", zcParams, 15000);
-  if (resp.error) throw new Error(`rewind failed: ${resp.error.message}`);
-  log("session/rewind → ok");
-  return (resp.result ?? {}) as Result;
-}
-
-/** session/rewindCascade → zcode session/rewindCascade: cascade rewind. */
-export async function rewindCascade(
-  server: ZcodeAcpServer,
-  params: ExtensionParams,
-): Promise<Result> {
-  const zcodeSid = await resolveSidOrThrow(server, params);
-  const zcParams: Record<string, unknown> = {
-    sessionId: zcodeSid,
-    target: buildCheckpointTarget(params),
-  };
-  if (params.scope) zcParams.scope = params.scope;
-  if (params.expectedRevision !== undefined) zcParams.expectedRevision = params.expectedRevision;
-  const resp = await server
-    .ensureBackend()
-    .request(server.nextId(), "session/rewindCascade", zcParams, 15000);
-  if (resp.error) throw new Error(`rewindCascade failed: ${resp.error.message}`);
-  log("session/rewindCascade → ok");
-  return (resp.result ?? {}) as Result;
 }
 
 /** session/goal → zcode session/goal: read/set/replace/clear/pause/resume the goal. */
@@ -171,20 +137,6 @@ export async function compact(
   // (the ACP method path ignores this non-standard flag). Mirrors Python's
   // "⚠ 压缩超时" branch in _handle_slash_command.
   return { ...((resp.result ?? {}) as Result), __lockTimeout: !released };
-}
-
-/** session/steer → zcode session/steer: append instructions to a running turn. */
-export async function steer(server: ZcodeAcpServer, params: ExtensionParams): Promise<Result> {
-  const zcodeSid = await resolveSidOrThrow(server, params);
-  const content = String(params.content ?? "");
-  if (!content.trim()) throw new Error("steer requires content");
-  const resp = await server
-    .ensureBackend()
-    .request(server.nextId(), "session/steer", { sessionId: zcodeSid, content }, 15000);
-  if (resp.error) throw new Error(`steer failed: ${resp.error.message}`);
-  const result = (resp.result ?? {}) as { kind?: string };
-  log(`session/steer → kind=${result.kind ?? "?"}`);
-  return result;
 }
 
 /** session/cancelBackgroundTask → zcode session/cancelBackgroundTask. */

--- a/src/handlers/slash.ts
+++ b/src/handlers/slash.ts
@@ -2,7 +2,7 @@
  * Slash-command interception inside `session/prompt`.
  *
  * When the prompt text starts with `/`, dispatch the matching ZCode method
- * directly (compact/goal/fork/rewind/steer/model/mode/thought), emit a short
+ * directly (compact/goal/fork/model/mode/thought), emit a short
  * feedback `agent_message_chunk`, and return `end_turn` — never reaching the
  * normal turn loop.
  *
@@ -43,7 +43,7 @@ import { formatQuota, queryQuota } from "../quota/index.js";
 import { CONFIG_DISPATCH, SLASH_COMMANDS, warn } from "../utils.js";
 import type { ZcodeAcpServer } from "../server.js";
 import { sendTextChunk } from "./io.js";
-import { compact, fork, goal, rewind, steer } from "./extensions.js";
+import { compact, fork, goal } from "./extensions.js";
 
 /**
  * ZCode built-in commands that require the TUI command center or interactive
@@ -188,15 +188,6 @@ export async function handleSlashCommand(
           forkedSessionId?: string;
         };
         return ok(`✓ forked new session: ${result.forkedSessionId ?? "?"}`);
-      }
-      case "rewind": {
-        await rewind(server, { sessionId: acpSid });
-        return ok("✓ rewound workspace to checkpoint");
-      }
-      case "steer": {
-        if (!arg) throw new RequestError(-32602, "/steer requires content");
-        await steer(server, { sessionId: acpSid, content: arg });
-        return ok("✓ appended instruction to the running turn");
       }
       case "model": {
         if (!arg) throw new RequestError(-32602, "/model requires a model id");

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,12 +29,9 @@ import {
   compact,
   fork,
   goal,
-  rewind,
-  rewindCascade,
   setMode,
   setModel,
   setThoughtLevel,
-  steer,
   updateRuntimeModelConfig,
 } from "./handlers/extensions.js";
 import { echoUserPromptToOthers, sendAvailableCommandsDeferred } from "./handlers/io.js";
@@ -161,14 +158,14 @@ async function main(): Promise<void> {
     )
     // ZCode-specific extensions (non-standard ACP methods). Use a passthrough
     // zod parser so all param fields survive into the handler.
+    // session/steer, session/rewind, session/rewindCascade were removed in
+    // zcode app-server 0.16+ (steer/rewind moved to the v4 conversation API);
+    // the bridge dropped its passthroughs accordingly.
     .onRequest("session/fork", extParams, (ctx) => fork(server, ctx.params))
-    .onRequest("session/rewind", extParams, (ctx) => rewind(server, ctx.params))
-    .onRequest("session/rewindCascade", extParams, (ctx) => rewindCascade(server, ctx.params))
     .onRequest("session/goal", extParams, (ctx) => goal(server, ctx.params))
     .onRequest("session/compact", extParams, (ctx) =>
       compact(server, ctx.params, server.clients.broadcast()),
     )
-    .onRequest("session/steer", extParams, (ctx) => steer(server, ctx.params))
     .onRequest("session/cancelBackgroundTask", extParams, (ctx) =>
       cancelBackgroundTask(server, ctx.params),
     )

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,10 +47,10 @@ export const ZCODE_CREDS_PATH = path.join(
  * Slash commands surfaced to the editor. Each maps to a ZCode session method
  * that the server forwards when the user types the command.
  *
- * Commands handled by the bridge (compact/goal/fork/rewind/steer/model/mode/
- * thought/quota/mcp) are intercepted in `handleSlashCommand`. Commands handled
- * by the ZCode backend (init) and plugin commands (code-review etc.) pass
- * through to `session/send` — the backend resolves them before the model.
+ * Commands handled by the bridge (compact/goal/fork/model/mode/thought/quota/
+ * mcp) are intercepted in `handleSlashCommand`. Commands handled by the ZCode
+ * backend (init) and plugin commands (code-review etc.) pass through to
+ * `session/send` — the backend resolves them before the model.
  *
  * Discovered Skills (arco-design, tdd, etc.) are also appended to the command
  * list at startup via `buildAllCommands()` — they pass through as normal text
@@ -64,12 +64,6 @@ export const SLASH_COMMANDS = [
     input: { hint: "goal description" },
   },
   { name: "fork", description: "Fork the session at the latest checkpoint" },
-  { name: "rewind", description: "Rewind workspace files to the latest checkpoint" },
-  {
-    name: "steer",
-    description: "Append an instruction to a running turn",
-    input: { hint: "content" },
-  },
   {
     name: "mode",
     description: "Switch permission mode (plan/build/edit/yolo)",


### PR DESCRIPTION
## Summary

The zcode app-server removed three RPC methods in 0.16+ (verified live against 0.16.3, bundled in ZCode desktop 3.8.1): `session/steer`, `session/rewind`, `session/rewindCascade` all answer `-32601 Method not found` — steer/rewind moved to the v4 conversation API, which this bridge does not speak.

Audit showed near-zero external usage (non-standard ACP extensions no editor calls; `rewindCascade` had no slash command either), and on 0.16+ the passthroughs only ever returned errors. So this drops them rather than gating them.

- Remove the three ACP extension registrations and handlers (`session/fork` stays as the checkpoint-branching alternative)
- Remove the `/rewind` and `/steer` slash commands and their advertisement
- Refresh `docs/BACKLOG.md` to a 0.16.3 audit: upstream removals, new candidates (`workspace/hooks/trustGrant`, `interaction/browser*`), new `session/send` params (`attachments`, `toolDenylist`, `runtimeModel`, …), v4 protocol family
- PROTOCOL.md / README version tables gain a 0.16.0 row
- Release 0.10.0 (breaking removal, 0.x minor)

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm test` (652 tests) all pass
- Rebuilt and drove the bridge over ACP stdio: `session/steer` / `session/rewind` / `session/rewindCascade` now return a clean ACP-level `-32601` (previously `-32603` after a wasted backend round-trip); `/rewind` `/steer` no longer advertised; core flow (initialize → session/new → session/prompt) unaffected