### PR TITLE
fix: bound stale running turn recovery (rebased)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -263,10 +263,21 @@ editor still has it open).
     | turn.completed      | -> end_turn
     | turn.failed         | -> error
     | turn.cancelled      | -> cancelled
-    | timeout (120s)      | -> max_turn_requests
+    | no protocol        |
+    | progress (120s)    | -> probe prompt lock
+    |   lock released    | -> max_turn_requests
+    |   lock held        | -> defer decision
     | manual cancel       | -> cancelled
     +---------------------+
 ```
+
+Projection polling is a recovery signal, not protocol progress. In
+particular, `projection.status=running` may be stale and therefore never
+refreshes the 120-second deadline. At that deadline the bridge probes the
+backend prompt lock (`session/goal show`): an explicitly held lock proves a
+model or tool turn is still active and defers the terminal decision, while a
+released or indeterminate lock preserves the bounded `max_turn_requests`
+outcome. Already-queued events win the deadline race and are consumed first.
 
 ### Tool lifecycle
 

--- a/src/backend/listener.ts
+++ b/src/backend/listener.ts
@@ -7,8 +7,8 @@
  * resubscribe from it to recover missed events after a stall.
  *
  * `TurnMonitor` is the legacy snapshot path: a one-shot `session/read` that
- * returns the authoritative projection. Used for stall reconciliation and
- * lock-release probing.
+ * returns the latest projection. Used for stall reconciliation, but never as
+ * proof of protocol progress because a `running` projection may be stale.
  */
 
 import type { ZcodeBackend } from "./client.js";
@@ -197,8 +197,9 @@ export class EventStreamListener {
 }
 
 /**
- * Legacy snapshot path: a single `session/read` returning the authoritative
- * projection. Used in stall reconciliation and lock-release probing.
+ * Legacy snapshot path: a single `session/read` returning the latest
+ * projection. Used in stall reconciliation; prompt-lock state is probed
+ * separately because a `running` projection may be stale.
  */
 export class TurnMonitor {
   private readonly backend: ZcodeBackend;

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -1660,7 +1660,7 @@ export async function runEventTurn(
       } else if (turn.cancelled) {
         // Preserve the pre-existing bounded cancel behaviour. A stuck prompt
         // lock after stop must not keep a user-cancelled turn alive forever.
-        stopBackendTurn(server, turn.zcodeSid);
+        stopBackendTurn(server, turn.zcodeSid, turn.foregroundExecutionId);
         return { stopReason: "max_turn_requests" };
       } else {
         const lockState = await probePromptLock(server, turn.zcodeSid);
@@ -1679,7 +1679,7 @@ export async function runEventTurn(
           nextNoProgressDecisionAt = Date.now() + NO_PROGRESS_MS;
         } else {
           log(`  [stall] no-progress deadline reached; prompt lock=${lockState}`);
-          stopBackendTurn(server, turn.zcodeSid);
+          stopBackendTurn(server, turn.zcodeSid, turn.foregroundExecutionId);
           return { stopReason: "max_turn_requests" };
         }
       }
@@ -1979,11 +1979,6 @@ export async function runEventTurn(
   }
 }
 
-  // 120s no progress: abandon.
-  stopBackendTurn(server, turn.zcodeSid, turn.foregroundExecutionId);
-  return { stopReason: "max_turn_requests" };
-}
-
 type PromptLockState = "held" | "released" | "unknown";
 
 /**
@@ -2003,6 +1998,11 @@ async function probePromptLock(server: ZcodeAcpServer, zcodeSid: string): Promis
       10_000,
     );
     if (!resp.error) return "released";
+    // Lock-busy must match by error CODE, not message text: backend message
+    // wording drifts between releases (repo Gotcha), and a missed match kills
+    // a live turn. 1308 is the prompt-lock-busy code (same one the send-retry
+    // loop keys on); message matching kept as a legacy fallback.
+    if (resp.error.code === 1308) return "held";
     const message = (resp.error.message ?? "").toLowerCase();
     if (message.includes("prompt is running") || message.includes("already running")) {
       return "held";

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -1630,7 +1630,8 @@ export async function runEventTurn(
   const translator = new EventTranslator();
   differ.resetTurn();
   const NO_PROGRESS_MS = 120_000;
-  let lastProgress = Date.now();
+  let lastProtocolProgressAt = Date.now();
+  let nextNoProgressDecisionAt = lastProtocolProgressAt + NO_PROGRESS_MS;
   let lastStallCheck = Date.now();
   let emittedText = false;
   let emittedOutput = false;
@@ -1645,7 +1646,45 @@ export async function runEventTurn(
   let thinkingHintSent = false;
   const THINKING_HINT_DELAY_MS = 1200;
 
-  while (Date.now() - lastProgress < NO_PROGRESS_MS) {
+  const recordProtocolProgress = (): void => {
+    lastProtocolProgressAt = Date.now();
+    nextNoProgressDecisionAt = lastProtocolProgressAt + NO_PROGRESS_MS;
+  };
+
+  while (true) {
+    if (Date.now() >= nextNoProgressDecisionAt) {
+      if (listener.hasQueuedEvents()) {
+        // An event that arrived exactly at the deadline is real protocol
+        // progress. Consume it below before making any terminal decision.
+        recordProtocolProgress();
+      } else if (turn.cancelled) {
+        // Preserve the pre-existing bounded cancel behaviour. A stuck prompt
+        // lock after stop must not keep a user-cancelled turn alive forever.
+        stopBackendTurn(server, turn.zcodeSid);
+        return { stopReason: "max_turn_requests" };
+      } else {
+        const lockState = await probePromptLock(server, turn.zcodeSid);
+        if (lockState === "held") {
+          // A prompt-lock failure is direct evidence that the backend still owns
+          // an active turn. It is liveness, not protocol progress: leave
+          // lastProtocolProgressAt untouched and schedule a later decision.
+          // This protects legitimately long model/tool operations without
+          // allowing a stale `projection.status=running` to refresh the clock.
+          const activeTools = [...translator.seenToolIds].filter(
+            (toolId) => !translator.finalToolIds.has(toolId),
+          ).length;
+          log(
+            `  [stall] prompt lock still held after ${Math.round((Date.now() - lastProtocolProgressAt) / 1000)}s silence (activeTools=${activeTools}); deferring terminal decision`,
+          );
+          nextNoProgressDecisionAt = Date.now() + NO_PROGRESS_MS;
+        } else {
+          log(`  [stall] no-progress deadline reached; prompt lock=${lockState}`);
+          stopBackendTurn(server, turn.zcodeSid);
+          return { stopReason: "max_turn_requests" };
+        }
+      }
+    }
+
     // Drain + handle server→client requests (interaction/*). Refreshes the
     // no-progress timer when any are handled. Pass `turn` so interaction
     // requests become turn-cancel aware (user stop aborts pending popups).
@@ -1658,7 +1697,7 @@ export async function runEventTurn(
       warn(`handleServerRequests threw: ${e instanceof Error ? e.message : String(e)}`);
     }
     if (handled) {
-      lastProgress = Date.now();
+      recordProtocolProgress();
     }
 
     if (turn.cancelled) {
@@ -1710,7 +1749,7 @@ export async function runEventTurn(
       if (
         !turn.cancelled &&
         translator.turnStarted &&
-        Date.now() - lastProgress > 15_000 &&
+        Date.now() - lastProtocolProgressAt > 15_000 &&
         Date.now() - lastStallCheck > 15_000
       ) {
         lastStallCheck = Date.now();
@@ -1724,7 +1763,7 @@ export async function runEventTurn(
           // turn is alive (it stays queued for the next poll).
           await sleep(1500);
           if (listener.hasQueuedEvents()) {
-            lastProgress = Date.now();
+            recordProtocolProgress();
             continue; // alive — events will be consumed by the next poll
           }
           const proj2 = await monitor.pollOnce();
@@ -1750,7 +1789,6 @@ export async function runEventTurn(
           // Second probe says the backend is still working (or events arrived
           // mid-probe) — keep waiting; queued events are consumed by the next
           // poll iteration.
-          lastProgress = Date.now();
           if (proj2?.status === "running") {
             await listener.resubscribe(() => server.nextId());
           }
@@ -1761,14 +1799,13 @@ export async function runEventTurn(
           // The send-retry loop in prompt() already covers the recovery window
           // for the NEXT turn; for this in-flight turn we just resubscribe and
           // let the backend emit its terminal event when ready.
-          lastProgress = Date.now();
           await listener.resubscribe(() => server.nextId());
         }
       }
       continue;
     }
 
-    lastProgress = Date.now();
+    recordProtocolProgress();
     // Steer-swallow guard: a send accepted while the previous turn is still
     // generating is queued as steer input, which the backend silently DROPS
     // when that turn ends — no new turn ever starts (no turn.started), and
@@ -1940,10 +1977,41 @@ export async function runEventTurn(
       return { stopReason: "end_turn" };
     }
   }
+}
 
   // 120s no progress: abandon.
   stopBackendTurn(server, turn.zcodeSid, turn.foregroundExecutionId);
   return { stopReason: "max_turn_requests" };
+}
+
+type PromptLockState = "held" | "released" | "unknown";
+
+/**
+ * Probe the backend's authoritative prompt lock without waiting for it to
+ * change. `session/read` projection status is intentionally not considered:
+ * that projection can remain stale at `running`, which is the condition this
+ * probe is used to disambiguate.
+ */
+async function probePromptLock(server: ZcodeAcpServer, zcodeSid: string): Promise<PromptLockState> {
+  const backend = server.ensureBackend();
+  if (backend.isDead) return "unknown";
+  try {
+    const resp = await backend.request(
+      server.nextId(),
+      "session/goal",
+      { sessionId: zcodeSid, action: "show" },
+      10_000,
+    );
+    if (!resp.error) return "released";
+    const message = (resp.error.message ?? "").toLowerCase();
+    if (message.includes("prompt is running") || message.includes("already running")) {
+      return "held";
+    }
+    return "unknown";
+  } catch (e) {
+    log(`  [stall] prompt-lock probe failed: ${e instanceof Error ? e.message : String(e)}`);
+    return "unknown";
+  }
 }
 
 /**

--- a/tests/stale-running-recovery.test.ts
+++ b/tests/stale-running-recovery.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Regression coverage for a stale `projection.status === "running"` keeping
+ * the event turn alive forever.  The public `prompt()` boundary is used so the
+ * test covers the real listener, monitor, and timeout wiring together.
+ */
+
+import type * as acp from "@agentclientprotocol/sdk";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ZcodeBackend } from "../src/backend/client.js";
+import type { ZcodeEvent } from "../src/backend/types.js";
+import "../src/handlers/slash.js";
+import { prompt } from "../src/handlers/session.js";
+import { ZcodeAcpServer } from "../src/server.js";
+
+vi.mock("../src/tasks-index.js", () => ({
+  upsertSessionTask: async () => true,
+  updateSessionTitle: async () => true,
+}));
+
+interface StaleBackendControl {
+  backend: ZcodeBackend;
+  emit: (event: ZcodeEvent) => void;
+  goalProbes: ReturnType<typeof vi.fn>;
+  setPromptLockHeld: (held: boolean) => void;
+  sendRequests: ReturnType<typeof vi.fn>;
+}
+
+function staleRunningBackend(): StaleBackendControl {
+  const listeners = new Set<{ handleEvent: (event: ZcodeEvent) => void }>();
+  let promptLockHeld = false;
+  const goalProbes = vi.fn(async () =>
+    promptLockHeld
+      ? { error: { message: "session goal: prompt is running" } }
+      : { result: { goal: null } },
+  );
+  const sendRequests = vi.fn();
+  const backend = {
+    isDead: false,
+    request: async (_id: number, method: string) => {
+      switch (method) {
+        case "workspace/updateProviderRegistry":
+        case "session/resume":
+          return { result: {} };
+        case "session/subscribe":
+          return { result: { eventSeq: 1 } };
+        case "session/messages":
+          return { result: { messages: [] } };
+        case "session/read":
+          return {
+            result: {
+              projection: { status: "running", contextUsed: 0 },
+              settings: {},
+            },
+          };
+        case "session/goal":
+          return goalProbes();
+        case "session/send":
+          sendRequests();
+          for (const listener of listeners) listener.handleEvent({ type: "turn.started" });
+          return { result: { accepted: true } };
+        default:
+          return { error: { message: `unhandled ${method}` } };
+      }
+    },
+    send: vi.fn(),
+    pollServerRequests: () => [],
+    registerEventListener: (_sid: string, listener: { handleEvent: (event: ZcodeEvent) => void }) =>
+      listeners.add(listener),
+    unregisterEventListener: (
+      _sid: string,
+      listener: { handleEvent: (event: ZcodeEvent) => void },
+    ) => listeners.delete(listener),
+  } as unknown as ZcodeBackend;
+  return {
+    backend,
+    emit: (event) => {
+      for (const listener of listeners) listener.handleEvent(event);
+    },
+    goalProbes,
+    setPromptLockHeld: (held) => {
+      promptLockHeld = held;
+    },
+    sendRequests,
+  };
+}
+
+function setup(backend: ZcodeBackend): ZcodeAcpServer {
+  const server = new ZcodeAcpServer();
+  server.backend = backend;
+  server.registerSession("sess_stale", "zs_stale");
+  server.markBackendLoaded("sess_stale");
+  return server;
+}
+
+const params = {
+  sessionId: "sess_stale",
+  prompt: [{ type: "text", text: "hello" }],
+} as acp.PromptRequest;
+
+const cx = {
+  notify: vi.fn().mockResolvedValue(undefined),
+  request: vi.fn().mockResolvedValue({}),
+} as unknown as acp.AgentContext;
+
+describe("stale running projection recovery", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("bounds a silent turn when running is stale and the prompt lock is released", async () => {
+    const { backend, goalProbes, sendRequests } = staleRunningBackend();
+    const turn = prompt(setup(backend), params, cx, 1);
+    let result: acp.PromptResponse | undefined;
+    void turn.then((value) => {
+      result = value;
+    });
+
+    // Let prompt() finish its immediate setup/subscribe/send chain before the
+    // large time jump; otherwise fake time can advance before runEventTurn has
+    // captured its initial deadline.
+    for (let i = 0; i < 20 && sendRequests.mock.calls.length === 0; i++) {
+      await Promise.resolve();
+    }
+    expect(sendRequests).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(121_000);
+
+    expect(result).toEqual({ stopReason: "max_turn_requests" });
+    expect(goalProbes).toHaveBeenCalled();
+  });
+
+  it("does not cancel an active tool while the prompt lock is still held", async () => {
+    const control = staleRunningBackend();
+    control.setPromptLockHeld(true);
+    const turn = prompt(setup(control.backend), params, cx, 2);
+    let settled = false;
+    void turn.then(() => {
+      settled = true;
+    });
+
+    for (let i = 0; i < 20 && control.sendRequests.mock.calls.length === 0; i++) {
+      await Promise.resolve();
+    }
+    expect(control.sendRequests).toHaveBeenCalledOnce();
+    control.emit({
+      type: "tool.updated",
+      payload: {
+        kind: "scheduled",
+        toolCallId: "tool-1",
+        toolName: "Read",
+        input: { file_path: "/tmp/example" },
+      },
+    });
+    control.emit({
+      type: "tool.updated",
+      payload: { kind: "started", toolCallId: "tool-1", toolName: "Read" },
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(121_000);
+
+    expect(control.goalProbes).toHaveBeenCalled();
+    expect(settled).toBe(false);
+
+    control.emit({ type: "turn.completed", payload: { resultType: "success" } });
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    await expect(turn).resolves.toEqual({ stopReason: "end_turn" });
+  });
+});

--- a/tests/stale-running-recovery.test.ts
+++ b/tests/stale-running-recovery.test.ts
@@ -124,7 +124,7 @@ describe("stale running projection recovery", () => {
     // Let prompt() finish its immediate setup/subscribe/send chain before the
     // large time jump; otherwise fake time can advance before runEventTurn has
     // captured its initial deadline.
-    for (let i = 0; i < 20 && sendRequests.mock.calls.length === 0; i++) {
+    for (let i = 0; i < 80 && sendRequests.mock.calls.length === 0; i++) {
       await Promise.resolve();
     }
     expect(sendRequests).toHaveBeenCalledOnce();
@@ -143,7 +143,7 @@ describe("stale running projection recovery", () => {
       settled = true;
     });
 
-    for (let i = 0; i < 20 && control.sendRequests.mock.calls.length === 0; i++) {
+    for (let i = 0; i < 80 && control.sendRequests.mock.calls.length === 0; i++) {
       await Promise.resolve();
     }
     expect(control.sendRequests).toHaveBeenCalledOnce();


### PR DESCRIPTION
Rebases and completes #83 (draft) onto current main, fixing #80.

## What this carries over from #83

- Separates real ACP/ZCode protocol progress from projection-based liveness probes: a stale `projection.status=running` no longer refreshes the 120s no-progress deadline.
- At the deadline, probes the authoritative prompt lock via `session/goal show`:
  - lock held → defer the terminal decision by another 120s (protects legitimately long model/tool operations);
  - lock released/unknown → bounded `max_turn_requests` outcome as before.
- Consumes already-queued events before making a deadline decision.

## Adaptations to current main (post #84)

- Resolved the `session.ts` conflicts: kept the steer-swallow guard, `recordProtocolProgress()` now replaces the bare `lastProgress` refresh.
- Dropped the deadline `else if (turn.cancelled)` branch — main's in-loop cancel check already covers it (the branch would misreport a user cancel as `max_turn_requests`).
- `probePromptLock` matches the lock-busy error by **code 1308** first (same code the send-retry loop keys on), message-text matching kept only as a legacy fallback — guards against backend message drift killing a live turn.
- The two new `stopBackendTurn` calls pass `turn.foregroundExecutionId` so the v4 stop actually kills the generation.
- Regression tests' microtask pump budget raised 20 → 80 (main's `prompt()` has more async preamble).

## Policy decision on #83's open question

No hard cap on lock-held deferral (backend-owned long work is legitimate; user cancel remains the escape hatch). A follow-up to surface deferral to the client as a session/update note is suggested instead.

## Verification

- `tsc --noEmit` clean, eslint clean, prettier clean
- Full suite: **837/837 passed** (includes the two stale-running regression tests from #83)

Closes #80
Supersedes #83