### PR TITLE
fix: create tool cards when scheduled events are missing

### DIFF
--- a/src/translators/event-translator.ts
+++ b/src/translators/event-translator.ts
@@ -193,47 +193,24 @@ export class EventTranslator {
     const results: InternalEvent[] = [];
     const tkind = (payload["kind"] as string) ?? "";
     const callId = (payload["toolCallId"] as string) ?? "";
-    let toolName = (payload["toolName"] as string) ?? "";
+    const toolName = (payload["toolName"] as string) ?? "";
 
     if (tkind === "scheduled") {
-      if (callId && !this.seenToolIds.has(callId)) {
-        this.seenToolIds.add(callId);
-        if (toolName) {
-          this.toolNames.set(callId, toolName);
-        } else {
-          toolName = this.toolNames.get(callId) ?? "unknown";
-        }
-        const acpKind = TOOL_KIND_MAP[toolName] ?? "execute";
-        // Input: scheduled payload first, fall back to cached tool_call input.
-        let inp = payload["input"];
-        if (inp === undefined) inp = this.toolInputs.get(callId);
-        const summary = summarizeToolInput(toolName, inp);
-        const title = summary ? `${toolName}: ${summary}` : toolName;
-        // Track background launches so the later `result` event (input omitted)
-        // can still tag its ToolCallUpdate. The BackgroundTaskListener also
-        // keys off this to know which callId owns the card.
-        const isBackground = isBackgroundInput(inp);
-        if (isBackground) this.backgroundCallIds.add(callId);
-        const newEv: InternalEvent = {
-          kind: "ToolCallNew",
-          callId,
-          tool: toolName,
-          acpKind,
-          status: "pending",
-          title,
-          ...(isBackground ? { background: true } : {}),
-        };
-        if (inp !== undefined) (newEv as { input?: unknown }).input = inp;
-        const locs = extractLocations(toolName, inp);
-        if (locs.length > 0) (newEv as { locations?: typeof locs }).locations = locs;
-        results.push(newEv);
-      }
+      const newEv = this.createToolCall(callId, toolName, payload["input"], "pending");
+      if (newEv) results.push(newEv);
     } else if (tkind === "started") {
       if (callId) {
-        results.push({ kind: "ToolCallUpdate", callId, status: "in_progress" });
+        const newEv = this.createToolCall(callId, toolName, payload["input"], "in_progress");
+        if (newEv) {
+          results.push(newEv);
+        } else {
+          results.push({ kind: "ToolCallUpdate", callId, status: "in_progress" });
+        }
       }
     } else if (tkind === "progress") {
       if (callId) {
+        const newEv = this.createToolCall(callId, toolName, payload["input"], "in_progress");
+        if (newEv) results.push(newEv);
         const output = payload["stdoutTail"] ?? payload["stderrTail"] ?? "";
         const tn = (toolName || this.toolNames.get(callId)) ?? "";
         results.push({
@@ -247,6 +224,8 @@ export class EventTranslator {
       }
     } else if (tkind === "result") {
       if (callId) {
+        const newEv = this.createToolCall(callId, toolName, payload["input"], "in_progress");
+        if (newEv) results.push(newEv);
         const resultPayload = payload["result"];
         const tn = (toolName || this.toolNames.get(callId)) ?? "";
         const ev: InternalEvent = {
@@ -268,6 +247,8 @@ export class EventTranslator {
       }
     } else if (tkind === "error") {
       if (callId) {
+        const newEv = this.createToolCall(callId, toolName, payload["input"], "in_progress");
+        if (newEv) results.push(newEv);
         const tn = (toolName || this.toolNames.get(callId)) ?? "";
         const errPayload = payload["error"];
         const ev: InternalEvent = {
@@ -297,6 +278,37 @@ export class EventTranslator {
       }
     }
     return results;
+  }
+
+  /** Create the first ACP tool event, even if the backend omitted `scheduled`. */
+  private createToolCall(
+    callId: string,
+    eventToolName: string,
+    eventInput: unknown,
+    status: "pending" | "in_progress",
+  ): Extract<InternalEvent, { kind: "ToolCallNew" }> | null {
+    if (!callId || this.seenToolIds.has(callId)) return null;
+    this.seenToolIds.add(callId);
+
+    const toolName = eventToolName || this.toolNames.get(callId) || "unknown";
+    this.toolNames.set(callId, toolName);
+    const input = eventInput === undefined ? this.toolInputs.get(callId) : eventInput;
+    const summary = summarizeToolInput(toolName, input);
+    const isBackground = isBackgroundInput(input);
+    if (isBackground) this.backgroundCallIds.add(callId);
+    const newEv: Extract<InternalEvent, { kind: "ToolCallNew" }> = {
+      kind: "ToolCallNew",
+      callId,
+      tool: toolName,
+      acpKind: TOOL_KIND_MAP[toolName] ?? "execute",
+      status,
+      title: summary ? `${toolName}: ${summary}` : toolName,
+      ...(isBackground ? { background: true } : {}),
+    };
+    if (input !== undefined) newEv.input = input;
+    const locations = extractLocations(toolName, input);
+    if (locations.length > 0) newEv.locations = locations;
+    return newEv;
   }
 
   private translateTurnDone(payload: Record<string, unknown>): InternalEvent[] {

--- a/tests/event-translator.test.ts
+++ b/tests/event-translator.test.ts
@@ -65,6 +65,43 @@ describe("EventTranslator", () => {
     expect(out2).toHaveLength(0);
   });
 
+  it("creates an in-progress tool call when started arrives without scheduled", () => {
+    const t = new EventTranslator();
+    t.translate(
+      ev("model.streaming", {
+        kind: "tool_call",
+        toolCallId: "c2_missing_scheduled",
+        toolName: "Bash",
+        input: { command: "sleep 140" },
+      }),
+    );
+
+    const out = t.translate(
+      ev("tool.updated", { kind: "started", toolCallId: "c2_missing_scheduled" }),
+    );
+
+    expect(out).toEqual([
+      expect.objectContaining({
+        kind: "ToolCallNew",
+        callId: "c2_missing_scheduled",
+        tool: "Bash",
+        status: "in_progress",
+        title: "Bash: sleep 140",
+        input: { command: "sleep 140" },
+      }),
+    ]);
+    expect(t.seenToolIds.has("c2_missing_scheduled")).toBe(true);
+    expect(
+      t.translate(
+        ev("tool.updated", {
+          kind: "scheduled",
+          toolCallId: "c2_missing_scheduled",
+          toolName: "Bash",
+        }),
+      ),
+    ).toEqual([]);
+  });
+
   it("translates tool.updated result → completed ToolCallUpdate with content for Read", () => {
     const t = new EventTranslator();
     t.translate(ev("tool.updated", { kind: "scheduled", toolCallId: "c3", toolName: "Read" }));
@@ -81,6 +118,36 @@ describe("EventTranslator", () => {
     expect(u.content?.[0]).toMatchObject({
       type: "content",
       content: { type: "text", text: "file body" },
+    });
+  });
+
+  it("creates a tool call before completing a result received without prior lifecycle events", () => {
+    const t = new EventTranslator();
+    t.translate(
+      ev("model.streaming", {
+        kind: "tool_call",
+        toolCallId: "c3_missing_lifecycle",
+        toolName: "Read",
+        input: { file_path: "README.md" },
+      }),
+    );
+
+    const out = t.translate(
+      ev("tool.updated", {
+        kind: "result",
+        toolCallId: "c3_missing_lifecycle",
+        result: { success: true, content: "file body" },
+      }),
+    );
+
+    expect(out.map((event) => [event.kind, event.status])).toEqual([
+      ["ToolCallNew", "in_progress"],
+      ["ToolCallUpdate", "completed"],
+    ]);
+    expect(out[0]).toMatchObject({
+      callId: "c3_missing_lifecycle",
+      tool: "Read",
+      input: { file_path: "README.md" },
     });
   });
 


### PR DESCRIPTION
## Summary

- create `ToolCallNew` from the first observed tool lifecycle event instead of
  requiring `tool.updated { kind: "scheduled" }`
- recover tool name/input from the cached `model.streaming { kind: "tool_call" }`
  payload when later lifecycle events omit them
- preserve `seenToolIds` deduplication so a late `scheduled` event cannot create
  a duplicate card
- emit a best-effort in-progress card before a first-seen terminal result/error,
  preserving the existing completion and Bash terminal-exit paths

Fixes #81.

## Why

ZCode runtime 0.16.5 was observed emitting `started` and `result` for a
foreground Bash call without a `scheduled` event. The bridge therefore sent
only `tool_call_update` notifications. ACP clients had no active tool card
while the process was running and later received an orphan completion.

The regression tests drive the translator directly with that captured event
ordering. Before this change they fail because the first event is
`ToolCallUpdate`; after this change the lifecycle is:

```text
started without scheduled
  -> ToolCallNew(in_progress)

result without any prior lifecycle event
  -> ToolCallNew(in_progress)
  -> ToolCallUpdate(completed)
```

## Test plan

```text
./node_modules/.bin/vitest run tests/event-translator.test.ts
./node_modules/.bin/vitest run
./node_modules/.bin/tsc --noEmit
./node_modules/.bin/eslint src/translators/event-translator.ts tests/event-translator.test.ts
./node_modules/.bin/tsc
```

Results locally:

- EventTranslator: 22/22 passed
- Full suite: 794/794 passed
- Typecheck, ESLint, and build passed

## Scope

This PR does not change turn timeout or stale-projection policy from #80. It
only repairs ACP tool lifecycle ordering at the translator boundary.
