### PR TITLE
fix: i18n cross-review follow-ups (startup crash, cache bust, coverage gaps)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.1] - 2026-09-01
+
+### Fixed
+
+Cross-review follow-ups to 0.16.0 (found by a dual Review + Adversary pass):
+
+- Startup crash: a `setting.json` carrying a non-string `locale` (number,
+  bool, array, object) threw `TypeError` inside `pick()` — the bridge died
+  at `buildAllCommands()` before serving anything. `pick()` now narrows to
+  strings, and the settings parse validates both keys.
+- The app-locale cache used a null sentinel that a literal `"locale": null`
+  punched through — every `messages()` call then re-read and re-parsed the
+  settings file synchronously (~6ms each on a large file). Replaced with an
+  explicit read-once flag.
+- `tests/mcp-list.test.ts` asserted the English `/mcp` card without pinning
+  `ZCODE_ACP_LANG`, and its fs mock falls through to the real fs — so the
+  suite read the developer's real `~/.zcode/v2/setting.json` and failed 6
+  cases on any zh-locale machine. Now pinned to `en`.
+- Localized the strings the first pass missed: auto-compact status lines,
+  the pre-popup tool_call titles ("Ready to code?", "tool permission (…)",
+  "interaction"), the replay "tool call" fallback, background-task card
+  titles, and the slash-command error messages (which previously stayed
+  English next to localized success feedback).
+- Import order normalized (alphabetical) for the new i18n imports;
+  `tests/i18n.test.ts` now asserts the nested `slashCommandDescriptions`
+  key sets match across languages and cover every static command.
+- CHANGELOG wording: 0.16.0's "covers every string" overstated — token-form
+  feedback (`✓ /mode = yolo`) and argument hints intentionally stay
+  as-is (language-neutral).
+
 ## [0.16.0] - 2026-09-01
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zcode-acp-server",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Agent Client Protocol (ACP) server bridging headless ZCode to editors like Zed and JetBrains.",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/config/auto-compact.ts
+++ b/src/config/auto-compact.ts
@@ -16,6 +16,7 @@ import { randomUUID } from "node:crypto";
 import type * as acp from "@agentclientprotocol/sdk";
 
 import { compact } from "../handlers/extensions.js";
+import { messages } from "../i18n.js";
 import type { ZcodeAcpServer } from "../server.js";
 import { log, warn } from "../utils.js";
 import { sendTextChunk } from "../handlers/io.js";
@@ -63,10 +64,11 @@ export async function maybeAutoCompact(
     if (used < threshold) return;
 
     log(`auto-compact: contextUsed=${used} >= threshold=${threshold}, compacting…`);
+    const m = messages();
     await sendTextChunk(
       cx,
       acpSid,
-      `🔄 auto-compact: context usage ${used.toLocaleString()} ≥ threshold ${threshold.toLocaleString()}, compressing…`,
+      m.autoCompactStart(used.toLocaleString(), threshold.toLocaleString()),
       msgId,
     );
 
@@ -75,14 +77,9 @@ export async function maybeAutoCompact(
       __lockTimeout?: boolean;
     };
     if (result.__lockTimeout) {
-      await sendTextChunk(
-        cx,
-        acpSid,
-        "⚠ auto-compact timed out (300s) — backend may still be processing",
-        msgId,
-      );
+      await sendTextChunk(cx, acpSid, m.autoCompactTimeout, msgId);
     } else {
-      await sendTextChunk(cx, acpSid, "✓ auto-compact: context compressed", msgId);
+      await sendTextChunk(cx, acpSid, m.autoCompactDone, msgId);
     }
     log("auto-compact: done");
   } catch (e) {
@@ -90,7 +87,7 @@ export async function maybeAutoCompact(
     await sendTextChunk(
       cx,
       acpSid,
-      `⚠ auto-compact failed: ${e instanceof Error ? e.message : String(e)}`,
+      messages().autoCompactFailed(e instanceof Error ? e.message : String(e)),
       msgId,
     );
     // Best-effort: never break the prompt response.

--- a/src/config/mcp-discovery.ts
+++ b/src/config/mcp-discovery.ts
@@ -15,8 +15,8 @@ import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 
-import { compareVersions, log } from "../utils.js";
 import { messages } from "../i18n.js";
+import { compareVersions, log } from "../utils.js";
 
 /** Information about a discovered MCP server. */
 export interface McpServerInfo {

--- a/src/handlers/background-tasks.ts
+++ b/src/handlers/background-tasks.ts
@@ -35,6 +35,7 @@ import { randomUUID } from "node:crypto";
 
 import type { EventListener } from "../backend/client.js";
 import type { ZcodeEvent } from "../backend/types.js";
+import { messages } from "../i18n.js";
 import { log, warn } from "../utils.js";
 import type { ZcodeAcpServer } from "../server.js";
 
@@ -104,8 +105,7 @@ function toAcpStatus(status: string | undefined): "in_progress" | "completed" | 
 
 /** Build the card title for a background task. */
 function cardTitle(description: string | undefined): string {
-  const d = (description ?? "").trim();
-  return d ? `[background] ${d}` : "[background] task";
+  return messages().backgroundTaskTitle((description ?? "").trim());
 }
 
 export class BackgroundTaskListener implements EventListener {

--- a/src/handlers/dispatch.ts
+++ b/src/handlers/dispatch.ts
@@ -23,8 +23,8 @@ import {
   parseSubagentMetadata,
   TOOL_KIND_MAP,
 } from "../translators/tool-helpers.js";
-import type { InternalEvent } from "../translators/types.js";
 import { messages } from "../i18n.js";
+import type { InternalEvent } from "../translators/types.js";
 import type { ZcodeAcpServer } from "../server.js";
 import { warn } from "../utils.js";
 import { sendSessionUpdate } from "./io.js";

--- a/src/handlers/replay.ts
+++ b/src/handlers/replay.ts
@@ -16,7 +16,9 @@ import { randomUUID } from "node:crypto";
 import type * as acp from "@agentclientprotocol/sdk";
 
 import type { ZcodeMessage, ZcodeMessagesResult } from "../backend/types.js";
-import { messages } from "../i18n.js";
+// Aliased: this module's own helpers take a `messages: ZcodeMessage[]`
+// parameter that would shadow the plain import name.
+import { messages as i18nMessages } from "../i18n.js";
 import type { ZcodeAcpServer } from "../server.js";
 import { log, warn } from "../utils.js";
 import { throwError, withReplayBatch } from "./io.js";
@@ -315,7 +317,7 @@ function transcriptTitle(tool: string, inputJson: string): string {
   } catch {
     /* non-JSON input — fall through */
   }
-  return messages().replayToolFallback(tool);
+  return i18nMessages().replayToolFallback(tool);
 }
 
 /** <summary> line of a task-notification, entities decoded, capped at 60. */
@@ -350,11 +352,11 @@ function collapseUserText(
     const raw =
       typeof summary?.title === "string" && summary.title
         ? summary.title
-        : messages().replayCompactSummary;
+        : i18nMessages().replayCompactSummary;
     return { title: raw.length > 60 ? raw.slice(0, 57) + "…" : raw, kind: "compact" };
   }
   if (CONTEXT_HANDOFF.test(text)) {
-    return { title: messages().replayContextHandoff, kind: "context-handoff" };
+    return { title: i18nMessages().replayContextHandoff, kind: "context-handoff" };
   }
   const tool = TOOL_TRANSCRIPT.exec(text);
   if (tool) {
@@ -470,7 +472,7 @@ export async function replayMessages(
           update: {
             sessionUpdate: "tool_call",
             toolCallId: tp.id ?? `histtool_${randomUUID().slice(0, 8)}`,
-            title: st.title ?? histToolName ?? "tool call",
+            title: st.title ?? histToolName ?? i18nMessages().replayToolCallFallback,
             kind: "other",
             status: (st.status as acp.ToolCallStatus) ?? "completed",
             ...(content.length > 0 ? { content } : {}),

--- a/src/handlers/server-requests.ts
+++ b/src/handlers/server-requests.ts
@@ -43,8 +43,8 @@ import {
   zcodePermissionToAcp,
 } from "../interaction/adapter.js";
 import { buildConfigOptions, buildModes } from "../config/options.js";
-import type { ClientLike } from "../remote/broadcast.js";
 import { messages } from "../i18n.js";
+import type { ClientLike } from "../remote/broadcast.js";
 import { log, warn } from "../utils.js";
 import type { PendingTurn, ZcodeAcpServer } from "../server.js";
 import { sendSessionUpdate } from "./io.js";
@@ -437,11 +437,12 @@ async function handleSinglePermission(
   // to have been emitted before request_permission).
   const toolCallId = p.toolCallId ?? "";
   const rawInput = p.input;
+  const m = messages();
   const tcTitle = epm
-    ? "Ready to code?"
+    ? m.popupTitleExitPlan
     : perm
-      ? `tool permission (${p.toolName ?? "?"})`
-      : "interaction";
+      ? m.popupTitleToolPermission(p.toolName ?? "?")
+      : m.popupTitleInteraction;
   const tcKind = epm ? "switch_mode" : "other";
   const toolName = epm ? "ExitPlanMode" : (p.toolName ?? "");
   const tcUpdate: acp.SessionUpdate = {

--- a/src/handlers/slash.ts
+++ b/src/handlers/slash.ts
@@ -178,7 +178,7 @@ export async function handleSlashCommand(
         return ok(messages().slashCompacted);
       }
       case "goal": {
-        if (!arg) throw new RequestError(-32602, "/goal requires a goal description");
+        if (!arg) throw new RequestError(-32602, messages().slashErrGoalArg);
         await goal(server, { sessionId: acpSid, action: "set", objective: arg });
         return ok(messages().slashGoalSet(arg));
       }
@@ -189,17 +189,17 @@ export async function handleSlashCommand(
         return ok(messages().slashForked(result.forkedSessionId ?? "?"));
       }
       case "model": {
-        if (!arg) throw new RequestError(-32602, "/model requires a model id");
+        if (!arg) throw new RequestError(-32602, messages().slashErrModelArg);
         const switchOk = await applyModelSwitch(server, zcodeSid, arg);
-        if (!switchOk) throw new RequestError(-32603, `model switch failed for ${arg}`);
+        if (!switchOk) throw new RequestError(-32603, messages().slashErrSwitchFailed(arg));
         await emitConfigOptionUpdate(server, cx, acpSid, zcodeSid, "model");
         return ok(messages().slashModelSet(arg));
       }
       case "mode":
       case "thought": {
-        if (!arg) throw new RequestError(-32602, `/${cmd} requires an argument`);
+        if (!arg) throw new RequestError(-32602, messages().slashErrArg(cmd));
         const dispatch = CONFIG_DISPATCH[cmd];
-        if (!dispatch) throw new RequestError(-32602, `unknown /${cmd}`);
+        if (!dispatch) throw new RequestError(-32602, messages().slashErrUnknown(cmd));
         const resp = await server
           .ensureBackend()
           .request(
@@ -208,7 +208,9 @@ export async function handleSlashCommand(
             { sessionId: zcodeSid, [dispatch.paramKey]: arg },
             15000,
           );
-        if (resp.error) throw new RequestError(-32603, `${cmd} failed: ${resp.error.message}`);
+        if (resp.error) {
+          throw new RequestError(-32603, messages().slashErrFailed(cmd, resp.error.message ?? ""));
+        }
         // Notify the editor UI: emit config_option_update (+ current_mode_update
         // for mode). Without this the dropdown / mode indicator never reflects
         // the change — slash commands return end_turn and bypass the turn-

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -23,8 +23,12 @@ import path from "node:path";
 export type Lang = "en" | "zh";
 
 export function resolveLanguage(env: NodeJS.ProcessEnv = process.env): Lang {
-  const pick = (value: string | undefined): Lang | undefined => {
-    const v = (value ?? "").toLowerCase();
+  // Non-string values (a malformed setting.json carrying `locale: 5` must
+  // never crash the bridge — pick is reached from messages() on hot paths)
+  // read as "no preference".
+  const pick = (value: unknown): Lang | undefined => {
+    if (typeof value !== "string") return undefined;
+    const v = value.toLowerCase();
     if (v.startsWith("zh")) return "zh";
     if (v.startsWith("en")) return "en";
     return undefined;
@@ -39,22 +43,29 @@ export function resolveLanguage(env: NodeJS.ProcessEnv = process.env): Lang {
   );
 }
 
-/** The ZCode desktop app's language choice, if the settings file exists. */
-let cachedAppLocale: string | undefined | null = null; // null = not read yet
+/** The ZCode desktop app's language choice, if the settings file exists.
+ *  Memoized with an explicit flag: a settings value of literal null must
+ *  cache as "no app locale", not re-read the file on every call. */
+let appLocaleCache: string | undefined;
+let appLocaleRead = false;
 
 function appLocale(): string | undefined {
-  if (cachedAppLocale === null) {
+  if (!appLocaleRead) {
+    appLocaleRead = true;
     let locale: string | undefined;
     try {
       const raw = readFileSync(path.join(os.homedir(), ".zcode", "v2", "setting.json"), "utf8");
-      const parsed = JSON.parse(raw) as { localePreference?: string; locale?: string };
-      locale = parsed.localePreference ?? parsed.locale;
+      const parsed = JSON.parse(raw) as { localePreference?: unknown; locale?: unknown };
+      const pref =
+        typeof parsed.localePreference === "string" ? parsed.localePreference : undefined;
+      const eff = typeof parsed.locale === "string" ? parsed.locale : undefined;
+      locale = pref ?? eff;
     } catch {
       locale = undefined; // app never installed / unreadable / malformed
     }
-    cachedAppLocale = locale;
+    appLocaleCache = locale;
   }
-  return cachedAppLocale;
+  return appLocaleCache;
 }
 
 export interface Messages {
@@ -122,6 +133,26 @@ export interface Messages {
   /** Editor slash-command menu: localized descriptions for the static
    *  commands (names and argument hints stay as-is — they are tokens). */
   slashCommandDescriptions: Record<string, string>;
+  /** Auto-compaction status lines. */
+  autoCompactStart: (used: string, threshold: string) => string;
+  autoCompactTimeout: string;
+  autoCompactDone: string;
+  autoCompactFailed: (err: string) => string;
+  /** Pre-popup tool_call titles for interactive requests. */
+  popupTitleExitPlan: string;
+  popupTitleToolPermission: (tool: string) => string;
+  popupTitleInteraction: string;
+  /** Replay fallback title when a history tool has no name/title. */
+  replayToolCallFallback: string;
+  /** Background-task card title (empty description → fallback). */
+  backgroundTaskTitle: (description: string) => string;
+  /** Slash-command errors surfaced to the editor via RequestError. */
+  slashErrGoalArg: string;
+  slashErrModelArg: string;
+  slashErrSwitchFailed: (model: string) => string;
+  slashErrArg: (cmd: string) => string;
+  slashErrUnknown: (cmd: string) => string;
+  slashErrFailed: (cmd: string, msg: string) => string;
 }
 
 const zh: Messages = {
@@ -190,6 +221,22 @@ const zh: Messages = {
     mcp: "列出可用的 MCP 服务器",
     init: "创建或更新工作区 AGENTS.md 指令",
   },
+  autoCompactStart: (used, threshold) =>
+    `🔄 自动压缩: 上下文用量 ${used} ≥ 阈值 ${threshold},正在压缩…`,
+  autoCompactTimeout: "⚠ 自动压缩超时（300s）——后端可能仍在处理",
+  autoCompactDone: "✓ 自动压缩: 上下文已压缩",
+  autoCompactFailed: (err) => `⚠ 自动压缩失败: ${err}`,
+  popupTitleExitPlan: "可以开始编码了吗？",
+  popupTitleToolPermission: (tool) => `工具权限 (${tool})`,
+  popupTitleInteraction: "交互",
+  replayToolCallFallback: "工具调用",
+  backgroundTaskTitle: (d) => (d ? `[后台] ${d}` : "[后台] 任务"),
+  slashErrGoalArg: "/goal 需要目标描述",
+  slashErrModelArg: "/model 需要模型 id",
+  slashErrSwitchFailed: (model) => `模型切换失败: ${model}`,
+  slashErrArg: (cmd) => `/${cmd} 需要参数`,
+  slashErrUnknown: (cmd) => `未知命令 /${cmd}`,
+  slashErrFailed: (cmd, msg) => `${cmd} 失败: ${msg}`,
 };
 
 const en: Messages = {
@@ -262,6 +309,22 @@ const en: Messages = {
     mcp: "List available MCP servers",
     init: "Create or update workspace AGENTS.md instructions",
   },
+  autoCompactStart: (used, threshold) =>
+    `🔄 auto-compact: context usage ${used} ≥ threshold ${threshold}, compressing…`,
+  autoCompactTimeout: "⚠ auto-compact timed out (300s) — backend may still be processing",
+  autoCompactDone: "✓ auto-compact: context compressed",
+  autoCompactFailed: (err) => `⚠ auto-compact failed: ${err}`,
+  popupTitleExitPlan: "Ready to code?",
+  popupTitleToolPermission: (tool) => `tool permission (${tool})`,
+  popupTitleInteraction: "interaction",
+  replayToolCallFallback: "tool call",
+  backgroundTaskTitle: (d) => (d ? `[background] ${d}` : "[background] task"),
+  slashErrGoalArg: "/goal requires a goal description",
+  slashErrModelArg: "/model requires a model id",
+  slashErrSwitchFailed: (model) => `model switch failed for ${model}`,
+  slashErrArg: (cmd) => `/${cmd} requires an argument`,
+  slashErrUnknown: (cmd) => `unknown /${cmd}`,
+  slashErrFailed: (cmd, msg) => `${cmd} failed: ${msg}`,
 };
 
 /** Current message table — resolved per call so env changes/tests apply live. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,8 +45,8 @@ import { loadSkillCommands } from "./config/skill-discovery.js";
 import { trackConnections } from "./remote/broadcast.js";
 import { parseRemoteConfig } from "./remote/config.js";
 import { startRemoteEndpoint, type RemoteEndpointHandle } from "./remote/endpoint.js";
-import { ZcodeAcpServer } from "./server.js";
 import { messages } from "./i18n.js";
+import { ZcodeAcpServer } from "./server.js";
 import { AGENT_INFO, SLASH_COMMANDS, log, warn } from "./utils.js";
 
 /**

--- a/tests/i18n.test.ts
+++ b/tests/i18n.test.ts
@@ -52,6 +52,25 @@ describe("resolveLanguage", () => {
     expect(resolveLanguage({})).toBe("zh");
   });
 
+  it("never crashes on non-string app locale values (number/bool/null/array/object)", async () => {
+    const { resolveLanguage } = await freshModule();
+    for (const bad of [5, true, null, [], { x: 1 }]) {
+      settingJson = JSON.stringify({ locale: bad });
+      expect(resolveLanguage({ LANG: "zh_CN" })).toBe("zh"); // falls through
+      expect(resolveLanguage({})).toBe("en"); // default
+    }
+  });
+
+  it("memoizes the app-settings read — a later file change does not flip the language", async () => {
+    const { resolveLanguage } = await freshModule();
+    settingJson = JSON.stringify({ locale: "zh-CN" });
+    expect(resolveLanguage({})).toBe("zh");
+    settingJson = JSON.stringify({ locale: "en-US" });
+    expect(resolveLanguage({})).toBe("zh"); // cached, not re-read
+    settingJson = JSON.stringify({ locale: null });
+    expect(resolveLanguage({})).toBe("zh"); // null value must not bust the cache
+  });
+
   it("falls through a missing or malformed app settings file", async () => {
     const { resolveLanguage } = await freshModule();
     settingJson = "{not json";
@@ -91,6 +110,20 @@ describe("message tables", () => {
       }
     }
     expect(zh.length).toBe(en.length);
+  });
+
+  it("slashCommandDescriptions: identical key sets covering every static command", async () => {
+    const { messages } = await freshModule();
+    const { SLASH_COMMANDS } = await import("../src/utils.js");
+    vi.stubEnv("ZCODE_ACP_LANG", "zh");
+    const zhKeys = Object.keys(messages().slashCommandDescriptions).sort();
+    vi.stubEnv("ZCODE_ACP_LANG", "en");
+    const enKeys = Object.keys(messages().slashCommandDescriptions).sort();
+    expect(enKeys).toEqual(zhKeys);
+    for (const cmd of SLASH_COMMANDS) {
+      expect(zhKeys).toContain(cmd.name);
+      expect(enKeys).toContain(cmd.name);
+    }
   });
 
   it("messages() follows env changes per call", async () => {

--- a/tests/mcp-list.test.ts
+++ b/tests/mcp-list.test.ts
@@ -8,7 +8,7 @@
 
 import { homedir } from "node:os";
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type * as acp from "@agentclientprotocol/sdk";
 import { ZcodeAcpServer } from "../src/server.js";
@@ -45,8 +45,7 @@ vi.mock("node:fs", async () => {
       return entries;
     },
     statSync: (p: string) => {
-      if (mockDirs.has(p))
-        return { isDirectory: () => true } as ReturnType<typeof actual.statSync>;
+      if (mockDirs.has(p)) return { isDirectory: () => true } as ReturnType<typeof actual.statSync>;
       return actual.statSync(p);
     },
   };
@@ -62,8 +61,16 @@ function resetMocks(): void {
 
 const HOME = homedir();
 
+// Asserts the English /mcp card; pin the language — this suite's fs mock
+// falls through to the real fs for unknown paths, so without the pin the
+// outcome would depend on the developer's ~/.zcode/v2/setting.json.
+beforeEach(() => {
+  vi.stubEnv("ZCODE_ACP_LANG", "en");
+});
+
 afterEach(() => {
   resetMocks();
+  vi.unstubAllEnvs();
 });
 
 describe("loadMcpServers", () => {
@@ -314,9 +321,7 @@ describe("formatMcpServers", () => {
   });
 
   it("includes the auto-invoke note", () => {
-    const text = formatMcpServers([
-      { name: "s", type: "stdio", command: "x", source: "config" },
-    ]);
+    const text = formatMcpServers([{ name: "s", type: "stdio", command: "x", source: "config" }]);
     expect(text).toContain("auto-invoked by the model");
   });
 });
@@ -366,10 +371,7 @@ describe("/mcp slash command", () => {
 
   it("returns end_turn with 'no servers' message when empty", async () => {
     resetMocks();
-    mockFiles.set(
-      `${HOME}/.zcode/cli/config.json`,
-      JSON.stringify({ mcp: { servers: {} } }),
-    );
+    mockFiles.set(`${HOME}/.zcode/cli/config.json`, JSON.stringify({ mcp: { servers: {} } }));
 
     const { cx, sent } = mockContext();
     const server = new ZcodeAcpServer();


### PR DESCRIPTION
## Summary

Follow-ups to #89 (bilingual user strings) from a dual cross-review (an independent Review pass plus an Adversary pass that reproduced its findings). All findings fixed; reproductions re-verified green.

## Fixed

- **Startup crash (block, reproduced)**: `setting.json` carrying a non-string `locale` (number/bool/array/object) threw `TypeError` in `pick()` before the bridge served anything (`buildAllCommands()` → exit 1). `pick()` now narrows to strings; the settings parse validates both keys. Repro `HOME=<fake> node dist/index.js` with `{"locale": 5}`: was exit 1, now clean startup.
- **Cache bust (concern, reproduced)**: the null-sentinel memoization was punched through by a literal `"locale": null` — every `messages()` call then re-read + re-parsed the settings file synchronously (~6ms each on a large file). Replaced with an explicit read-once flag; a new test proves a later file change (including a `null` value) does not flip the language.
- **Red suite on zh-locale machines (block, reproduced)**: `tests/mcp-list.test.ts` asserted the English `/mcp` card unpinned while its fs mock falls through to the real fs — 6 failures for any developer whose `~/.zcode/v2/setting.json` is zh. Pinned `ZCODE_ACP_LANG=en`; verified `ZCODE_ACP_LANG=zh` now passes 15/15.
- **Coverage gaps found by the review pass**: localized the auto-compact status lines, the pre-popup tool_call titles ("Ready to code?", "tool permission (…)", "interaction"), the replay "tool call" fallback, background-task card titles, and the slash-command error messages (previously English next to localized success feedback).
- `tests/i18n.test.ts`: asserts the nested `slashCommandDescriptions` key sets match across languages and cover every static command; non-string app-locale values never crash.
- Import order normalized for the new i18n imports; CHANGELOG wording corrected (0.16.0's "covers every string" overstated — token-form feedback stays as-is by design).

## Test plan

- `pnpm test`: 895/897 (the 2 `armSandboxArgv` failures are environmental to sandboxed dev sessions; pass in CI).
- Adversary reproductions re-run: startup crash → clean; zh-env mcp-list → 15/15; memoization → stable across file mutation.
