### PR TITLE
feat: re-send undecided interaction requests to reconnected remote clients

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -562,6 +562,15 @@ mechanisms based on client capabilities:
 `clientCapabilities.elicitation.form`. The server detects it with
 `server.supportsElicitationForm()`.
 
+**Reconnect resend**: interaction requests are one-shot and raced across the
+clients connected when they fire (first response wins). A client that was
+offline at that moment never sees them — so when a client completes
+`session/load` / `session/resume` (the reconnect catch-up), the bridge re-sends
+that session's still-unanswered interaction requests to it (after a short
+delay, so the replay renders first). The re-send joins the existing race: if
+another client answers first, the reconnected client receives `$/cancel_request`
+and should drop the dialog.
+
 **elicitation form example** (AskUserQuestion):
 
 ```json

--- a/src/handlers/server-requests.ts
+++ b/src/handlers/server-requests.ts
@@ -13,6 +13,11 @@
  * the same requestId/toolCallId. The first request forwards to the client;
  * reannounces either get the cached result (if it arrived) or just record
  * their zcode id for a later unified reply.
+ *
+ * Reconnect resend: a client-side request fired while a remote client was
+ * offline never reaches it. Undecided waits are tracked (ActiveInteraction)
+ * and re-sent to a client when its session/load / session/resume completes —
+ * the re-send joins the existing first-response-wins race.
  */
 
 import type * as acp from "@agentclientprotocol/sdk";
@@ -38,6 +43,7 @@ import {
   zcodePermissionToAcp,
 } from "../interaction/adapter.js";
 import { buildConfigOptions, buildModes } from "../config/options.js";
+import type { ClientLike } from "../remote/broadcast.js";
 import { log, warn } from "../utils.js";
 import type { PendingTurn, ZcodeAcpServer } from "../server.js";
 import { sendSessionUpdate } from "./io.js";
@@ -95,6 +101,152 @@ export function getPendingInteractions(server: ZcodeAcpServer): Map<string, Dedu
   (server as unknown as { _pendingInteractions: Map<string, DedupEntry> })._pendingInteractions =
     fresh;
   return fresh;
+}
+
+/**
+ * One in-flight client interaction request (`session/request_permission` or
+ * `elicitation/create`) whose answer is still pending.
+ *
+ * A request fired while a remote client was offline never reaches it, and the
+ * broadcast race snapshots its client list once — a client attaching mid-wait
+ * is invisible to it. Tracking each wait here lets `resendPendingInteractions`
+ * fire a targeted re-send at a client that just (re)connected; the re-send
+ * joins this race (first response wins, losing clients get `$/cancel_request`
+ * so their dialogs dismiss).
+ */
+interface ActiveInteraction {
+  readonly method: string;
+  readonly params: unknown;
+  readonly label: string;
+  /** Abort controller per in-flight client attempt; aborting dismisses that client's dialog. */
+  readonly controllers: Set<AbortController>;
+  /** Set once any attempt answered or the wait was interrupted — no further attempts join. */
+  settled: boolean;
+  /** In-flight attempt count; reaching zero without a winner rejects the race. */
+  inFlight: number;
+  firstError: unknown;
+  readonly promise: Promise<unknown>;
+  resolve: (value: unknown) => void;
+  reject: (err: unknown) => void;
+}
+
+/** Per-server active interaction registry (lazy-initialised). */
+function getActiveInteractions(server: ZcodeAcpServer): Set<ActiveInteraction> {
+  const holder = server as unknown as { _activeInteractions?: Set<ActiveInteraction> };
+  if (holder._activeInteractions) return holder._activeInteractions;
+  const fresh = new Set<ActiveInteraction>();
+  holder._activeInteractions = fresh;
+  return fresh;
+}
+
+/** Create the unresolved race entry for one interaction wait. */
+function createActiveInteraction(
+  method: string,
+  params: unknown,
+  label: string,
+): ActiveInteraction {
+  let resolve!: (value: unknown) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<unknown>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return {
+    method,
+    params,
+    label,
+    controllers: new Set(),
+    settled: false,
+    inFlight: 0,
+    firstError: undefined,
+    promise,
+    resolve,
+    reject,
+  };
+}
+
+/**
+ * Fire one attempt of an interaction race. The first attempt goes through the
+ * broadcast proxy (itself a first-response-wins race across the currently
+ * connected clients); later attempts are targeted re-sends at clients that
+ * attached mid-wait. The first attempt to answer resolves the race and aborts
+ * every other attempt's controller; when all in-flight attempts fail instead,
+ * the race rejects with the first error (surfaces like a single-client failure).
+ */
+function fireInteractionAttempt(
+  entry: ActiveInteraction,
+  send: (options: acp.SendRequestOptions) => Promise<unknown>,
+): void {
+  const ctrl = new AbortController();
+  entry.controllers.add(ctrl);
+  entry.inFlight++;
+  // send() may throw synchronously (broken/just-closed connection); funnel
+  // that into the rejection path — the reconnect re-send calls this from a
+  // timer callback, where a sync throw would crash the bridge.
+  let attempt: Promise<unknown>;
+  try {
+    attempt = send({ cancellationSignal: ctrl.signal });
+  } catch (err) {
+    attempt = Promise.reject(err);
+  }
+  attempt.then(
+    (value) => {
+      entry.inFlight--;
+      entry.controllers.delete(ctrl);
+      if (entry.settled) return;
+      entry.settled = true;
+      for (const other of entry.controllers) other.abort();
+      entry.controllers.clear();
+      entry.resolve(value);
+    },
+    (err) => {
+      entry.inFlight--;
+      entry.controllers.delete(ctrl);
+      if (entry.firstError === undefined) entry.firstError = err;
+      if (!entry.settled && entry.inFlight === 0) {
+        entry.settled = true;
+        entry.reject(entry.firstError);
+      }
+    },
+  );
+}
+
+/**
+ * Delay before a reconnect re-send fires. The resend is triggered by the
+ * client's session/load / session/resume completing; the pause lets that
+ * response plus the replay updates land first, so the popup renders on a
+ * settled session view instead of racing the replay (clients commonly reset
+ * dialog state when a load starts).
+ */
+const RESEND_DELAY_MS = 300;
+
+/**
+ * Re-send this session's still-undecided interaction requests to a client that
+ * just (re)connected, so an agent question that fired while the client was
+ * offline becomes answerable there. Fire-and-forget, best-effort: each re-send
+ * joins the existing first-response-wins race; if another client answers first,
+ * the re-send is cancelled and the reconnected client's dialog (if any) drops.
+ */
+export function resendPendingInteractions(
+  server: ZcodeAcpServer,
+  client: ClientLike,
+  acpSid: string,
+): void {
+  const active = getActiveInteractions(server);
+  if (active.size === 0) return;
+  for (const entry of [...active]) {
+    if (entry.settled) continue;
+    const sid = (entry.params as { sessionId?: string }).sessionId;
+    if (sid !== acpSid) continue;
+    log(`  ⟳ ${entry.label} still unanswered, re-sending to reconnected client (sid=${acpSid})`);
+    const timer = setTimeout(() => {
+      if (entry.settled) return;
+      fireInteractionAttempt(entry, (options) =>
+        client.request(entry.method, entry.params, options),
+      );
+    }, RESEND_DELAY_MS);
+    timer.unref?.();
+  }
 }
 
 /**
@@ -314,6 +466,7 @@ async function handleSinglePermission(
     `  ⟳ ${toolName || "permission"}, forwarding session/request_permission (acp_id=${acpReqId})`,
   );
   const acpResp = await requestWithTimeout(
+    server,
     cx,
     "session/request_permission",
     acpParams,
@@ -428,7 +581,7 @@ export async function handleAskUserQuestion(
  * `decline` on any failure so the caller can degrade gracefully.
  */
 async function handleAskUserViaElicitation(
-  _server: ZcodeAcpServer,
+  server: ZcodeAcpServer,
   cx: acp.AgentContext,
   acpSid: string,
   params: ZcodeInteractionUserInputParams,
@@ -451,6 +604,7 @@ async function handleAskUserViaElicitation(
     `  ⟳ AskUserQuestion forwarding elicitation/create (form, ${Object.keys(formParams.requestedSchema.properties).length} fields)`,
   );
   const acpResp = await requestWithTimeout(
+    server,
     cx,
     "elicitation/create",
     formParams,
@@ -496,7 +650,7 @@ async function emitAskToolCall(
 
 /** Send one requestPermission and await the response. */
 async function askOnce(
-  _server: ZcodeAcpServer,
+  server: ZcodeAcpServer,
   cx: acp.AgentContext,
   acpParams: {
     options: unknown[];
@@ -508,9 +662,10 @@ async function askOnce(
   _label: string,
   turn?: PendingTurn,
 ): Promise<unknown> {
-  const acpReqId = _server.nextId();
+  const acpReqId = server.nextId();
   log(`  ⟳ AskUserQuestion forwarding session/request_permission (acp_id=${acpReqId})`);
   const resp = await requestWithTimeout(
+    server,
     cx,
     "session/request_permission",
     acpParams,
@@ -575,12 +730,17 @@ type InteractionResult = unknown | typeof INTERRUPTED;
  * Send a client-side request and wait for the response. By default waits
  * indefinitely (see {@link INTERACTION_TIMEOUT_MS}). Resolves to the client
  * response, `null` if the client returned null/errored, or {@link INTERRUPTED}
- * if the wait was broken by connection close / env timeout / turn cancel. The
- * underlying `cx.request` promise stays pending after an interrupt (the SDK has
- * no abort) but is no longer awaited; it settles naturally when the client
- * eventually responds or the connection closes.
+ * if the wait was broken by connection close / env timeout / turn cancel.
+ *
+ * The client request runs inside a tracked first-response-wins race (see
+ * {@link ActiveInteraction}): the broadcast proxy races the clients connected
+ * at fire time, and `resendPendingInteractions` can add targeted attempts at
+ * clients that attach mid-wait. After the wait settles (answered OR
+ * interrupted — the caller replies decline), the entry is dropped and every
+ * still-open attempt is aborted, dismissing the leftover dialogs.
  */
 async function requestWithTimeout(
+  server: ZcodeAcpServer,
   cx: acp.AgentContext,
   method: string,
   params: unknown,
@@ -596,13 +756,19 @@ async function requestWithTimeout(
   const disposers: Array<() => void> = [];
   const settled = { done: false };
 
-  // Build the racers. The primary is the client request itself.
+  // Primary racer: the tracked interaction race (broadcast attempt + any
+  // reconnect re-sends). Failures surface as null, matching a single client
+  // request that errors.
+  const active = getActiveInteractions(server);
+  const entry = createActiveInteraction(method, params, label);
+  active.add(entry);
   const racers: Array<Promise<InteractionResult>> = [
-    cx.request(method, params as never).catch((e: unknown) => {
+    entry.promise.catch((e: unknown) => {
       warn(`  ⚠ ${label} failed: ${e instanceof Error ? e.message : String(e)}`);
       return null;
     }),
   ];
+  fireInteractionAttempt(entry, (options) => cx.request(method, params as never, options));
 
   // Connection-close detection: replaces the old finite timeout as the crash
   // guard. `cx.signal` is an AbortSignal that fires when the stream closes;
@@ -661,10 +827,10 @@ async function requestWithTimeout(
   }
 
   const winner = await Promise.race(racers);
-  // Mark settled BEFORE disposing: the primary racer (the client request)
-  // resolves without touching settled.done, so a later `closed.then(fire)`
-  // would otherwise pass its guard and emit a spurious "aborted (client
-  // connection closed)" warn long after a normal completion.
+  // Mark settled BEFORE disposing: a non-primary racer can win while the
+  // interaction race is still open, and a later `closed.then(fire)` would
+  // otherwise pass its guard and emit a spurious "aborted (client connection
+  // closed)" warn long after a normal completion.
   settled.done = true;
   // Tear down every racer's timer/listener so the losers don't leak. The
   // turn-cancel interval is the critical one: without this it fires forever.
@@ -674,6 +840,15 @@ async function requestWithTimeout(
     } catch {
       /* best-effort cleanup */
     }
+  }
+  // The interaction is decided either way (answered, or interrupted — the
+  // caller replies decline): unregister it and dismiss dialogs still open on
+  // clients that never answered (abort → `$/cancel_request`).
+  active.delete(entry);
+  if (!entry.settled) {
+    entry.settled = true;
+    for (const ctrl of entry.controllers) ctrl.abort();
+    entry.controllers.clear();
   }
   return winner;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ import {
 } from "./handlers/extensions.js";
 import { echoUserPromptToOthers, sendAvailableCommandsDeferred } from "./handlers/io.js";
 import { loadEarlier } from "./handlers/replay.js";
+import { resendPendingInteractions } from "./handlers/server-requests.js";
 import { loadPluginCommands } from "./config/plugin-commands.js";
 import { loadSkillCommands } from "./config/skill-discovery.js";
 import { trackConnections } from "./remote/broadcast.js";
@@ -125,11 +126,16 @@ async function main(): Promise<void> {
     .onRequest("session/resume", async (ctx) => {
       const result = await resumeSession(server, ctx.params, server.clients.broadcast());
       sendAvailableCommandsDeferred(server.clients.broadcast(), ctx.params.sessionId, allCommands);
+      // A client that (re)connects catches up via resume/load; any interaction
+      // request still waiting for an answer is re-sent to it so a question
+      // fired while it was offline becomes answerable there.
+      resendPendingInteractions(server, ctx.client, ctx.params.sessionId);
       return result;
     })
     .onRequest("session/load", async (ctx) => {
       const result = await loadSession(server, ctx.params, server.clients.broadcast());
       sendAvailableCommandsDeferred(server.clients.broadcast(), ctx.params.sessionId, allCommands);
+      resendPendingInteractions(server, ctx.client, ctx.params.sessionId);
       return result;
     })
     // Tail-replay pagination (non-standard; Proposal 0001) — params stay

--- a/tests/interaction-resend.test.ts
+++ b/tests/interaction-resend.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Tests for reconnect resend of undecided interaction requests.
+ *
+ * Bug: `session/request_permission` / `elicitation/create` are one-shot
+ * requests raced across the clients connected at fire time. A remote client
+ * that was offline when the agent asked (or dropped mid-wait) never sees the
+ * request, and after reconnecting it could not answer — only the primary
+ * editor could.
+ *
+ * Fix: every undecided interaction wait is tracked (ActiveInteraction). When a
+ * client completes session/load / session/resume (the reconnect catch-up), the
+ * bridge re-sends the session's pending requests to it; the re-send joins the
+ * existing first-response-wins race and losers are cancelled so their dialogs
+ * dismiss.
+ */
+
+import type * as acp from "@agentclientprotocol/sdk";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PendingTurn, ZcodeAcpServer } from "../src/server.js";
+import type { ZcodeInteractionUserInputParams } from "../src/backend/types.js";
+
+// Mock sendSessionUpdate so emit paths do not need a real cx.notify.
+vi.mock("../src/handlers/io.js", () => ({
+  sendSessionUpdate: vi.fn().mockResolvedValue(undefined),
+}));
+
+import {
+  handleAskUserQuestion,
+  resendPendingInteractions,
+} from "../src/handlers/server-requests.js";
+import type { ClientLike } from "../src/remote/broadcast.js";
+
+/** Minimal server stub: elicitation form supported (preferred AskUser path). */
+function makeServer(): ZcodeAcpServer {
+  return {
+    supportsElicitationForm: () => true,
+    nextId: () => 1,
+  } as unknown as ZcodeAcpServer;
+}
+
+/** A client whose `request` never settles — a dialog left open, nobody answers. */
+function makeSilentClient(): {
+  client: ClientLike;
+  request: ReturnType<typeof vi.fn>;
+  signal: () => AbortSignal | undefined;
+} {
+  let captured: AbortSignal | undefined;
+  const request = vi.fn(
+    (_method: string, _params: unknown, options?: { cancellationSignal?: AbortSignal }) => {
+      captured = options?.cancellationSignal;
+      return new Promise<never>(() => {});
+    },
+  );
+  return {
+    client: { request } as unknown as ClientLike,
+    request,
+    signal: () => captured,
+  };
+}
+
+/** A client that answers every request with a canned elicitation accept. */
+function makeAnsweringClient(answer: unknown): {
+  client: ClientLike;
+  request: ReturnType<typeof vi.fn>;
+  signal: () => AbortSignal | undefined;
+} {
+  let captured: AbortSignal | undefined;
+  const request = vi.fn(
+    (_method: string, _params: unknown, options?: { cancellationSignal?: AbortSignal }) => {
+      captured = options?.cancellationSignal;
+      return Promise.resolve(answer);
+    },
+  );
+  return {
+    client: { request } as unknown as ClientLike,
+    request,
+    signal: () => captured,
+  };
+}
+
+/** One single-select question (elicitation form: property q_0). */
+function askParams(): ZcodeInteractionUserInputParams {
+  return {
+    requestId: "r1",
+    sessionId: "zs1",
+    toolCallId: "tc1",
+    questions: [
+      {
+        question: "Language?",
+        multiSelect: false,
+        options: [{ label: "TS" }, { label: "JS" }],
+      },
+    ],
+  };
+}
+
+/** Elicitation accept answering q_0 with `value`. */
+function elicitAccept(value: string): unknown {
+  return { action: "accept", content: { q_0: value } };
+}
+
+/**
+ * Start an AskUserQuestion whose client request stays in flight. Synchronous
+ * on purpose: with fake timers enabled, awaiting inside a helper after the
+ * ask has started deadlocks the test (vitest 2.1.9); flush with
+ * `vi.advanceTimersByTimeAsync(0)` in the test body instead.
+ */
+function startPendingAsk(
+  server: ZcodeAcpServer,
+  cx: acp.AgentContext,
+  turn?: PendingTurn,
+): Promise<{ action: string }> {
+  return handleAskUserQuestion(server, cx, "s1", askParams(), turn) as Promise<{
+    action: string;
+  }>;
+}
+
+describe("reconnect resend of undecided interactions", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("re-sends a pending interaction to the reconnected client and adopts its answer", async () => {
+    const server = makeServer();
+    const zed = makeSilentClient(); // original target: dialog open, no answer
+    const resultP = startPendingAsk(server, zed.client as unknown as acp.AgentContext);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(zed.request).toHaveBeenCalledTimes(1);
+
+    const phone = makeAnsweringClient(elicitAccept("TS"));
+    resendPendingInteractions(server, phone.client, "s1");
+    await vi.advanceTimersByTimeAsync(300);
+
+    // The reconnected client got the same elicitation/create for this session.
+    expect(phone.request).toHaveBeenCalledTimes(1);
+    const [method, params] = phone.request.mock.calls[0] as unknown as [
+      string,
+      { sessionId?: string },
+    ];
+    expect(method).toBe("elicitation/create");
+    expect(params.sessionId).toBe("s1");
+
+    // Its answer wins the race and completes the AskUserQuestion.
+    expect(await resultP).toMatchObject({
+      action: "accept",
+      content: { answers: { "Language?": "TS" } },
+    });
+    // The original client lost the race: its dialog is dismissed via cancel.
+    expect(zed.signal()?.aborted).toBe(true);
+  });
+
+  it("ignores other sessions' pending interactions", async () => {
+    const server = makeServer();
+    const zed = makeSilentClient();
+    void startPendingAsk(server, zed.client as unknown as acp.AgentContext); // s1
+    await vi.advanceTimersByTimeAsync(0);
+
+    const phone = makeAnsweringClient(elicitAccept("TS"));
+    resendPendingInteractions(server, phone.client, "s2"); // different session
+    await vi.advanceTimersByTimeAsync(300);
+    expect(phone.request).not.toHaveBeenCalled();
+  });
+
+  it("lets the original client win; the re-send is cancelled", async () => {
+    const server = makeServer();
+    // Zed answers after a delay once the resend is in flight.
+    let resolveZed!: (v: unknown) => void;
+    const zedRequest = vi.fn(
+      (_method: string, _params: unknown, options?: { cancellationSignal?: AbortSignal }) =>
+        new Promise<unknown>((res) => {
+          resolveZed = res;
+          options?.cancellationSignal?.addEventListener("abort", () => res(undefined), {
+            once: true,
+          });
+        }),
+    );
+    const zedCx = { request: zedRequest } as unknown as acp.AgentContext;
+    const resultP = startPendingAsk(server, zedCx);
+    await vi.advanceTimersByTimeAsync(0);
+
+    const phone = makeSilentClient();
+    resendPendingInteractions(server, phone.client, "s1");
+    await vi.advanceTimersByTimeAsync(300);
+    expect(phone.request).toHaveBeenCalledTimes(1);
+
+    resolveZed(elicitAccept("JS"));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(await resultP).toMatchObject({
+      action: "accept",
+      content: { answers: { "Language?": "JS" } },
+    });
+    // The phone's re-sent request was cancelled — its dialog drops.
+    expect(phone.signal()?.aborted).toBe(true);
+  });
+
+  it("does not resend an interaction whose wait was interrupted", async () => {
+    const server = makeServer();
+    const zed = makeSilentClient();
+    const turn: PendingTurn = { zcodeSid: "zs1", cancelled: false };
+    const resultP = startPendingAsk(server, zed.client as unknown as acp.AgentContext, turn);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // User stops the turn → wait interrupted → decline; entry unregistered.
+    turn.cancelled = true;
+    await vi.advanceTimersByTimeAsync(200); // turn-cancel poll runs at 100ms
+    expect(await resultP).toMatchObject({ action: "decline" });
+
+    const phone = makeAnsweringClient(elicitAccept("TS"));
+    resendPendingInteractions(server, phone.client, "s1");
+    await vi.advanceTimersByTimeAsync(300);
+    expect(phone.request).not.toHaveBeenCalled();
+  });
+
+  it("does not resend after the interaction was already answered", async () => {
+    const server = makeServer();
+    const zed = makeAnsweringClient(elicitAccept("TS"));
+    const resultP = startPendingAsk(server, zed.client as unknown as acp.AgentContext);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(await resultP).toMatchObject({ action: "accept" });
+
+    const phone = makeAnsweringClient(elicitAccept("JS"));
+    resendPendingInteractions(server, phone.client, "s1");
+    await vi.advanceTimersByTimeAsync(300);
+    expect(phone.request).not.toHaveBeenCalled();
+  });
+
+  it("survives a re-send client whose request throws synchronously", async () => {
+    const server = makeServer();
+    // Zed holds the dialog open, answerable via a deferred.
+    let resolveZed!: (v: unknown) => void;
+    const zedRequest = vi.fn(
+      (_method: string, _params: unknown, options?: { cancellationSignal?: AbortSignal }) =>
+        new Promise<unknown>((res) => {
+          resolveZed = res;
+          options?.cancellationSignal?.addEventListener("abort", () => res(undefined), {
+            once: true,
+          });
+        }),
+    );
+    const zedCx = { request: zedRequest } as unknown as acp.AgentContext;
+    const resultP = startPendingAsk(server, zedCx);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The reconnected client's request throws synchronously (broken
+    // connection): the timer callback must not crash the process, and the
+    // race stays open for the original client.
+    const boom = {
+      request: vi.fn(() => {
+        throw new Error("connection closed");
+      }),
+    } as unknown as ClientLike;
+    resendPendingInteractions(server, boom, "s1");
+    await vi.advanceTimersByTimeAsync(300);
+    expect(boom.request).toHaveBeenCalledTimes(1);
+
+    resolveZed(elicitAccept("JS"));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(await resultP).toMatchObject({
+      action: "accept",
+      content: { answers: { "Language?": "JS" } },
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`session/request_permission` / `elicitation/create` are one-shot requests raced across the clients connected at fire time (first response wins). A remote client that was offline when the agent asked (or dropped mid-wait) never sees the request; after reconnecting it still cannot answer — the reannounce dedup only records zcode ids (no re-prompt) and the session/load replay only re-sends pending tool_call cards, not interaction requests.

## Fix

- **`src/handlers/server-requests.ts`**: every interaction wait in `requestWithTimeout` is tracked as an `ActiveInteraction` — a cross-attempt first-response-wins race (method/params + deferred + per-attempt AbortControllers). The first attempt goes through the broadcast proxy as before; targeted re-sends join the same race and losers are aborted (SDK emits `$/cancel_request`, so Zed and the phone client dismiss their dialogs).
- **`src/index.ts`**: after a client's `session/load` / `session/resume` completes (the reconnect catch-up), `resendPendingInteractions` re-sends that session's still-unanswered interaction requests to it, 300 ms delayed so the replay renders first. Connect-time resend was rejected deliberately: the phone client clears `permission`/`elicitation` state when a load starts, which would swallow an immediately re-sent dialog.
- On wait settle (answered OR interrupted) the entry is unregistered and remaining attempts aborted — this also dismisses Zed's stale popup after a turn cancel (previous behavior left it open).
- A re-send client whose `request` throws synchronously is funnelled into the rejection path: the resend fires from a timer callback, where a sync throw would crash the bridge.

## Verification

- 6 new tests in `tests/interaction-resend.test.ts` (reconnect adoption + loser cancel, session filtering, original-wins, interrupted-wait, already-answered, sync-throw survival).
- `pnpm typecheck` / `pnpm lint` / full suite (42 files, 658 tests) pass.
- Cross-checked the abort semantics against the ACP SDK source (abort only emits `$/cancel_request`; the request promise stays pending until the peer answers) and the phone client's `onCancelRequest` handling.
- `docs/PROTOCOL.md`: documented the reconnect-resend behavior in the interaction routing section.