### PR TITLE
fix(registry): skip providers with zero models in provider registry

### DIFF
--- a/src/config/provider-registry.ts
+++ b/src/config/provider-registry.ts
@@ -126,12 +126,25 @@ function buildProviderElement(providerId: string, p: ProviderEntry): Record<stri
  * Unlike `loadAllModels` (dropdown, enabled-only), the registry pushes every
  * configured provider so the backend recognises any of them when a session
  * switches to it. The backend applies its own enable/availability rules.
+ *
+ * Providers with zero models are skipped: the backend's schema requires
+ * `models` to have >= 1 item and rejects the WHOLE payload otherwise, so a
+ * single empty provider (e.g. a plan tier with no models listed yet) would
+ * break the registry sync and every session would fail with
+ * `provider_not_configured` before auth is even tried.
  */
 export function buildProviderRegistry(): ProviderRegistryPayload {
   const cfg = JSON.parse(readFileSync(ZCODE_CREDS_PATH, "utf8")) as ConfigShape;
-  const providers = Object.entries(cfg.provider ?? {}).map(([pid, p]) =>
-    buildProviderElement(pid, p ?? {}),
-  );
+  const allEntries = Object.entries(cfg.provider ?? {});
+  const skipped: string[] = [];
+  const providers = [] as ReturnType<typeof buildProviderElement>[];
+  for (const [pid, p] of allEntries) {
+    if (Object.keys((p ?? {}).models ?? {}).length === 0) {
+      skipped.push(pid);
+      continue;
+    }
+    providers.push(buildProviderElement(pid, p ?? {}));
+  }
   const generatedAt = Date.now();
   // revision is a content hash; the backend skips unchanged revisions. A stable
   // JSON hash over provider ids+kinds+baseURLs is enough — apiKey changes are
@@ -139,7 +152,8 @@ export function buildProviderRegistry(): ProviderRegistryPayload {
   const revision = hashRevision(providers);
   log(
     `provider-registry: built ${providers.length} provider(s) ` +
-      `(ids: ${providers.map((p) => p.providerId).join(", ") || "none"})`,
+      `(ids: ${providers.map((p) => p.providerId).join(", ") || "none"})` +
+      (skipped.length > 0 ? `; skipped empty-model provider(s): ${skipped.join(", ")}` : ""),
   );
   return { providers, generatedAt, revision };
 }

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -27,6 +27,20 @@ const FAKE_CONFIG = {
       options: { baseURL: "https://example.test/primary" },
       models: { "model-a": { limit: { context: 128000 } } },
     },
+    "builtin:empty-plan": {
+      name: "Empty Plan",
+      kind: "anthropic",
+      enabled: true,
+      source: "builtin",
+      options: { baseURL: "https://example.test/empty-plan" },
+      models: {},
+    },
+    "builtin:no-models-key": {
+      name: "No Models Key",
+      kind: "anthropic",
+      enabled: true,
+      source: "builtin",
+    },
     "custom-openai-kind": {
       name: "Custom One",
       kind: "openai-compatible",
@@ -78,6 +92,15 @@ describe("buildProviderRegistry", () => {
     expect(ids).toContain("builtin:primary");
     expect(ids).toContain("custom-openai-kind");
     expect(ids).toContain("custom-anthropic-kind");
+  });
+
+  it("skips providers with zero models — an empty models array is rejected by the backend's schema and would fail the whole registry sync", () => {
+    const reg = buildProviderRegistry();
+    const ids = reg.providers.map((p) => p.providerId);
+    expect(ids).not.toContain("builtin:empty-plan");
+    expect(ids).not.toContain("builtin:no-models-key");
+    // Non-empty providers still make it through.
+    expect(ids).toContain("builtin:primary");
   });
 
   it("wraps apiKey as the inline union {source:'inline', value}, never a bare string", () => {


### PR DESCRIPTION
## Problem

When `~/.zcode/v2/config.json` contains a provider whose `models` map is empty (observed in the wild with `builtin:bigmodel-start-plan` and `builtin:zai-start-plan` — plan tiers whose model list was never populated), the entire `workspace/updateProviderRegistry` sync is rejected by the backend:

```
provider-registry: sync failed: Invalid params —
  registry.providers.3.models: Too small: expected array to have >=1 items;
  registry.providers.5.models: Too small: expected array to have >=1 items
```

Because the registry is applied all-or-nothing, the backend ends up recognising **no** providers, and every session/turn then fails with:

```
turn.failed (code=provider_not_configured)
```

— before auth is even attempted, which is very misleading to debug.

## Fix

Skip providers with zero models (empty `models` map or no `models` key) when building the registry payload, and log which provider ids were skipped. Providers with at least one model are unaffected.

## Testing

- `tsc --noEmit` clean.
- `tests/provider-registry.test.ts`: 13/13 pass, including a new test that a config mixing empty-model providers with normal ones yields a registry containing only the non-empty ones.
- Full suite: 838/839 pass. The one failure (`tests/remote-endpoint.test.ts > hub cross-instance session dedupe`) also fails on a clean checkout of `main` and is unrelated to this change.