### PR TITLE
fix: bound stale running turn recovery

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -263,10 +263,21 @@ editor still has it open).
     | turn.completed      | -> end_turn
     | turn.failed         | -> error
     | turn.cancelled      | -> cancelled
-    | timeout (120s)      | -> max_turn_requests
+    | no protocol        |
+    | progress (120s)    | -> probe prompt lock
+    |   lock released    | -> max_turn_requests
+    |   lock held        | -> defer decision
     | manual cancel       | -> cancelled
     +---------------------+
 ```
+
+Projection polling is a recovery signal, not protocol progress. In
+particular, `projection.status=running` may be stale and therefore never
+refreshes the 120-second deadline. At that deadline the bridge probes the
+backend prompt lock (`session/goal show`): an explicitly held lock proves a
+model or tool turn is still active and defers the terminal decision, while a
+released or indeterminate lock preserves the bounded `max_turn_requests`
+outcome. Already-queued events win the deadline race and are consumed first.
 
 ### Tool lifecycle
 

--- a/src/backend/listener.ts
+++ b/src/backend/listener.ts
@@ -7,8 +7,8 @@
  * resubscribe from it to recover missed events after a stall.
  *
  * `TurnMonitor` is the legacy snapshot path: a one-shot `session/read` that
- * returns the authoritative projection. Used for stall reconciliation and
- * lock-release probing.
+ * returns the latest projection. Used for stall reconciliation, but never as
+ * proof of protocol progress because a `running` projection may be stale.
  */
 
 import type { ZcodeBackend } from "./client.js";
@@ -196,8 +196,9 @@ export class EventStreamListener {
 }
 
 /**
- * Legacy snapshot path: a single `session/read` returning the authoritative
- * projection. Used in stall reconciliation and lock-release probing.
+ * Legacy snapshot path: a single `session/read` returning the latest
+ * projection. Used in stall reconciliation; prompt-lock state is probed
+ * separately because a `running` projection may be stale.
  */
 export class TurnMonitor {
   private readonly backend: ZcodeBackend;

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -1380,7 +1380,8 @@ async function runEventTurn(
   const translator = new EventTranslator();
   differ.resetTurn();
   const NO_PROGRESS_MS = 120_000;
-  let lastProgress = Date.now();
+  let lastProtocolProgressAt = Date.now();
+  let nextNoProgressDecisionAt = lastProtocolProgressAt + NO_PROGRESS_MS;
   let lastStallCheck = Date.now();
   let emittedText = false;
   let emittedOutput = false;
@@ -1395,7 +1396,45 @@ async function runEventTurn(
   let thinkingHintSent = false;
   const THINKING_HINT_DELAY_MS = 1200;
 
-  while (Date.now() - lastProgress < NO_PROGRESS_MS) {
+  const recordProtocolProgress = (): void => {
+    lastProtocolProgressAt = Date.now();
+    nextNoProgressDecisionAt = lastProtocolProgressAt + NO_PROGRESS_MS;
+  };
+
+  while (true) {
+    if (Date.now() >= nextNoProgressDecisionAt) {
+      if (listener.hasQueuedEvents()) {
+        // An event that arrived exactly at the deadline is real protocol
+        // progress. Consume it below before making any terminal decision.
+        recordProtocolProgress();
+      } else if (turn.cancelled) {
+        // Preserve the pre-existing bounded cancel behaviour. A stuck prompt
+        // lock after stop must not keep a user-cancelled turn alive forever.
+        stopBackendTurn(server, turn.zcodeSid);
+        return { stopReason: "max_turn_requests" };
+      } else {
+        const lockState = await probePromptLock(server, turn.zcodeSid);
+        if (lockState === "held") {
+          // A prompt-lock failure is direct evidence that the backend still owns
+          // an active turn. It is liveness, not protocol progress: leave
+          // lastProtocolProgressAt untouched and schedule a later decision.
+          // This protects legitimately long model/tool operations without
+          // allowing a stale `projection.status=running` to refresh the clock.
+          const activeTools = [...translator.seenToolIds].filter(
+            (toolId) => !translator.finalToolIds.has(toolId),
+          ).length;
+          log(
+            `  [stall] prompt lock still held after ${Math.round((Date.now() - lastProtocolProgressAt) / 1000)}s silence (activeTools=${activeTools}); deferring terminal decision`,
+          );
+          nextNoProgressDecisionAt = Date.now() + NO_PROGRESS_MS;
+        } else {
+          log(`  [stall] no-progress deadline reached; prompt lock=${lockState}`);
+          stopBackendTurn(server, turn.zcodeSid);
+          return { stopReason: "max_turn_requests" };
+        }
+      }
+    }
+
     // Drain + handle server→client requests (interaction/*). Refreshes the
     // no-progress timer when any are handled. Pass `turn` so interaction
     // requests become turn-cancel aware (user stop aborts pending popups).
@@ -1408,7 +1447,7 @@ async function runEventTurn(
       warn(`handleServerRequests threw: ${e instanceof Error ? e.message : String(e)}`);
     }
     if (handled) {
-      lastProgress = Date.now();
+      recordProtocolProgress();
     }
 
     if (turn.cancelled) {
@@ -1456,7 +1495,7 @@ async function runEventTurn(
       if (
         !turn.cancelled &&
         translator.turnStarted &&
-        Date.now() - lastProgress > 15_000 &&
+        Date.now() - lastProtocolProgressAt > 15_000 &&
         Date.now() - lastStallCheck > 15_000
       ) {
         lastStallCheck = Date.now();
@@ -1470,7 +1509,7 @@ async function runEventTurn(
           // turn is alive (it stays queued for the next poll).
           await sleep(1500);
           if (listener.hasQueuedEvents()) {
-            lastProgress = Date.now();
+            recordProtocolProgress();
             continue; // alive — events will be consumed by the next poll
           }
           const proj2 = await monitor.pollOnce();
@@ -1496,7 +1535,6 @@ async function runEventTurn(
           // Second probe says the backend is still working (or events arrived
           // mid-probe) — keep waiting; queued events are consumed by the next
           // poll iteration.
-          lastProgress = Date.now();
           if (proj2?.status === "running") {
             await listener.resubscribe(() => server.nextId());
           }
@@ -1507,14 +1545,13 @@ async function runEventTurn(
           // The send-retry loop in prompt() already covers the recovery window
           // for the NEXT turn; for this in-flight turn we just resubscribe and
           // let the backend emit its terminal event when ready.
-          lastProgress = Date.now();
           await listener.resubscribe(() => server.nextId());
         }
       }
       continue;
     }
 
-    lastProgress = Date.now();
+    recordProtocolProgress();
     // Turn-attribution gate: before this turn's own turn.started arrives, any
     // event is leftover from a prior turn (cancelled/preempted but still
     // finalising) that landed in the queue while send was retrying on a busy
@@ -1660,10 +1697,36 @@ async function runEventTurn(
       return { stopReason: "end_turn" };
     }
   }
+}
 
-  // 120s no progress: abandon.
-  stopBackendTurn(server, turn.zcodeSid);
-  return { stopReason: "max_turn_requests" };
+type PromptLockState = "held" | "released" | "unknown";
+
+/**
+ * Probe the backend's authoritative prompt lock without waiting for it to
+ * change. `session/read` projection status is intentionally not considered:
+ * that projection can remain stale at `running`, which is the condition this
+ * probe is used to disambiguate.
+ */
+async function probePromptLock(server: ZcodeAcpServer, zcodeSid: string): Promise<PromptLockState> {
+  const backend = server.ensureBackend();
+  if (backend.isDead) return "unknown";
+  try {
+    const resp = await backend.request(
+      server.nextId(),
+      "session/goal",
+      { sessionId: zcodeSid, action: "show" },
+      10_000,
+    );
+    if (!resp.error) return "released";
+    const message = (resp.error.message ?? "").toLowerCase();
+    if (message.includes("prompt is running") || message.includes("already running")) {
+      return "held";
+    }
+    return "unknown";
+  } catch (e) {
+    log(`  [stall] prompt-lock probe failed: ${e instanceof Error ? e.message : String(e)}`);
+    return "unknown";
+  }
 }
 
 /**

--- a/tests/stale-running-recovery.test.ts
+++ b/tests/stale-running-recovery.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Regression coverage for a stale `projection.status === "running"` keeping
+ * the event turn alive forever.  The public `prompt()` boundary is used so the
+ * test covers the real listener, monitor, and timeout wiring together.
+ */
+
+import type * as acp from "@agentclientprotocol/sdk";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ZcodeBackend } from "../src/backend/client.js";
+import type { ZcodeEvent } from "../src/backend/types.js";
+import "../src/handlers/slash.js";
+import { prompt } from "../src/handlers/session.js";
+import { ZcodeAcpServer } from "../src/server.js";
+
+vi.mock("../src/tasks-index.js", () => ({
+  upsertSessionTask: async () => true,
+  updateSessionTitle: async () => true,
+}));
+
+interface StaleBackendControl {
+  backend: ZcodeBackend;
+  emit: (event: ZcodeEvent) => void;
+  goalProbes: ReturnType<typeof vi.fn>;
+  setPromptLockHeld: (held: boolean) => void;
+  sendRequests: ReturnType<typeof vi.fn>;
+}
+
+function staleRunningBackend(): StaleBackendControl {
+  const listeners = new Set<{ handleEvent: (event: ZcodeEvent) => void }>();
+  let promptLockHeld = false;
+  const goalProbes = vi.fn(async () =>
+    promptLockHeld
+      ? { error: { message: "session goal: prompt is running" } }
+      : { result: { goal: null } },
+  );
+  const sendRequests = vi.fn();
+  const backend = {
+    isDead: false,
+    request: async (_id: number, method: string) => {
+      switch (method) {
+        case "workspace/updateProviderRegistry":
+        case "session/resume":
+          return { result: {} };
+        case "session/subscribe":
+          return { result: { eventSeq: 1 } };
+        case "session/messages":
+          return { result: { messages: [] } };
+        case "session/read":
+          return {
+            result: {
+              projection: { status: "running", contextUsed: 0 },
+              settings: {},
+            },
+          };
+        case "session/goal":
+          return goalProbes();
+        case "session/send":
+          sendRequests();
+          for (const listener of listeners) listener.handleEvent({ type: "turn.started" });
+          return { result: { accepted: true } };
+        default:
+          return { error: { message: `unhandled ${method}` } };
+      }
+    },
+    send: vi.fn(),
+    pollServerRequests: () => [],
+    registerEventListener: (_sid: string, listener: { handleEvent: (event: ZcodeEvent) => void }) =>
+      listeners.add(listener),
+    unregisterEventListener: (
+      _sid: string,
+      listener: { handleEvent: (event: ZcodeEvent) => void },
+    ) => listeners.delete(listener),
+  } as unknown as ZcodeBackend;
+  return {
+    backend,
+    emit: (event) => {
+      for (const listener of listeners) listener.handleEvent(event);
+    },
+    goalProbes,
+    setPromptLockHeld: (held) => {
+      promptLockHeld = held;
+    },
+    sendRequests,
+  };
+}
+
+function setup(backend: ZcodeBackend): ZcodeAcpServer {
+  const server = new ZcodeAcpServer();
+  server.backend = backend;
+  server.registerSession("sess_stale", "zs_stale");
+  server.markBackendLoaded("sess_stale");
+  return server;
+}
+
+const params = {
+  sessionId: "sess_stale",
+  prompt: [{ type: "text", text: "hello" }],
+} as acp.PromptRequest;
+
+const cx = {
+  notify: vi.fn().mockResolvedValue(undefined),
+  request: vi.fn().mockResolvedValue({}),
+} as unknown as acp.AgentContext;
+
+describe("stale running projection recovery", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("bounds a silent turn when running is stale and the prompt lock is released", async () => {
+    const { backend, goalProbes, sendRequests } = staleRunningBackend();
+    const turn = prompt(setup(backend), params, cx, 1);
+    let result: acp.PromptResponse | undefined;
+    void turn.then((value) => {
+      result = value;
+    });
+
+    // Let prompt() finish its immediate setup/subscribe/send chain before the
+    // large time jump; otherwise fake time can advance before runEventTurn has
+    // captured its initial deadline.
+    for (let i = 0; i < 20 && sendRequests.mock.calls.length === 0; i++) {
+      await Promise.resolve();
+    }
+    expect(sendRequests).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(121_000);
+
+    expect(result).toEqual({ stopReason: "max_turn_requests" });
+    expect(goalProbes).toHaveBeenCalled();
+  });
+
+  it("does not cancel an active tool while the prompt lock is still held", async () => {
+    const control = staleRunningBackend();
+    control.setPromptLockHeld(true);
+    const turn = prompt(setup(control.backend), params, cx, 2);
+    let settled = false;
+    void turn.then(() => {
+      settled = true;
+    });
+
+    for (let i = 0; i < 20 && control.sendRequests.mock.calls.length === 0; i++) {
+      await Promise.resolve();
+    }
+    expect(control.sendRequests).toHaveBeenCalledOnce();
+    control.emit({
+      type: "tool.updated",
+      payload: {
+        kind: "scheduled",
+        toolCallId: "tool-1",
+        toolName: "Read",
+        input: { file_path: "/tmp/example" },
+      },
+    });
+    control.emit({
+      type: "tool.updated",
+      payload: { kind: "started", toolCallId: "tool-1", toolName: "Read" },
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(121_000);
+
+    expect(control.goalProbes).toHaveBeenCalled();
+    expect(settled).toBe(false);
+
+    control.emit({ type: "turn.completed", payload: { resultType: "success" } });
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    await expect(turn).resolves.toEqual({ stopReason: "end_turn" });
+  });
+});


### PR DESCRIPTION
## Summary

- separate real ACP/ZCode protocol progress from projection-based liveness probes
- stop refreshing the 120-second deadline when `session/read` only repeats `status: running`
- at the no-progress deadline, probe the authoritative prompt lock with `session/goal show`
- preserve long-running model/tool work when the prompt lock is explicitly held
- keep the existing bounded `max_turn_requests` outcome when the lock is released or indeterminate
- consume already-queued events before making a deadline decision

## Why this is a Draft

This implements the narrow, conservative case described in #80: a stale running projection can no longer keep a turn alive after the real prompt lock has been released.

An explicitly held prompt lock defers the next terminal decision by another 120 seconds. That can repeat while the backend continues to prove ownership of the turn. This avoids imposing an arbitrary hard limit on a legitimate long-running model or tool operation, but deliberately does not define policy for a genuinely stuck prompt lock. Maintainer feedback on that boundary is welcome before marking this ready.

## Tests

- added a deterministic public-boundary regression test through `prompt()` for stale running plus released lock
- added a long-running active-tool regression test proving an explicitly held lock is not cancelled and later completion still returns `end_turn`
- `eslint` on changed TypeScript files
- `tsc --noEmit`
- `tsc`
- full test suite: 56 files, 794 tests passed

Refs #80
