### PR TITLE
chore: release 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-08-20
+
+### Added
+
+- Reconnect resend of undecided interactions: a `session/request_permission` /
+  `elicitation/create` fired while a remote client was offline (or dropped
+  mid-wait) is re-sent to that client once its `session/load` /
+  `session/resume` completes — the reconnect catch-up — after a 300 ms delay
+  so the replay renders first. Every interaction wait is now tracked as a
+  cross-attempt first-response-wins race: the re-send joins it, and losing
+  attempts are aborted (`$/cancel_request`), dismissing leftover dialogs on
+  the other clients. A wait interrupted by turn cancel or timeout now also
+  dismisses the client's still-open popup. Protocol behaviour documented in
+  docs/PROTOCOL.md (interaction routing).
+
 ## [0.10.0] - 2026-08-20
 
 ### Removed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zcode-acp-server",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Agent Client Protocol (ACP) server bridging headless ZCode to editors like Zed and JetBrains.",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
Version bump for the reconnect interaction resend feature merged in #64.

- package.json 0.10.0 → 0.11.0 (single source of truth; hub-vs-bridge version handshake reads it)
- CHANGELOG.md 0.11.0 entry (Keep a Changelog format)