### PR TITLE
fix: preserve structured quota failures over ACP

### DIFF
--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -842,14 +842,13 @@ export async function prompt(
         // Only a transient TurnFailedError is retryable; everything else (send
         // failures, non-transient turn errors, exhausted retries, cancellation)
         // propagates to the caller.
-        if (
-          e instanceof TurnFailedError &&
-          attempt < MAX_TURN_ATTEMPTS &&
-          !turn.cancelled &&
-          isTransientTurnError(e.turnError)
-        ) {
-          lastTurnError = e.turnError;
-          continue;
+        if (e instanceof TurnFailedError) {
+          const transient = isTransientTurnError(e.turnError);
+          if (attempt < MAX_TURN_ATTEMPTS && !turn.cancelled && transient) {
+            lastTurnError = e.turnError;
+            continue;
+          }
+          if (!transient) throw turnFailureRequestError(e);
         }
         throw e;
       }
@@ -966,6 +965,67 @@ class TurnFailedError extends Error {
     this.name = "TurnFailedError";
     this.turnError = turnError;
   }
+}
+
+interface AcpTurnFailureData {
+  type: "zcode_turn_failed";
+  code?: string;
+  reason?: string;
+  statusCode?: number;
+  providerCode?: string;
+  retryable?: boolean;
+  retryAfterMs?: number;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value !== "string" || value.trim() === "") return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/** Build a small, safe ACP error payload from a backend turn failure. */
+function acpTurnFailureData(turnError: Record<string, unknown>): AcpTurnFailureData {
+  const cause = asRecord(turnError["cause"]) ?? turnError;
+  const context = asRecord(cause["context"]);
+  const summary = asRecord(context?.["responseBodySummary"]);
+  const headers = asRecord(summary?.["responseHeaders"]);
+  const retryAfterMs =
+    finiteNumber(context?.["retryAfterMs"]) ??
+    (() => {
+      const seconds = finiteNumber(headers?.["retry-after"]);
+      return seconds === undefined ? undefined : seconds * 1000;
+    })();
+
+  const data: AcpTurnFailureData = { type: "zcode_turn_failed" };
+  const code = cause["code"] ?? cause["type"];
+  if (typeof code === "string" && code.trim()) data.code = code;
+  const reason = context?.["reason"];
+  if (typeof reason === "string" && reason.trim()) data.reason = reason;
+  const statusCode = finiteNumber(context?.["statusCode"] ?? context?.["responseStatus"]);
+  if (statusCode !== undefined) data.statusCode = statusCode;
+  const providerCode = context?.["providerCode"];
+  if (typeof providerCode === "string" && providerCode.trim()) data.providerCode = providerCode;
+  const retryable = context?.["retryable"];
+  if (typeof retryable === "boolean") data.retryable = retryable;
+  if (retryAfterMs !== undefined) data.retryAfterMs = retryAfterMs;
+  return data;
+}
+
+function turnFailureRequestError(error: TurnFailedError): RequestError {
+  const cause = asRecord(error.turnError["cause"]);
+  const detail = formatTurnError(cause ?? error.turnError) || error.message;
+  return new RequestError(
+    -32603,
+    `ZCode turn failed: ${detail}`,
+    acpTurnFailureData(error.turnError),
+  );
 }
 
 /**

--- a/src/translators/tool-helpers.ts
+++ b/src/translators/tool-helpers.ts
@@ -382,6 +382,7 @@ export function formatTurnError(error: unknown): string {
 const TRANSIENT_CAUSE_CODES = new Set([
   "model_request_failed",
   "invalid_model_request", // provider rejected the request — often plan/quota or brief provider-side rejection
+  "model_rate_limited",
   "provider_not_configured",
   "rate_limit",
   "timeout",
@@ -429,6 +430,15 @@ export function isTransientTurnError(error: unknown): boolean {
 function matchesTransient(node: unknown): boolean {
   if (!node || typeof node !== "object" || Array.isArray(node)) return false;
   const n = node as Record<string, unknown>;
+  const context = n["context"];
+  if (
+    context &&
+    typeof context === "object" &&
+    !Array.isArray(context) &&
+    (context as Record<string, unknown>)["retryable"] === false
+  ) {
+    return false;
+  }
   const code = String(n["code"] ?? n["type"] ?? "").trim();
   if (code && TRANSIENT_CAUSE_CODES.has(code)) return true;
   const message = String(n["message"] ?? n["detail"] ?? "").toLowerCase();

--- a/tests/turn-retry.test.ts
+++ b/tests/turn-retry.test.ts
@@ -32,6 +32,7 @@ describe("isTransientTurnError", () => {
       "invalid_model_request",
       "provider_not_configured",
       "rate_limit",
+      "model_rate_limited",
       "timeout",
       "ECONNRESET",
       "ETIMEDOUT",
@@ -57,6 +58,14 @@ describe("isTransientTurnError", () => {
     expect(
       isTransientTurnError({ cause: { message: "provider rejected the model request" } }),
     ).toBe(true);
+  });
+
+  it("does not retry when the backend explicitly marks a rate limit non-retryable", () => {
+    expect(
+      isTransientTurnError({
+        cause: { code: "rate_limit", context: { retryable: false } },
+      }),
+    ).toBe(false);
   });
 
   it("matches via message keyword when code is absent/unrecognised", () => {

--- a/tests/turn-state.test.ts
+++ b/tests/turn-state.test.ts
@@ -129,6 +129,62 @@ describe("$/zcode/turnState emission", () => {
     expect(server.pendingTurns.size).toBe(0);
   });
 
+  it("preserves a non-retryable model quota failure in the ACP error", async () => {
+    const server = setup(
+      scriptedBackend(() => [
+        { type: "turn.started" },
+        {
+          type: "turn.failed",
+          payload: {
+            error: {
+              code: "UNKNOWN_ERROR",
+              message: "Turn execution failed",
+              cause: {
+                code: "model_rate_limited",
+                message: "Usage limit reached; resets later",
+                context: {
+                  providerCode: "1308",
+                  responseStatus: 429,
+                  reason: "rate_limited",
+                  retryable: false,
+                  responseBodySummary: {
+                    responseHeaders: { "retry-after": "1118", "set-cookie": "secret" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      ]),
+    );
+    const { cx, turnStates } = collectCx();
+
+    const error = await prompt(server, promptParams(), cx, 3).then(
+      () => null,
+      (reason: unknown) => reason,
+    );
+
+    expect(error).toMatchObject({
+      name: "RequestError",
+      code: -32603,
+      message: "ZCode turn failed: model_rate_limited Usage limit reached; resets later",
+      data: {
+        type: "zcode_turn_failed",
+        code: "model_rate_limited",
+        reason: "rate_limited",
+        statusCode: 429,
+        providerCode: "1308",
+        retryable: false,
+        retryAfterMs: 1_118_000,
+      },
+    });
+    expect(JSON.stringify((error as { data?: unknown }).data)).not.toContain("secret");
+    expect(turnStates).toEqual([
+      { sessionId: "sess_ts", running: true },
+      { sessionId: "sess_ts", running: false },
+    ]);
+  });
+
   it("preempted turn's exit reports running:true while the preemptor is in flight", async () => {
     let sendCount = 0;
     const server = setup(


### PR DESCRIPTION
## Summary

- recognize ZCode's `model_rate_limited` cause code while honoring an explicit `context.retryable: false`
- convert non-retryable `turn.failed` events into an ACP `RequestError` instead of allowing the SDK to collapse them to a generic `Internal error`
- preserve a small machine-readable error payload (`code`, `reason`, status/provider codes, retryability, and `retryAfterMs`) without forwarding response headers or cookies
- add an end-to-end prompt-handler regression test based on the observed coding-plan quota failure

This deliberately leaves delayed retry scheduling to ACP clients/control planes. The bridge keeps the session resumable and provides the metadata those clients need to decide when to resume.

Closes #77

## Test plan

- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint .`
- `./node_modules/.bin/tsc`
- `./node_modules/.bin/vitest run` — 52 files, 723 tests passed
