### PR TITLE
fix: empty locale preference, BOM settings, zh-machine test pins (0.16.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.2] - 2026-09-01
+
+### Fixed
+
+Second dual Review + Adversary pass over the 0.16.1 commit (pre-publish gate):
+
+- `setting.json` with an empty-string `localePreference` (`""`) read as a
+  real preference and masked a valid `locale`; the empty string now reads
+  as unset and the effective locale wins.
+- A UTF-8 BOM prefix in `setting.json` made `JSON.parse` throw and the
+  bridge silently fell back to English; the BOM is stripped before parsing.
+- Two more suites asserted English output without pinning
+  `ZCODE_ACP_LANG` (`tests/auto-compact.test.ts`,
+  `tests/background-tasks.test.ts`) — the same zh-machine redness 0.16.1
+  fixed for `mcp-list.test.ts` (6 cases went red per run). Both are now
+  pinned to `en`.
+- `tests/i18n.test.ts`'s crash-guard loop reused one module instance for
+  all five malformed locale values, so memoization short-circuited four of
+  them; each value now parses through a fresh module.
+- Removed a dead `?? ""` on `resp.error.message` (non-optional) in
+  `src/handlers/slash.ts`, and corrected 0.16.1's overstated "import order
+  normalized" claim below.
+
 ## [0.16.1] - 2026-09-01
 
 ### Fixed
@@ -28,8 +51,7 @@ Cross-review follow-ups to 0.16.0 (found by a dual Review + Adversary pass):
   "interaction"), the replay "tool call" fallback, background-task card
   titles, and the slash-command error messages (which previously stayed
   English next to localized success feedback).
-- Import order normalized (alphabetical) for the new i18n imports;
-  `tests/i18n.test.ts` now asserts the nested `slashCommandDescriptions`
+- `tests/i18n.test.ts` now asserts the nested `slashCommandDescriptions`
   key sets match across languages and cover every static command.
 - CHANGELOG wording: 0.16.0's "covers every string" overstated — token-form
   feedback (`✓ /mode = yolo`) and argument hints intentionally stay

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zcode-acp-server",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Agent Client Protocol (ACP) server bridging headless ZCode to editors like Zed and JetBrains.",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/handlers/slash.ts
+++ b/src/handlers/slash.ts
@@ -209,7 +209,7 @@ export async function handleSlashCommand(
             15000,
           );
         if (resp.error) {
-          throw new RequestError(-32603, messages().slashErrFailed(cmd, resp.error.message ?? ""));
+          throw new RequestError(-32603, messages().slashErrFailed(cmd, resp.error.message));
         }
         // Notify the editor UI: emit config_option_update (+ current_mode_update
         // for mode). Without this the dropdown / mode indicator never reflects

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -55,11 +55,14 @@ function appLocale(): string | undefined {
     let locale: string | undefined;
     try {
       const raw = readFileSync(path.join(os.homedir(), ".zcode", "v2", "setting.json"), "utf8");
-      const parsed = JSON.parse(raw) as { localePreference?: unknown; locale?: unknown };
+      // Editors saving UTF-8 with a BOM leave \uFEFF in the string; JSON.parse
+      // rejects it, which would silently fall the bridge back to English.
+      const bomless = raw.charCodeAt(0) === 0xfeff ? raw.slice(1) : raw;
+      const parsed = JSON.parse(bomless) as { localePreference?: unknown; locale?: unknown };
       const pref =
         typeof parsed.localePreference === "string" ? parsed.localePreference : undefined;
       const eff = typeof parsed.locale === "string" ? parsed.locale : undefined;
-      locale = pref ?? eff;
+      locale = pref || eff; // an empty preference string reads as unset
     } catch {
       locale = undefined; // app never installed / unreadable / malformed
     }

--- a/tests/auto-compact.test.ts
+++ b/tests/auto-compact.test.ts
@@ -8,7 +8,7 @@
  */
 
 import type * as acp from "@agentclientprotocol/sdk";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ZcodeAcpServer } from "../src/server.js";
 import type { ZcodeResponse } from "../src/backend/types.js";
@@ -68,7 +68,14 @@ function makeServerWithProjection(
   return { server, backend, compactCalls: compactMock };
 }
 
+// Pin the language: asserted status lines are English and fs is not mocked
+// (a real zh ~/.zcode/v2/setting.json would flip them on a zh-locale machine).
+beforeEach(() => {
+  vi.stubEnv("ZCODE_ACP_LANG", "en");
+});
+
 afterEach(() => {
+  vi.unstubAllEnvs();
   vi.restoreAllMocks();
 });
 

--- a/tests/background-tasks.test.ts
+++ b/tests/background-tasks.test.ts
@@ -7,11 +7,20 @@
  * backend or ACP client — `notifyByZcodeSid` is stubbed to record calls.
  */
 
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { BackgroundTaskListener } from "../src/handlers/background-tasks.js";
 import type { ZcodeAcpServer } from "../src/server.js";
 import type { ZcodeEvent } from "../src/backend/types.js";
+
+// Pin the language: asserted card titles are English and fs is not mocked.
+beforeEach(() => {
+  vi.stubEnv("ZCODE_ACP_LANG", "en");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 /** A minimal fake server: records every session/update it would send. */
 interface FakeServer {

--- a/tests/i18n.test.ts
+++ b/tests/i18n.test.ts
@@ -52,9 +52,23 @@ describe("resolveLanguage", () => {
     expect(resolveLanguage({})).toBe("zh");
   });
 
-  it("never crashes on non-string app locale values (number/bool/null/array/object)", async () => {
+  it("treats an empty-string localePreference as unset", async () => {
     const { resolveLanguage } = await freshModule();
+    settingJson = JSON.stringify({ localePreference: "", locale: "zh-CN" });
+    expect(resolveLanguage({})).toBe("zh");
+  });
+
+  it("parses a BOM-prefixed settings file", async () => {
+    const { resolveLanguage } = await freshModule();
+    settingJson = "\uFEFF" + JSON.stringify({ locale: "zh-CN" });
+    expect(resolveLanguage({})).toBe("zh");
+  });
+
+  it("never crashes on non-string app locale values (number/bool/null/array/object)", async () => {
+    // A fresh module per value — memoization would otherwise short-circuit
+    // every file parse after the first.
     for (const bad of [5, true, null, [], { x: 1 }]) {
+      const { resolveLanguage } = await freshModule();
       settingJson = JSON.stringify({ locale: bad });
       expect(resolveLanguage({ LANG: "zh_CN" })).toBe("zh"); // falls through
       expect(resolveLanguage({})).toBe("en"); // default


### PR DESCRIPTION
## Summary

Second dual Review + Adversary pass over 13f37da (the 0.16.1 cross-review
fixes) as the pre-publish gate for 0.16.2. The runtime code survived the
attack; the findings closed here are locale-resolution edge cases plus a
test-hermeticity gap of the same class 0.16.1 itself fixed elsewhere.

## Changes

- `src/i18n.ts`: an empty-string `localePreference` no longer masks a valid
  `locale` (`??` → `||`); a UTF-8 BOM prefix in `setting.json` is stripped
  before `JSON.parse` (previously threw → silent English fallback).
- `tests/auto-compact.test.ts`, `tests/background-tasks.test.ts`: pinned
  `ZCODE_ACP_LANG=en` — both suites assert English output without an fs
  mock, so a zh-locale machine ran 6 cases red (reproduced with a fake zh
  `setting.json` HOME; green after the pin).
- `tests/i18n.test.ts`: the crash-guard loop now takes a fresh module per
  malformed value (memoization previously short-circuited 4 of 5); added
  regression tests for the empty-string preference and BOM cases.
- `src/handlers/slash.ts`: removed a dead `?? ""` on non-optional
  `resp.error.message`.
- CHANGELOG: added 0.16.2; corrected 0.16.1's inaccurate "import order
  normalized" claim; version bumped to 0.16.2.

## Verification

- Targeted suites (i18n, auto-compact, background-tasks, mcp-list): 60/60.
- zh-machine repro (fake zh `setting.json` HOME, no env override): 48/48.
- typecheck / lint / build green; full suite 897/899 locally — the 2
  `armSandboxArgv` failures are the known shell-sandbox environmental
  issue (CI is unaffected and runs them green).

## Review provenance

Findings from the dual pass are archived at
`.zcode/scratch/release-review-review.md` and
`.zcode/scratch/release-review-adversary.md`.
