### PR TITLE
feat: remote session-create via known projects and headless serve bridges (ADR-0014)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - 2026-09-01
+
+### Added
+
+Remote session-create (ADR-0014): a remote client can start a NEW agent
+session in any of the machine's known projects, no editor required.
+
+- `GET /api/projects` (hub, token auth): the known-project list aggregated
+  from the App's `tasks-index.sqlite` — every workspace that ever ran a
+  session, filtered (system temp trees, `~/.zcode` itself, vanished
+  directories) and sorted by last activity.
+- `POST /api/instances {workspacePath}` (hub, token auth): spawns
+  `zcode-acp serve` — a headless bridge — detached in the project cwd,
+  waits for its heartbeat registration, and returns `{id, reused}`. The
+  project list doubles as the whitelist: paths outside it get 403, so a
+  remote client can never spawn an agent in an arbitrary directory. A live
+  serve instance for the same workspace is reused instead of re-spawned.
+- `zcode-acp serve` CLI subcommand: the same ACP surface as the stdio
+  server minus the editor — spawned by the hub with remote ENV, it
+  registers back, serves remote WS clients, and exits after 10 idle
+  minutes with no clients and no running turns (ADR-0001's headless
+  counterpart). In serve mode `session/new` ignores client cwds and always
+  uses the process cwd, keeping the whitelist closed end to end.
+- Registration heartbeats and `/api/instances` now carry an `origin`
+  field (`"editor"` or `"serve"`, older bridges default to `"editor"`)
+  so remote UIs can label CLI-started instances and the hub can dedupe
+  them per workspace.
+
 ## [0.16.2] - 2026-09-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,38 @@ session in any of the machine's known projects, no editor required.
   so remote UIs can label CLI-started instances and the hub can dedupe
   them per workspace.
 
+### Fixed
+
+- A bridge rejected by the hub (401, typically a token rotation it did
+  not observe) permanently stopped registering — its sessions vanished
+  from remote until the editor window was manually restarted. 401 no
+  longer poisons the heartbeat: the bridge keeps retrying every 10s and
+  spawns a replacement hub carrying its own token, with exponential
+  backoff (60s doubling to a 10min cap) so a mixed-token fleet that
+  keeps the stale hub alive cannot churn spawn attempts forever. Once
+  the stale hub exits — immediately if the port is free, or via its
+  zero-instance idle-exit — the next spawn installs a hub that accepts
+  the bridge and everything converges without manual restarts.
+- Hardening from an adversarial review of the new remote surfaces:
+  - serve-mode cwd pinning now covers EVERY cwd entry point, not just
+    `session/new`: a durable lazy-session alias minted with an arbitrary
+    cwd on an editor bridge can no longer be resumed on a serve bridge to
+    drag it into a foreign workspace (foreign-cwd records read as unknown
+    ids; resume/load pin the root and never adopt the backend's returned
+    workspace — the value the `/fs` file endpoint scopes to).
+  - `POST /api/instances` keeps one in-flight spawn per workspace:
+    concurrent creates join the same incubation instead of racing a
+    duplicate detached process past the live-instance check.
+  - Registration answers that are neither 2xx nor 401 (e.g. the port
+    held by a non-hub service) now warn once per stretch instead of
+    silently disabling remote discovery.
+  - `listKnownWorkspaces(dbPath)` actually opens the injected path —
+    `withSqliteRetry` used to hardcode the default tasks index, so the
+    parameter only gated the existence check.
+  - The known-project list is documented as a convenience bound, not a
+    security boundary: bridge-side session materialization also writes
+    list rows, so the real trust boundary is the token itself.
+
 ## [0.16.2] - 2026-09-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,15 +19,15 @@ session in any of the machine's known projects, no editor required.
 - `POST /api/instances {workspacePath}` (hub, token auth): spawns
   `zcode-acp serve` — a headless bridge — detached in the project cwd,
   waits for its heartbeat registration, and returns `{id, reused}`. The
-  project list doubles as the whitelist: paths outside it get 403, so a
-  remote client can never spawn an agent in an arbitrary directory. A live
+  project list gates the create: paths outside it get 403 (a convenience
+  bound, not a security boundary — the trust boundary is the token). A live
   serve instance for the same workspace is reused instead of re-spawned.
 - `zcode-acp serve` CLI subcommand: the same ACP surface as the stdio
   server minus the editor — spawned by the hub with remote ENV, it
   registers back, serves remote WS clients, and exits after 10 idle
   minutes with no clients and no running turns (ADR-0001's headless
   counterpart). In serve mode `session/new` ignores client cwds and always
-  uses the process cwd, keeping the whitelist closed end to end.
+  uses the process cwd, pinning the session cwd end to end.
 - Registration heartbeats and `/api/instances` now carry an `origin`
   field (`"editor"` or `"serve"`, older bridges default to `"editor"`)
   so remote UIs can label CLI-started instances and the hub can dedupe
@@ -64,6 +64,21 @@ session in any of the machine's known projects, no editor required.
   - The known-project list is documented as a convenience bound, not a
     security boundary: bridge-side session materialization also writes
     list rows, so the real trust boundary is the token itself.
+- Second adversarial round over the branch:
+  - Serve-instance dedupe (and every serve-side workspace comparison)
+    now canonicalizes paths via realpath: a whitelist row or registration
+    carrying a symlinked spelling previously never matched the serve
+    child's resolved process cwd — every create 502'd after 10s and each
+    retry spawned another duplicate serve bridge.
+  - serve mode also pins `session/list` to the project cwd (a client cwd
+    could enumerate sessions in other projects) and refuses to resume or
+    load a raw backend session id that lives in another workspace.
+  - 401 recovery resets the whole replacement-hub schedule, so a second
+    token rotation self-heals at full speed instead of inheriting the
+    previous stretch's backoff timestamp.
+  - The serve spawn forwards `ZCODE_ACP_HUB_HOST` (parity with
+    bridge-side hub spawns) and fails fast on async spawn errors instead
+    of burning the 10s registration budget.
 
 ## [0.16.2] - 2026-09-01
 

--- a/README.md
+++ b/README.md
@@ -195,11 +195,36 @@ discovery ~30s after it stops.
 
 ```text
 GET /api/instances              → [{"id","port","pid","startedAt","workspace",
-                                    "sessions":[{"sessionId","title?","updatedAt"}]}]
+                                    "origin","sessions":[{"sessionId","title?","updatedAt"}]}]
 GET /api/instances?probe=1      → same list, but unreachable bridges are pruned first
 WS   /acp?instance=<id>         → proxied to that bridge's endpoint
 GET /api/instances/{id}/fs/…    → read-only session files (list + raw bytes, ADR-0004)
 ```
+
+`origin` labels how an instance was started: `"editor"` (a bridge an editor
+spawned over stdio) or `"serve"` (a headless bridge created remotely, see
+below).
+
+**Remote session-create** (ADR-0014). A remote client can start a NEW agent
+session in any of the machine's known projects — no editor required:
+
+```text
+GET  /api/projects              → [{"workspacePath","sessions","lastActive"}]
+POST /api/instances {workspacePath} → {"id","reused"}
+```
+
+`/api/projects` aggregates the App's tasks index: every workspace that ever
+ran a session (system temp trees, `~/.zcode` itself, and vanished
+directories filtered out), newest activity first. The list doubles as the
+whitelist — the POST refuses (403) any path outside it, so a remote client
+can never spawn an agent in an arbitrary directory. On create the hub
+spawns `zcode-acp serve` — a headless bridge — in the project's cwd; it
+registers back within seconds and is reachable like any other instance. A
+live serve instance for the same workspace is reused instead of re-spawned
+(`reused:true`). The serve bridge lives for remote interest only: it exits
+~10 minutes after the last client detaches and the last turn finishes, and
+its `session/new` always uses the project cwd regardless of what a client
+sends.
 
 `sessions` lists the project's **currently running** conversations (live
 editor tabs and remote attachments) under the same ACP session ids the

--- a/README.md
+++ b/README.md
@@ -215,9 +215,10 @@ POST /api/instances {workspacePath} → {"id","reused"}
 
 `/api/projects` aggregates the App's tasks index: every workspace that ever
 ran a session (system temp trees, `~/.zcode` itself, and vanished
-directories filtered out), newest activity first. The list doubles as the
-whitelist — the POST refuses (403) any path outside it, so a remote client
-can never spawn an agent in an arbitrary directory. On create the hub
+directories filtered out), newest activity first. The list gates the POST —
+paths outside it get 403 (a convenience bound, not a security boundary: a
+token holder can already drive an editor-bridge session in any cwd; the
+trust boundary is the token). On create the hub
 spawns `zcode-acp serve` — a headless bridge — in the project's cwd; it
 registers back within seconds and is reachable like any other instance. A
 live serve instance for the same workspace is reused instead of re-spawned

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -177,13 +177,14 @@ POST /api/instances {workspacePath} → {"id","reused"}
 ```
 
 `/api/projects` 聚合 App 的任务索引：所有跑过会话的项目（过滤系统临时
-目录、`~/.zcode` 自身和已不存在的目录），按最近活跃排序。这份列表同时
-就是白名单——POST 对列表之外的路径一律 403，远程永远无法在任意目录里
-启动 agent。创建时 hub 会在项目目录下拉起 `zcode-acp serve`（无头 bridge），
+目录、`~/.zcode` 自身和已不存在的目录），按最近活跃排序。这份列表约束
+POST——列表之外的路径一律 403（注意这是便利性约束而非安全边界：持有
+token 者本就能以任意 cwd 驱动 editor bridge 会话，真正的信任边界是
+token 本身）。创建时 hub 会在项目目录下拉起 `zcode-acp serve`（无头 bridge），
 数秒内注册回 hub，之后像普通实例一样可连接；同项目已有存活的 serve 实例
 则直接复用（`reused:true`）。serve bridge 只为远程连接而活：最后一个客户端
 断开且最后一个 turn 结束约 10 分钟后自动退出；其 `session/new` 无论客户端
-传什么都使用项目目录（白名单端到端闭合）。
+传什么都使用项目目录（cwd 端到端钉死在项目内）。
 
 **语义。** 所有 agent 通知广播给每个已连接客户端；权限 / elicitation 请求
 发给所有客户端，**先应答者生效**，其余客户端收到 `$/cancel_request` 关闭

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -168,10 +168,28 @@ token 鉴权、实例发现、字节级 WebSocket 代理——不保存会话状
 心跳，心跳停止约 30 秒后从发现列表移除；客户端刷新时也可调用
 `GET /api/instances?probe=1` 主动探测，立即清理不可达的实例。
 
+**远程创建会话**（ADR-0014）。远程客户端可以在本机的已知项目里直接开一个
+新会话——不需要任何编辑器在场：
+
+```text
+GET  /api/projects                  → [{"workspacePath","sessions","lastActive"}]
+POST /api/instances {workspacePath} → {"id","reused"}
+```
+
+`/api/projects` 聚合 App 的任务索引：所有跑过会话的项目（过滤系统临时
+目录、`~/.zcode` 自身和已不存在的目录），按最近活跃排序。这份列表同时
+就是白名单——POST 对列表之外的路径一律 403，远程永远无法在任意目录里
+启动 agent。创建时 hub 会在项目目录下拉起 `zcode-acp serve`（无头 bridge），
+数秒内注册回 hub，之后像普通实例一样可连接；同项目已有存活的 serve 实例
+则直接复用（`reused:true`）。serve bridge 只为远程连接而活：最后一个客户端
+断开且最后一个 turn 结束约 10 分钟后自动退出；其 `session/new` 无论客户端
+传什么都使用项目目录（白名单端到端闭合）。
+
 **语义。** 所有 agent 通知广播给每个已连接客户端；权限 / elicitation 请求
 发给所有客户端，**先应答者生效**，其余客户端收到 `$/cancel_request` 关闭
 对话框。同一会话的并发 prompt 与单编辑器一样串行化。任一客户端声明的能力
-按 OR 合并。
+按 OR 合并。`/api/instances` 的每个实例带 `origin` 字段（`"editor"`＝编辑器
+stdio 桥，`"serve"`＝远程创建的无头桥），客户端可据此标注。
 
 **隧道。** 面向单端口隧道（Cloudflare Tunnel、frp）设计：只映射 hub 端口。
 frp 的 `tcp` 模式原样透传 WebSocket；Cloudflare Tunnel 会断开空闲连接，

--- a/docs/REMOTE-CLIENTS.md
+++ b/docs/REMOTE-CLIENTS.md
@@ -148,14 +148,17 @@ GET  {hub}/api/projects
 
 POST {hub}/api/instances  body {"workspacePath":"/Users/me/proj"}
    → 200 {"id":"47073","reused":false}
-   → 403 "unknown project"          (path not on the list — the list IS the whitelist)
+   → 403 "unknown project"          (path not on the known-project list)
    → 502 (spawn failed / bridge died during startup / never registered, 10s budget)
 ```
 
 - `GET /api/projects` aggregates the App's tasks index: every workspace that
   ever ran a session, filtered (system temp trees, `~/.zcode` itself,
-  vanished directories) and sorted by last activity. No arbitrary paths are
-  ever accepted — the POST validates against this exact list.
+  vanished directories) and sorted by last activity. The POST validates
+  against this exact list — no arbitrary paths. Note this is a convenience
+  bound, not a security boundary: a token holder can already run any
+  editor-bridge session in an arbitrary cwd; the trust boundary is the
+  token itself.
 - On create the hub spawns `zcode-acp serve` — a headless bridge — detached
   in the project's cwd and waits for its heartbeat registration (it appears
   in `/api/instances` with `origin:"serve"` within seconds). Connect with
@@ -163,7 +166,8 @@ POST {hub}/api/instances  body {"workspacePath":"/Users/me/proj"}
   new conversation's cwd is the project directory regardless of what
   `session/new` sends.
 - A live serve instance for the same workspace is reused (`reused:true`)
-  instead of spawning a second one.
+  instead of spawning a second one; concurrent creates join the same
+  in-flight spawn instead of racing a duplicate.
 - Lifetime: the serve bridge exists for remote interest only. It exits ~10
   minutes after the last client detaches AND the last running turn
   finishes — a running turn always completes, even with all clients gone.

--- a/docs/REMOTE-CLIENTS.md
+++ b/docs/REMOTE-CLIENTS.md
@@ -55,6 +55,8 @@ ACP editor ────── stdio ──────────┘
 | `POST /api/instances/{id}/sessions/{sessionId}/rename` | required | Rename a session — see [Renaming a session](#renaming-a-session).                            |
 | `GET /api/quota`                                      | required | Account-level usage stats — same payload as `account/usage_stats`, no ACP connection needed. |
 | `POST /api/upgrade`                                   | required | Trigger the hub's own staleness check — see [Hub self-upgrade](#hub-self-upgrade).           |
+| `GET /api/projects`                                   | required | Known-project list (remote session-create whitelist) — see below.                            |
+| `POST /api/instances {workspacePath}`                 | required | Create (or reuse) a headless serve bridge for one known project — see below.                 |
 
 HTTP auth: `Authorization: Bearer <token>` or `?token=<token>`.
 
@@ -68,6 +70,7 @@ HTTP auth: `Authorization: Bearer <token>` or `?token=<token>`.
     "pid": 72341,
     "startedAt": 1723800000000,
     "workspace": "/Users/me/proj",
+    "origin": "editor",
     "sessions": [
       {
         "sessionId": "5f0c…",
@@ -82,6 +85,9 @@ HTTP auth: `Authorization: Bearer <token>` or `?token=<token>`.
 
 - `id` is the bridge process id — stable for that editor window's lifetime,
   unique per window.
+- `origin` is `"editor"` (a bridge an editor spawned over stdio) or
+  `"serve"` (a headless bridge created via remote session-create — see
+  below; older bridges send no field, treat as `"editor"`).
 - **On refresh, call `/api/instances?probe=1`**: the hub TCP-probes each
   registered bridge's loopback port and prunes unreachable ones before
   answering. A plain `GET` returns the heartbeat-based view, which can list a
@@ -130,6 +136,39 @@ Lifecycle timings: a bridge re-registers every 10s (the registration doubles as
 heartbeat); an instance disappears ~30s after its heartbeats stop; the hub
 exits after ~10 idle minutes with no instances and no proxies, and the next
 bridge re-spawns it on demand.
+
+## Remote session-create
+
+A remote client can start a NEW agent session in any of the machine's known
+projects — no editor required (bridge 0.17.0, ADR-0014):
+
+```text
+GET  {hub}/api/projects
+   → 200 [{"workspacePath":"/Users/me/proj","sessions":294,"lastActive":1723800000000}, …]
+
+POST {hub}/api/instances  body {"workspacePath":"/Users/me/proj"}
+   → 200 {"id":"47073","reused":false}
+   → 403 "unknown project"          (path not on the list — the list IS the whitelist)
+   → 502 (spawn failed / bridge died during startup / never registered, 10s budget)
+```
+
+- `GET /api/projects` aggregates the App's tasks index: every workspace that
+  ever ran a session, filtered (system temp trees, `~/.zcode` itself,
+  vanished directories) and sorted by last activity. No arbitrary paths are
+  ever accepted — the POST validates against this exact list.
+- On create the hub spawns `zcode-acp serve` — a headless bridge — detached
+  in the project's cwd and waits for its heartbeat registration (it appears
+  in `/api/instances` with `origin:"serve"` within seconds). Connect with
+  the normal `WS /acp?instance=<id>` and drive it like any instance; the
+  new conversation's cwd is the project directory regardless of what
+  `session/new` sends.
+- A live serve instance for the same workspace is reused (`reused:true`)
+  instead of spawning a second one.
+- Lifetime: the serve bridge exists for remote interest only. It exits ~10
+  minutes after the last client detaches AND the last running turn
+  finishes — a running turn always completes, even with all clients gone.
+  Treat a vanished serve instance like any other dead bridge: re-create it
+  on demand.
 
 ## Connecting
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -340,13 +340,19 @@ http://127.0.0.1:<hub-port>/api/health` fails, or `/api/*` returns 401.
 
 1. 401 means a token mismatch — `ZCODE_ACP_REMOTE_TOKEN` must be identical in
    the bridge env, the hub env (if run manually), and the client request.
-2. A dead hub self-heals: the next bridge heartbeat (≤10s; worst ~1min under
+2. Bridges on ≥0.17.0 self-heal after 401s (e.g. the token was rotated while
+   some windows kept the old env): the bridge keeps heartbeating and spawns a
+   replacement hub carrying its own token (≤1/min). Convergence needs the
+   mismatched hub to exit — instantly when nothing else holds the port, or via
+   its 10-minute zero-instance idle-exit. On older bridges a 401 permanently
+   stopped registration: restart the affected editor windows.
+3. A dead hub self-heals: the next bridge heartbeat (≤10s; worst ~1min under
    the spawn throttle) re-spawns the hub daemon. Retry with backoff rather
    than restarting anything by hand.
-3. Confirm the ports match: the client must reach `ZCODE_ACP_HUB_PORT`
+4. Confirm the ports match: the client must reach `ZCODE_ACP_HUB_PORT`
    (default 8377) through the tunnel, and the tunnel maps exactly that one
    port.
-4. Remote silently disabled? `ZCODE_ACP_REMOTE=1` without a token logs a
+5. Remote silently disabled? `ZCODE_ACP_REMOTE=1` without a token logs a
    warning and leaves the bridge stdio-only by design.
 
 ### Remote access: stale instance in the list / connect fails

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zcode-acp-server",
-  "version": "0.16.2",
+  "version": "0.17.0",
   "description": "Agent Client Protocol (ACP) server bridging headless ZCode to editors like Zed and JetBrains.",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -72,7 +72,7 @@ Commands:
                     -i <sec>, -d detail, -p plain, provider glm|go.
   hub               Run the remote-access hub daemon (was zcode-acp-hub;
                     usually auto-spawned by bridges, rarely run by hand).
-  serve             Headless bridge for remote session-create (ADR-0012):
+  serve             Headless bridge for remote session-create (ADR-0014):
                     no stdio editor, lives for remote WS clients until idle.
                     Normally spawned by the hub, not run by hand (needs
                     ZCODE_ACP_REMOTE=1 + ZCODE_ACP_REMOTE_TOKEN).

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,7 @@ import process from "node:process";
 
 import { main as runHub } from "./bin/hub.js";
 import { main as runQuota } from "./bin/quota.js";
-import { main as runServer } from "./index.js";
+import { main as runServer, runHeadless } from "./index.js";
 import { runRepl } from "./repl/run.js";
 import { AGENT_INFO } from "./utils.js";
 
@@ -26,6 +26,7 @@ export type Invocation =
   | { kind: "help" }
   | { kind: "repl"; explicit: boolean }
   | { kind: "server" }
+  | { kind: "serve" }
   | { kind: "hub" }
   | { kind: "quota"; args: string[] }
   | { kind: "unknown"; sub: string };
@@ -48,6 +49,8 @@ export function resolveInvocation(invokedAs: string, argv: readonly string[]): I
   switch (sub) {
     case "server":
       return { kind: "server" };
+    case "serve":
+      return { kind: "serve" };
     case "hub":
       return { kind: "hub" };
     case "quota":
@@ -69,6 +72,10 @@ Commands:
                     -i <sec>, -d detail, -p plain, provider glm|go.
   hub               Run the remote-access hub daemon (was zcode-acp-hub;
                     usually auto-spawned by bridges, rarely run by hand).
+  serve             Headless bridge for remote session-create (ADR-0012):
+                    no stdio editor, lives for remote WS clients until idle.
+                    Normally spawned by the hub, not run by hand (needs
+                    ZCODE_ACP_REMOTE=1 + ZCODE_ACP_REMOTE_TOKEN).
   server            The editor-facing ACP bridge over stdio (was
                     zcode-acp-server; editors normally launch it via the bin
                     alias without this subcommand).
@@ -107,6 +114,9 @@ async function main(): Promise<void> {
       return;
     case "server":
       await runServer();
+      return;
+    case "serve":
+      await runHeadless();
       return;
     case "hub":
       await runHub();

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -13,6 +13,7 @@
 
 import process from "node:process";
 import { randomUUID } from "node:crypto";
+import { realpathSync } from "node:fs";
 import type * as acp from "@agentclientprotocol/sdk";
 import { RequestError } from "@agentclientprotocol/sdk";
 
@@ -74,6 +75,20 @@ function workspaceFor(cwd?: string): { workspacePath: string; workspaceKey: stri
  */
 function sanitizeClientCwd(client: string | undefined): string | null {
   return client && client !== "/" ? client : null;
+}
+
+/**
+ * Same-directory check tolerant of spelling: a workspace can be recorded or
+ * reported under a symlinked / non-canonical spelling while the serve bridge
+ * holds the resolved process cwd. Compare realpaths; a vanished path falls
+ * back to raw equality (both sides unchanged → still equal).
+ */
+function sameProjectDir(a: string, b: string): boolean {
+  try {
+    return realpathSync(a) === realpathSync(b);
+  } catch {
+    return a === b;
+  }
 }
 
 /**
@@ -147,7 +162,7 @@ export async function newSession(
 ): Promise<acp.NewSessionResponse> {
   // Creation is the one moment a client's cwd is trusted (the editor
   // declaring its worktree); "/" is still rejected as a degenerate root.
-  // Serve mode (ADR-0012) is the exception: a headless bridge exists for ONE
+  // Serve mode (ADR-0014) is the exception: a headless bridge exists for ONE
   // hub-chosen project — the process cwd wins and client-supplied values are
   // ignored, so the remote create-whitelist cannot be bypassed via session/new.
   const cwd = server.serveMode ? process.cwd() : (sanitizeClientCwd(params.cwd) ?? process.cwd());
@@ -217,12 +232,14 @@ export async function ensureRealSession(server: ZcodeAcpServer, acpSid: string):
     // (the backend session still exists — re-register the alias); one without
     // re-hydrates the pending entry so the create path below runs.
     const record = lookupLazySession(acpSid);
-    // Serve mode (ADR-0012) honors durable records for ITS OWN project only.
+    // Serve mode (ADR-0014) honors durable records for ITS OWN project only.
     // Aliases are minted by editor bridges, which trust their local client's
     // session/new cwd — a remote client can mint {sid → arbitrary cwd} there
     // and then resume it here to drag this bridge into a foreign workspace.
-    // Records from another cwd read as unknown ids.
-    if (server.serveMode && record && record.cwd !== process.cwd()) {
+    // Records from another cwd read as unknown ids. The comparison tolerates
+    // spelling differences (symlinked record cwd vs the resolved process cwd)
+    // — same project under another spelling stays resumable.
+    if (server.serveMode && record && !sameProjectDir(record.cwd, process.cwd())) {
       log(`ensureRealSession: serve mode ignores a foreign lazy record (${acpSid})`);
       throw new Error(`session ${acpSid} not found`);
     }
@@ -315,8 +332,12 @@ export async function listSessions(
 ): Promise<acp.ListSessionsResponse> {
   const backend = server.ensureBackend();
   const zcParams: Record<string, unknown> = {};
-  if (params.cwd) {
-    zcParams.workspace = workspaceFor(params.cwd);
+  // Serve mode (ADR-0014) pins the workspace: a remote client must not use a
+  // client-supplied cwd to enumerate the machine's sessions in OTHER projects
+  // (the backend scopes the listing to the workspace it is given).
+  const listCwd = server.serveMode ? process.cwd() : params.cwd;
+  if (listCwd) {
+    zcParams.workspace = workspaceFor(listCwd);
   }
 
   const resp = await backend.request(server.nextId(), "session/list", zcParams, 15000);
@@ -420,7 +441,7 @@ export async function resumeSession(
   // The Session Root never comes from the client (params.cwd is ignored):
   // start from what the bridge recorded, then let the backend's own resume
   // result correct it below — a remote client must not move a session's
-  // file scope by sending its own cwd. Serve mode (ADR-0012) skips both
+  // file scope by sending its own cwd. Serve mode (ADR-0014) skips both
   // sources: the bridge exists for ONE hub-chosen project, so the root (and
   // the workspace sent to the backend's resume) stays the process cwd.
   let cwd = server.serveMode ? process.cwd() : authoritativeSessionCwd(server, acpSid);
@@ -457,9 +478,15 @@ export async function resumeSession(
     await repairUnavailableModel(server, zcodeSid);
     // The backend's session record is the root authority: adopt its
     // workspace as the session root (heals any stale/polluted entry).
-    // Serve mode keeps its pinned cwd (see above).
+    // Serve mode keeps its pinned cwd (see above) — and a session that
+    // genuinely lives in ANOTHER workspace is refused outright: a raw
+    // backend id from session/list elsewhere must not be replayed through
+    // a serve bridge pinned to one project.
     const backendWs = workspaceFromResumeResult(resumeResult);
     if (backendWs && !server.serveMode) cwd = backendWs;
+    if (server.serveMode && backendWs && !sameProjectDir(backendWs, process.cwd())) {
+      throw new Error("session belongs to another workspace");
+    }
   }
 
   server.registerSession(acpSid, zcodeSid);
@@ -494,7 +521,7 @@ export async function loadSession(
   // The Session Root never comes from the client (params.cwd is ignored):
   // start from what the bridge recorded, then let the backend's own resume
   // result correct it below — a remote client must not move a session's
-  // file scope by sending its own cwd. Serve mode (ADR-0012) pins the root
+  // file scope by sending its own cwd. Serve mode (ADR-0014) pins the root
   // (and the workspace sent to resume) to the process cwd throughout.
   let cwd = server.serveMode ? process.cwd() : authoritativeSessionCwd(server, acpSid);
 
@@ -518,9 +545,13 @@ export async function loadSession(
     await repairUnavailableModel(server, zcodeSid);
     // The backend's session record is the root authority: adopt its
     // workspace as the session root (heals any stale/polluted entry).
-    // Serve mode keeps its pinned cwd (see above).
+    // Serve mode keeps its pinned cwd (see above) — and refuses sessions
+    // from another workspace outright (same rule as resumeSession).
     const backendWs = workspaceFromResumeResult(resumeResult);
     if (backendWs && !server.serveMode) cwd = backendWs;
+    if (server.serveMode && backendWs && !sameProjectDir(backendWs, process.cwd())) {
+      throw new Error("session belongs to another workspace");
+    }
   }
   server.registerSession(acpSid, zcodeSid);
   // Same as resumeSession: backend-authoritative session root for file access.

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -147,7 +147,10 @@ export async function newSession(
 ): Promise<acp.NewSessionResponse> {
   // Creation is the one moment a client's cwd is trusted (the editor
   // declaring its worktree); "/" is still rejected as a degenerate root.
-  const cwd = sanitizeClientCwd(params.cwd) ?? process.cwd();
+  // Serve mode (ADR-0012) is the exception: a headless bridge exists for ONE
+  // hub-chosen project — the process cwd wins and client-supplied values are
+  // ignored, so the remote create-whitelist cannot be bypassed via session/new.
+  const cwd = server.serveMode ? process.cwd() : (sanitizeClientCwd(params.cwd) ?? process.cwd());
   // Placeholder id — the client addresses this session with it until the
   // backend session materializes; never shown in session/list.
   const acpSid = randomUUID();

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -217,14 +217,26 @@ export async function ensureRealSession(server: ZcodeAcpServer, acpSid: string):
     // (the backend session still exists — re-register the alias); one without
     // re-hydrates the pending entry so the create path below runs.
     const record = lookupLazySession(acpSid);
+    // Serve mode (ADR-0012) honors durable records for ITS OWN project only.
+    // Aliases are minted by editor bridges, which trust their local client's
+    // session/new cwd — a remote client can mint {sid → arbitrary cwd} there
+    // and then resume it here to drag this bridge into a foreign workspace.
+    // Records from another cwd read as unknown ids.
+    if (server.serveMode && record && record.cwd !== process.cwd()) {
+      log(`ensureRealSession: serve mode ignores a foreign lazy record (${acpSid})`);
+      throw new Error(`session ${acpSid} not found`);
+    }
     if (record?.zcodeSid) {
       server.registerSession(acpSid, record.zcodeSid);
       return record.zcodeSid;
     }
     if (record) {
-      pending = { cwd: record.cwd };
+      // Serve mode pins to its process cwd even here (belt and suspenders —
+      // the guard above already proved the record's cwd matches).
+      const cwd = server.serveMode ? process.cwd() : record.cwd;
+      pending = { cwd };
       server.pendingSessions.set(acpSid, pending);
-      if (record.cwd !== "/") server.sessionCwds.set(acpSid, record.cwd);
+      if (cwd !== "/") server.sessionCwds.set(acpSid, cwd);
     }
   }
   if (!pending) throw new Error(`session ${acpSid} not found`);
@@ -408,8 +420,10 @@ export async function resumeSession(
   // The Session Root never comes from the client (params.cwd is ignored):
   // start from what the bridge recorded, then let the backend's own resume
   // result correct it below — a remote client must not move a session's
-  // file scope by sending its own cwd.
-  let cwd = authoritativeSessionCwd(server, acpSid);
+  // file scope by sending its own cwd. Serve mode (ADR-0012) skips both
+  // sources: the bridge exists for ONE hub-chosen project, so the root (and
+  // the workspace sent to the backend's resume) stays the process cwd.
+  let cwd = server.serveMode ? process.cwd() : authoritativeSessionCwd(server, acpSid);
 
   // Lazy placeholders (session/new) resolve to their real backend session
   // here; alreadyLive targets skip the resume RPC because the session is live
@@ -443,8 +457,9 @@ export async function resumeSession(
     await repairUnavailableModel(server, zcodeSid);
     // The backend's session record is the root authority: adopt its
     // workspace as the session root (heals any stale/polluted entry).
+    // Serve mode keeps its pinned cwd (see above).
     const backendWs = workspaceFromResumeResult(resumeResult);
-    if (backendWs) cwd = backendWs;
+    if (backendWs && !server.serveMode) cwd = backendWs;
   }
 
   server.registerSession(acpSid, zcodeSid);
@@ -479,8 +494,9 @@ export async function loadSession(
   // The Session Root never comes from the client (params.cwd is ignored):
   // start from what the bridge recorded, then let the backend's own resume
   // result correct it below — a remote client must not move a session's
-  // file scope by sending its own cwd.
-  let cwd = authoritativeSessionCwd(server, acpSid);
+  // file scope by sending its own cwd. Serve mode (ADR-0012) pins the root
+  // (and the workspace sent to resume) to the process cwd throughout.
+  let cwd = server.serveMode ? process.cwd() : authoritativeSessionCwd(server, acpSid);
 
   // Same placeholder resolution as resumeSession; alreadyLive targets skip the
   // backend resume RPC (the session is live in this subprocess).
@@ -502,8 +518,9 @@ export async function loadSession(
     await repairUnavailableModel(server, zcodeSid);
     // The backend's session record is the root authority: adopt its
     // workspace as the session root (heals any stale/polluted entry).
+    // Serve mode keeps its pinned cwd (see above).
     const backendWs = workspaceFromResumeResult(resumeResult);
-    if (backendWs) cwd = backendWs;
+    if (backendWs && !server.serveMode) cwd = backendWs;
   }
   server.registerSession(acpSid, zcodeSid);
   // Same as resumeSession: backend-authoritative session root for file access.

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,9 +88,6 @@ export async function main(): Promise<void> {
   // Load all commands once at startup (they don't change mid-session).
   const allCommands = buildAllCommands();
 
-  /** Passthrough params parser for the ZCode-specific extension methods. */
-  const extParams = z.object({ sessionId: z.string() }).passthrough();
-
   log(`starting ${AGENT_INFO.name} ${AGENT_INFO.version}, ACP protocol v${acp.PROTOCOL_VERSION}`);
 
   // Remote access handle (null unless ZCODE_ACP_REMOTE is enabled and the
@@ -124,96 +121,7 @@ export async function main(): Promise<void> {
   }, 2000);
   backendDeathInterval.unref();
 
-  const app = acp
-    .agent({ name: AGENT_INFO.name })
-    .onRequest("initialize", (ctx) => server.initialize(ctx.params))
-    .onRequest("session/new", async (ctx) => {
-      const result = await newSession(server, ctx.params);
-      for (const sid of server.sessionAliases(result.sessionId)) {
-        sendAvailableCommandsDeferred(server.clients.broadcast(), sid, allCommands);
-      }
-      return result;
-    })
-    .onRequest("session/list", (ctx) => listSessions(server, ctx.params))
-    .onRequest("session/resume", async (ctx) => {
-      const result = await resumeSession(server, ctx.params, server.clients.broadcast());
-      for (const sid of server.sessionAliases(ctx.params.sessionId)) {
-        sendAvailableCommandsDeferred(server.clients.broadcast(), sid, allCommands);
-      }
-      // A client that (re)connects catches up via resume/load; any interaction
-      // request still waiting for an answer is re-sent to it so a question
-      // fired while it was offline becomes answerable there.
-      resendPendingInteractions(server, ctx.client, ctx.params.sessionId);
-      return result;
-    })
-    .onRequest("session/load", async (ctx) => {
-      const result = await loadSession(server, ctx.params, server.clients.broadcast());
-      for (const sid of server.sessionAliases(ctx.params.sessionId)) {
-        sendAvailableCommandsDeferred(server.clients.broadcast(), sid, allCommands);
-      }
-      resendPendingInteractions(server, ctx.client, ctx.params.sessionId);
-      return result;
-    })
-    // Tail-replay pagination (non-standard; Proposal 0001) — params stay
-    // top-level because the parser below is ours, unlike spec methods where
-    // bridge extensions must ride in `_meta.zcode`.
-    .onRequest(
-      "session/load_earlier",
-      z
-        .object({ sessionId: z.string(), before: z.string(), limit: z.number().optional() })
-        .passthrough(),
-      (ctx) => loadEarlier(server, ctx.params, server.clients.broadcast()),
-    )
-    // Account-level plan quota for remote clients (non-standard; Proposal
-    // 0002). Pull-only, no session required; errors carry the failure kind in
-    // `data.kind` so clients can hide the quota UI.
-    .onRequest("account/usage_stats", z.object({}).passthrough(), () => accountUsageStats())
-    .onRequest("session/prompt", (ctx) => {
-      // Mirror the user's message to every other client before the turn
-      // starts — the prompting client renders it locally, the others only
-      // ever see the agent's output.
-      echoUserPromptToOthers(server, ctx.client, ctx.params);
-      // JSON-RPC requests always carry a non-null id; the SDK types it as the
-      // wider JsonRpcId, hence the narrowing cast.
-      return prompt(
-        server,
-        ctx.params,
-        server.clients.broadcast(),
-        ctx.requestId as number | string,
-      );
-    })
-    .onRequest("session/set_config_option", (ctx) =>
-      setConfigOptionHandler(server, ctx.params, server.clients.broadcast()),
-    )
-    // ZCode-specific extensions (non-standard ACP methods). Use a passthrough
-    // zod parser so all param fields survive into the handler.
-    // session/steer, session/rewind, session/rewindCascade were removed in
-    // zcode app-server 0.16+ (steer/rewind moved to the v4 conversation API);
-    // the bridge dropped its passthroughs accordingly.
-    .onRequest("session/fork", extParams, (ctx) => fork(server, ctx.params))
-    .onRequest("session/goal", extParams, (ctx) => goal(server, ctx.params))
-    .onRequest("session/compact", extParams, (ctx) =>
-      compact(server, ctx.params, server.clients.broadcast()),
-    )
-    .onRequest("session/cancelBackgroundTask", extParams, (ctx) =>
-      cancelBackgroundTask(server, ctx.params),
-    )
-    .onRequest("session/setThoughtLevel", extParams, (ctx) => setThoughtLevel(server, ctx.params))
-    .onRequest("session/updateRuntimeModelConfig", extParams, (ctx) =>
-      updateRuntimeModelConfig(server, ctx.params),
-    )
-    .onRequest("session/setModel", extParams, (ctx) => setModel(server, ctx.params))
-    .onRequest("session/setMode", extParams, (ctx) =>
-      setMode(server, ctx.params, server.clients.broadcast()),
-    )
-    // Spec spelling of the same call (ACP session-modes uses snake_case with
-    // `modeId`); the handler normalizes the param. Without this route, spec-only
-    // clients (e.g. Paseo) get -32601 and cannot create agents in a non-default
-    // mode.
-    .onRequest("session/set_mode", extParams, (ctx) =>
-      setMode(server, ctx.params, server.clients.broadcast()),
-    )
-    .onNotification("session/cancel", (ctx) => cancel(server, ctx.params));
+  const app = buildAgentApp(server, allCommands);
 
   // Register broadcast tracking BEFORE connect so the stdio connection is
   // captured, then wire the stdio transport. The same app is later shared
@@ -228,6 +136,214 @@ export async function main(): Promise<void> {
   if (remoteConfig) {
     remoteHandle = await startRemoteEndpoint(server, app, remoteConfig);
   }
+}
+
+/**
+ * The full ACP method surface (spec + ZCode extensions), shared verbatim by
+ * the stdio server (`main`) and the headless serve bridge (`runHeadless`) —
+ * one build, two transports.
+ */
+function buildAgentApp(server: ZcodeAcpServer, allCommands: ReturnType<typeof buildAllCommands>) {
+  /** Passthrough params parser for the ZCode-specific extension methods. */
+  const extParams = z.object({ sessionId: z.string() }).passthrough();
+
+  return (
+    acp
+      .agent({ name: AGENT_INFO.name })
+      .onRequest("initialize", (ctx) => server.initialize(ctx.params))
+      .onRequest("session/new", async (ctx) => {
+        const result = await newSession(server, ctx.params);
+        for (const sid of server.sessionAliases(result.sessionId)) {
+          sendAvailableCommandsDeferred(server.clients.broadcast(), sid, allCommands);
+        }
+        return result;
+      })
+      .onRequest("session/list", (ctx) => listSessions(server, ctx.params))
+      .onRequest("session/resume", async (ctx) => {
+        const result = await resumeSession(server, ctx.params, server.clients.broadcast());
+        for (const sid of server.sessionAliases(ctx.params.sessionId)) {
+          sendAvailableCommandsDeferred(server.clients.broadcast(), sid, allCommands);
+        }
+        // A client that (re)connects catches up via resume/load; any interaction
+        // request still waiting for an answer is re-sent to it so a question
+        // fired while it was offline becomes answerable there.
+        resendPendingInteractions(server, ctx.client, ctx.params.sessionId);
+        return result;
+      })
+      .onRequest("session/load", async (ctx) => {
+        const result = await loadSession(server, ctx.params, server.clients.broadcast());
+        for (const sid of server.sessionAliases(ctx.params.sessionId)) {
+          sendAvailableCommandsDeferred(server.clients.broadcast(), sid, allCommands);
+        }
+        resendPendingInteractions(server, ctx.client, ctx.params.sessionId);
+        return result;
+      })
+      // Tail-replay pagination (non-standard; Proposal 0001) — params stay
+      // top-level because the parser below is ours, unlike spec methods where
+      // bridge extensions must ride in `_meta.zcode`.
+      .onRequest(
+        "session/load_earlier",
+        z
+          .object({ sessionId: z.string(), before: z.string(), limit: z.number().optional() })
+          .passthrough(),
+        (ctx) => loadEarlier(server, ctx.params, server.clients.broadcast()),
+      )
+      // Account-level plan quota for remote clients (non-standard; Proposal
+      // 0002). Pull-only, no session required; errors carry the failure kind in
+      // `data.kind` so clients can hide the quota UI.
+      .onRequest("account/usage_stats", z.object({}).passthrough(), () => accountUsageStats())
+      .onRequest("session/prompt", (ctx) => {
+        // Mirror the user's message to every other client before the turn
+        // starts — the prompting client renders it locally, the others only
+        // ever see the agent's output.
+        echoUserPromptToOthers(server, ctx.client, ctx.params);
+        // JSON-RPC requests always carry a non-null id; the SDK types it as the
+        // wider JsonRpcId, hence the narrowing cast.
+        return prompt(
+          server,
+          ctx.params,
+          server.clients.broadcast(),
+          ctx.requestId as number | string,
+        );
+      })
+      .onRequest("session/set_config_option", (ctx) =>
+        setConfigOptionHandler(server, ctx.params, server.clients.broadcast()),
+      )
+      // ZCode-specific extensions (non-standard ACP methods). Use a passthrough
+      // zod parser so all param fields survive into the handler.
+      // session/steer, session/rewind, session/rewindCascade were removed in
+      // zcode app-server 0.16+ (steer/rewind moved to the v4 conversation API);
+      // the bridge dropped its passthroughs accordingly.
+      .onRequest("session/fork", extParams, (ctx) => fork(server, ctx.params))
+      .onRequest("session/goal", extParams, (ctx) => goal(server, ctx.params))
+      .onRequest("session/compact", extParams, (ctx) =>
+        compact(server, ctx.params, server.clients.broadcast()),
+      )
+      .onRequest("session/cancelBackgroundTask", extParams, (ctx) =>
+        cancelBackgroundTask(server, ctx.params),
+      )
+      .onRequest("session/setThoughtLevel", extParams, (ctx) => setThoughtLevel(server, ctx.params))
+      .onRequest("session/updateRuntimeModelConfig", extParams, (ctx) =>
+        updateRuntimeModelConfig(server, ctx.params),
+      )
+      .onRequest("session/setModel", extParams, (ctx) => setModel(server, ctx.params))
+      .onRequest("session/setMode", extParams, (ctx) =>
+        setMode(server, ctx.params, server.clients.broadcast()),
+      )
+      // Spec spelling of the same call (ACP session-modes uses snake_case with
+      // `modeId`); the handler normalizes the param. Without this route, spec-only
+      // clients (e.g. Paseo) get -32601 and cannot create agents in a non-default
+      // mode.
+      .onRequest("session/set_mode", extParams, (ctx) =>
+        setMode(server, ctx.params, server.clients.broadcast()),
+      )
+      .onNotification("session/cancel", (ctx) => cancel(server, ctx.params))
+  );
+}
+
+// ---------- headless serve bridge (remote session-create, ADR-0012) ----------
+
+/** How long a serve bridge stays up with no clients attached and no turn running. */
+const SERVE_IDLE_MS = 10 * 60_000;
+const SERVE_IDLE_CHECK_MS = 30_000;
+
+/**
+ * Pure idle decision for the serve bridge: exit only when nothing is attached
+ * (no ACP clients, no in-flight turns) AND that has been true for `idleMs`.
+ * Busy ticks refresh `lastBusy` at the call site, so a long turn with all
+ * clients gone still exits one idle window after it finishes — never mid-turn.
+ */
+export function serveIdleDecision(
+  clients: number,
+  pendingTurns: number,
+  lastBusy: number,
+  now: number,
+  idleMs: number,
+): boolean {
+  if (clients > 0 || pendingTurns > 0) return false;
+  return now - lastBusy >= idleMs;
+}
+
+/**
+ * Headless bridge for remote session-create (`zcode-acp serve`): the same ACP
+ * surface as `main`, minus the stdio editor. Spawned detached by the hub with
+ * cwd = the chosen project; its lifecycle is the mirror of ADR-0001 — instead
+ * of following the editor's stdio, it follows remote interest: stays alive
+ * while any client is attached or any turn runs, exits SERVE_IDLE_MS after
+ * the last of those ends. Remote access is not optional here — without the
+ * endpoint the process has no reason to exist, so a missing config or failed
+ * endpoint exits instead of degrading.
+ */
+export async function runHeadless(): Promise<void> {
+  const remoteConfig = parseRemoteConfig();
+  if (!remoteConfig) {
+    warn(
+      "serve: remote access is required for a headless bridge — set " +
+        "ZCODE_ACP_REMOTE=1 and ZCODE_ACP_REMOTE_TOKEN",
+    );
+    process.exit(2);
+  }
+  const server = new ZcodeAcpServer({ serveMode: true });
+  const allCommands = buildAllCommands();
+  log(
+    `starting ${AGENT_INFO.name} ${AGENT_INFO.version} serve (headless), project=${server.projectCwd()}`,
+  );
+
+  let remoteHandle: RemoteEndpointHandle | null = null;
+  let shuttingDown = false;
+  const shutdown = async (reason: string) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    log(`serve: shutting down (${reason})`);
+    if (remoteHandle) await remoteHandle.stop();
+    if (server.backend) await server.backend.close();
+    process.exit(0);
+  };
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"] as const) {
+    process.on(sig, () => void shutdown(sig));
+  }
+  // Backend reader died (zcode subprocess exited) — bridge is useless without it.
+  const backendDeathInterval = setInterval(() => {
+    if (server.backend?.isDead) void shutdown("backend dead");
+  }, 2000);
+  backendDeathInterval.unref();
+  // No stdin lifecycle here by design: the hub spawns the serve bridge with
+  // stdin ignored, and ADR-0001's "editor closed stdin" signal has no editor
+  // to come from — idle exit below is this mode's shutdown path.
+
+  const app = buildAgentApp(server, allCommands);
+  // Track connections BEFORE the endpoint accepts any WS client so every
+  // remote connection lands in the broadcast registry from its first message.
+  trackConnections(app, server.clients);
+
+  remoteHandle = await startRemoteEndpoint(server, app, { ...remoteConfig, origin: "serve" });
+  if (!remoteHandle) {
+    warn("serve: remote endpoint failed to start — exiting");
+    process.exit(1);
+  }
+
+  // Idle lifecycle + the process's only keep-alive: the endpoint's HTTP server
+  // and heartbeat timers are all unref'd (ADR-0001), so without this interval
+  // the process would exit immediately. Deliberately NOT unref'd.
+  let lastBusy = Date.now();
+  const idleCheck = setInterval(() => {
+    if (server.clients.size > 0 || server.pendingTurns.size > 0) {
+      lastBusy = Date.now();
+      return;
+    }
+    if (
+      serveIdleDecision(
+        server.clients.size,
+        server.pendingTurns.size,
+        lastBusy,
+        Date.now(),
+        SERVE_IDLE_MS,
+      )
+    ) {
+      void shutdown("idle — no clients attached and no turn running");
+    }
+  }, SERVE_IDLE_CHECK_MS);
+  void idleCheck;
 }
 
 // Only auto-run when invoked directly (not when imported by the Unified CLI

--- a/src/index.ts
+++ b/src/index.ts
@@ -241,7 +241,7 @@ function buildAgentApp(server: ZcodeAcpServer, allCommands: ReturnType<typeof bu
   );
 }
 
-// ---------- headless serve bridge (remote session-create, ADR-0012) ----------
+// ---------- headless serve bridge (remote session-create, ADR-0014) ----------
 
 /** How long a serve bridge stays up with no clients attached and no turn running. */
 const SERVE_IDLE_MS = 10 * 60_000;

--- a/src/remote/config.ts
+++ b/src/remote/config.ts
@@ -26,7 +26,7 @@ export interface RemoteConfig {
   bridgePort: number;
   /**
    * Who this bridge serves: "editor" (spawned by an editor over stdio) or
-   * "serve" (headless, hub-spawned for remote session-create, ADR-0012).
+   * "serve" (headless, hub-spawned for remote session-create, ADR-0014).
    * Rides the registration heartbeat; the hub uses it to dedupe headless
    * instances per workspace and label them for remote clients.
    */

--- a/src/remote/config.ts
+++ b/src/remote/config.ts
@@ -24,6 +24,13 @@ export interface RemoteConfig {
   hubPort: number;
   hubHost: string;
   bridgePort: number;
+  /**
+   * Who this bridge serves: "editor" (spawned by an editor over stdio) or
+   * "serve" (headless, hub-spawned for remote session-create, ADR-0012).
+   * Rides the registration heartbeat; the hub uses it to dedupe headless
+   * instances per workspace and label them for remote clients.
+   */
+  origin: "editor" | "serve";
 }
 
 export const DEFAULT_HUB_PORT = 8377;
@@ -57,6 +64,7 @@ export function parseRemoteConfig(env: NodeJS.ProcessEnv = process.env): RemoteC
     hubPort: parsePort(env.ZCODE_ACP_HUB_PORT, DEFAULT_HUB_PORT, "ZCODE_ACP_HUB_PORT"),
     hubHost: (env.ZCODE_ACP_HUB_HOST ?? "").trim() || DEFAULT_HUB_HOST,
     bridgePort: parsePort(env.ZCODE_ACP_REMOTE_PORT, DEFAULT_BRIDGE_PORT, "ZCODE_ACP_REMOTE_PORT"),
+    origin: "editor",
   };
 }
 
@@ -72,5 +80,6 @@ export function parseHubConfig(env: NodeJS.ProcessEnv = process.env): RemoteConf
     hubPort: parsePort(env.ZCODE_ACP_HUB_PORT, DEFAULT_HUB_PORT, "ZCODE_ACP_HUB_PORT"),
     hubHost: (env.ZCODE_ACP_HUB_HOST ?? "").trim() || DEFAULT_HUB_HOST,
     bridgePort: parsePort(env.ZCODE_ACP_REMOTE_PORT, DEFAULT_BRIDGE_PORT, "ZCODE_ACP_REMOTE_PORT"),
+    origin: "editor",
   };
 }

--- a/src/remote/endpoint.ts
+++ b/src/remote/endpoint.ts
@@ -268,7 +268,7 @@ export async function startRemoteEndpoint(
     pid: process.pid,
     workspace: server.workspaceLabel(),
     sessions,
-    // "editor" (stdio bridge) or "serve" (headless, hub-spawned, ADR-0012):
+    // "editor" (stdio bridge) or "serve" (headless, hub-spawned, ADR-0014):
     // lets the hub dedupe headless instances per workspace and label them.
     origin: config.origin,
     // Lets the hub detect that it is older than this bridge and restart
@@ -361,8 +361,12 @@ export async function startRemoteEndpoint(
       if (res.ok) {
         if (authRejected) {
           authRejected = false;
-          // Fresh ladder for any future rejection stretch.
+          // Fresh ladder for any future rejection stretch — BOTH the backoff
+          // and the next-spawn timestamp, or the next stretch's first 401
+          // would inherit the old schedule and skip its own replacement
+          // spawn for up to the 10min cap.
           authSpawnBackoffMs = SPAWN_THROTTLE_MS;
+          nextAuthSpawnAt = 0;
           log("remote: hub registration recovered after 401 rejection");
         }
         unexpectedStatus = null;

--- a/src/remote/endpoint.ts
+++ b/src/remote/endpoint.ts
@@ -258,6 +258,9 @@ export async function startRemoteEndpoint(
     pid: process.pid,
     workspace: server.workspaceLabel(),
     sessions,
+    // "editor" (stdio bridge) or "serve" (headless, hub-spawned, ADR-0012):
+    // lets the hub dedupe headless instances per workspace and label them.
+    origin: config.origin,
     // Lets the hub detect that it is older than this bridge and restart
     // itself (we then re-spawn it from this dist — see registerOnce).
     version: AGENT_INFO.version,

--- a/src/remote/endpoint.ts
+++ b/src/remote/endpoint.ts
@@ -46,6 +46,8 @@ interface AdvertisedSession {
 const HEARTBEAT_MS = 10_000;
 /** Minimum spacing between hub spawn attempts (avoids spawn storms). */
 const SPAWN_THROTTLE_MS = 60_000;
+/** Cap for the 401-spawn backoff ladder (starts at SPAWN_THROTTLE_MS, doubles). */
+const AUTH_SPAWN_MAX_BACKOFF_MS = 10 * 60_000;
 /** Max ports probed above ZCODE_ACP_REMOTE_PORT before giving up. */
 const MAX_PORT_PROBES = 100;
 
@@ -249,6 +251,14 @@ export async function startRemoteEndpoint(
   const instanceId = String(process.pid);
   let stopped = false;
   let authRejected = false;
+  // 401-spawn schedule: an independent ladder from the unreachable-path
+  // throttle, because a mixed-token fleet can keep the mismatched hub alive
+  // indefinitely (its own bridges keep re-registering) — every spawn before
+  // that hub dies is a lost port race, so the attempts back off to a cap.
+  let nextAuthSpawnAt = 0;
+  let authSpawnBackoffMs = SPAWN_THROTTLE_MS;
+  // Last non-2xx/non-401 register status we warned about (once per stretch).
+  let unexpectedStatus: number | null = null;
   let spawnThrottledUntil = 0;
 
   const payload = (sessions: AdvertisedSession[]) => ({
@@ -304,15 +314,18 @@ export async function startRemoteEndpoint(
   let lastSessions: AdvertisedSession[] = [];
 
   const registerOnce = async (): Promise<void> => {
-    if (stopped || authRejected) return;
+    if (stopped) return;
     // Project-scoped session list before every heartbeat (session/list merge,
-    // ~100-300ms). Never throws; wrapped anyway so a surprise failure can't
-    // fall into the hub-spawn catch below (which would misread it as "hub
-    // unreachable").
-    try {
-      lastSessions = await collectSessions(server);
-    } catch {
-      /* keep lastSessions */
+    // ~100-300ms). Skipped while token-rejected: the payload would be refused
+    // anyway, so keep advertising lastSessions until a hub accepts us again.
+    // Never throws; wrapped anyway so a surprise failure can't fall into the
+    // hub-spawn catch below (which would misread it as "hub unreachable").
+    if (!authRejected) {
+      try {
+        lastSessions = await collectSessions(server);
+      } catch {
+        /* keep lastSessions */
+      }
     }
     try {
       const res = await postJson(
@@ -320,11 +333,45 @@ export async function startRemoteEndpoint(
         payload(lastSessions),
       );
       if (res.status === 401) {
-        authRejected = true;
-        warn(
-          "remote: hub rejected the token (401) — registration stopped, check ZCODE_ACP_REMOTE_TOKEN",
-        );
+        // Token mismatch — typically the token was rotated while this bridge
+        // (or the running hub) kept the old value. Never poison permanently:
+        // keep heartbeating so the bridge heals the moment a hub with a
+        // matching token answers, and spawn a replacement hub carrying OUR
+        // token. While a mismatched hub still holds the port the spawn loses
+        // the singleton race and exits; once that hub stops answering (it
+        // idle-exits once no bridge can register with it) the next spawn
+        // installs one that accepts us. Spawn spacing backs off to the cap —
+        // see nextAuthSpawnAt above.
+        if (!authRejected) {
+          authRejected = true;
+          warn(
+            "remote: hub rejected the token (401) — registration keeps retrying; " +
+              "a replacement hub is spawned (with backoff) until one accepts this token",
+          );
+        }
+        if (Date.now() >= nextAuthSpawnAt) {
+          nextAuthSpawnAt = Date.now() + authSpawnBackoffMs;
+          authSpawnBackoffMs = Math.min(authSpawnBackoffMs * 2, AUTH_SPAWN_MAX_BACKOFF_MS);
+          spawnHub();
+          const retry = setTimeout(() => void registerOnce(), 1500);
+          retry.unref();
+        }
         return;
+      }
+      if (res.ok) {
+        if (authRejected) {
+          authRejected = false;
+          // Fresh ladder for any future rejection stretch.
+          authSpawnBackoffMs = SPAWN_THROTTLE_MS;
+          log("remote: hub registration recovered after 401 rejection");
+        }
+        unexpectedStatus = null;
+      } else if (unexpectedStatus !== res.status) {
+        // Neither 2xx nor 401 — e.g. the port is held by a non-hub service.
+        // Without this the endpoint would be silently dead; warn once per
+        // stretch so the 10s heartbeat can't spam it.
+        unexpectedStatus = res.status;
+        warn(`remote: hub answered registration with unexpected status ${res.status}`);
       }
       // Version handshake: the hub saw a newer bridge and is exiting. It is
       // gone by now (it exits ~0.5s after replying) — re-spawn it from THIS

--- a/src/remote/hub-server.ts
+++ b/src/remote/hub-server.ts
@@ -23,6 +23,7 @@
  * next bridge re-spawns it on demand.
  */
 
+import { spawn, type ChildProcess } from "node:child_process";
 import { createHash, timingSafeEqual } from "node:crypto";
 import type { Dirent } from "node:fs";
 import { readdir, readFile, stat } from "node:fs/promises";
@@ -36,12 +37,14 @@ import {
 } from "node:http";
 import net from "node:net";
 import path from "node:path";
+import process from "node:process";
 import { fileURLToPath } from "node:url";
 
 import { WebSocket, WebSocketServer, type RawData } from "ws";
 
 import { AGENT_INFO, compareVersions, log, warn } from "../utils.js";
 import { accountUsageStats, type UsageStatsResult } from "../handlers/account.js";
+import { listKnownWorkspaces } from "../tasks-index.js";
 
 export interface HubOptions {
   port: number;
@@ -66,6 +69,17 @@ export interface HubOptions {
    * directory this module runs from.
    */
   codePaths?: { packageJson: string; distDir: string };
+  /**
+   * Override where the remote session-create endpoints read the known-project
+   * whitelist from (tests point this at a fixture sqlite). Default: the App's
+   * tasks-index.sqlite (see listKnownWorkspaces).
+   */
+  projectsDbPath?: string;
+  /**
+   * Override how POST /api/instances spawns the headless serve bridge (tests
+   * inject a fake). Default: this node + this package's dist/cli.js.
+   */
+  spawnServe?: (opts: { cwd: string; env: NodeJS.ProcessEnv }) => ChildProcess;
 }
 
 export interface HubHandle {
@@ -89,6 +103,8 @@ interface InstanceEntry {
   workspace: string;
   sessions: SessionSummary[];
   lastSeen: number;
+  /** "editor" (stdio bridge) or "serve" (headless, hub-spawned, ADR-0012). */
+  origin: "editor" | "serve";
 }
 
 const HEARTBEAT_TIMEOUT_MS = 30_000;
@@ -162,6 +178,43 @@ function validSessions(raw: unknown): SessionSummary[] | null {
     });
   }
   return out;
+}
+
+/** How long POST /api/instances waits for the spawned bridge to register. */
+const SERVE_REGISTER_TIMEOUT_MS = 10_000;
+const SERVE_REGISTER_POLL_MS = 300;
+
+/** Register-origin parser: only "serve" is special; anything else is "editor". */
+function parseOrigin(raw: unknown): "editor" | "serve" {
+  return raw === "serve" ? "serve" : "editor";
+}
+
+/**
+ * Default serve-bridge spawner (remote session-create, ADR-0012): this node
+ * running this package's cli.js `serve` subcommand, detached in the project's
+ * cwd with the ENV the bridge needs to find its way back to this hub. Mirrors
+ * endpoint.ts's spawnHub: detached + unref'd (the hub must not own its life),
+ * stderr piped and tail-logged so startup failures surface instead of
+ * silently vanishing with an "ignore" pipe.
+ */
+function defaultSpawnServe(opts: { cwd: string; env: NodeJS.ProcessEnv }): ChildProcess {
+  // dist/remote/hub-server.js → dist/cli.js (one level up).
+  const cliJs = fileURLToPath(new URL("../cli.js", import.meta.url));
+  const child = spawn(process.execPath, [cliJs, "serve"], {
+    cwd: opts.cwd,
+    detached: true,
+    stdio: ["ignore", "ignore", "pipe"],
+    env: opts.env,
+  });
+  child.stderr?.setEncoding("utf8");
+  child.stderr?.on("data", (d: string) => {
+    for (const line of d.split("\n")) {
+      if (line.trim()) warn(`serve-bridge[${opts.cwd}]: ${line}`);
+    }
+  });
+  child.once("error", (e) => warn(`serve-bridge[${opts.cwd}] spawn failed: ${e.message}`));
+  child.unref();
+  return child;
 }
 
 /**
@@ -307,6 +360,8 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
     onIdleExit,
     onRestart,
     codePaths = defaultCodePaths(),
+    projectsDbPath,
+    spawnServe = defaultSpawnServe,
   } = options;
 
   /** Frozen at hub start — the anchor the /api/upgrade signals compare to. */
@@ -449,6 +504,7 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
           pid: e.pid,
           startedAt: e.startedAt,
           workspace: e.workspace,
+          origin: e.origin,
           sessions: e.sessions.filter((s) => winners.get(s.sessionId)?.instance === e),
         }));
       res.writeHead(200, { "Content-Type": "application/json" });
@@ -474,6 +530,104 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
         res.end("quota query failed");
       }
       return;
+    }
+    // GET /api/projects — the machine's known-project list (remote
+    // session-create, ADR-0012). Sourced from the App's tasks index: every
+    // workspace that ever ran a session. This list IS the create whitelist —
+    // POST /api/instances refuses paths outside it, so a remote client can
+    // never spawn an agent in an arbitrary directory.
+    if (url.pathname === "/api/projects" && req.method === "GET") {
+      if (!authorized(req, url, token)) {
+        res.writeHead(401, { "Content-Type": "text/plain" });
+        res.end("unauthorized");
+        return;
+      }
+      const projects = await listKnownWorkspaces(projectsDbPath);
+      res.writeHead(200, {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-store",
+      });
+      res.end(JSON.stringify(projects));
+      return;
+    }
+    // POST /api/instances — create (or reuse) a headless serve bridge for one
+    // known project. The hub spawns `zcode-acp serve` detached in the project
+    // cwd and waits for its heartbeat registration; the bridge lives its own
+    // idle-timed life afterwards (ADR-0012). Dedupe: one serve instance per
+    // workspace — an existing live one is returned instead of a second spawn.
+    if (url.pathname === "/api/instances" && req.method === "POST") {
+      if (!authorized(req, url, token)) {
+        res.writeHead(401, { "Content-Type": "text/plain" });
+        res.end("unauthorized");
+        return;
+      }
+      const body = await readJson(req);
+      const rawPath = (body as { workspacePath?: unknown } | undefined)?.workspacePath;
+      const workspacePath = typeof rawPath === "string" ? rawPath.trim() : "";
+      if (!workspacePath) {
+        res.writeHead(400, { "Content-Type": "text/plain" });
+        res.end("workspacePath required");
+        return;
+      }
+      const known = await listKnownWorkspaces(projectsDbPath);
+      if (!known.some((p) => p.workspacePath === workspacePath)) {
+        res.writeHead(403, { "Content-Type": "text/plain" });
+        res.end("unknown project");
+        return;
+      }
+      const findServe = (): InstanceEntry | undefined =>
+        Array.from(instances.values()).find(
+          (e) => e.origin === "serve" && e.workspace === workspacePath,
+        );
+      const existing = findServe();
+      if (existing) {
+        log(`hub: serve instance for ${workspacePath} already live (${existing.id}) — reusing`);
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ id: existing.id, reused: true }));
+        return;
+      }
+      let child: ChildProcess;
+      try {
+        child = spawnServe({
+          cwd: workspacePath,
+          env: {
+            ...process.env,
+            ZCODE_ACP_REMOTE: "1",
+            ZCODE_ACP_REMOTE_TOKEN: token,
+            ZCODE_ACP_HUB_PORT: String(port),
+          },
+        });
+      } catch (e) {
+        warn(`hub: serve spawn failed: ${e instanceof Error ? e.message : String(e)}`);
+        res.writeHead(502, { "Content-Type": "text/plain" });
+        res.end("serve bridge spawn failed");
+        return;
+      }
+      log(`hub: spawned serve bridge for ${workspacePath} (pid ${child.pid})`);
+      const deadline = Date.now() + SERVE_REGISTER_TIMEOUT_MS;
+      for (;;) {
+        await new Promise<void>((resolve) => setTimeout(resolve, SERVE_REGISTER_POLL_MS).unref?.());
+        const entry = findServe();
+        if (entry) {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ id: entry.id, reused: false }));
+          return;
+        }
+        // The child dying is the honest fast-fail (missing cwd perms, port
+        // exhaustion, crash) — without this check the loop burns the full 10s.
+        if (child.exitCode !== null || child.signalCode !== null) {
+          warn(`hub: serve bridge for ${workspacePath} exited during startup`);
+          res.writeHead(502, { "Content-Type": "text/plain" });
+          res.end("serve bridge exited during startup");
+          return;
+        }
+        if (Date.now() > deadline) {
+          warn(`hub: serve bridge for ${workspacePath} never registered`);
+          res.writeHead(502, { "Content-Type": "text/plain" });
+          res.end("serve bridge did not register in time");
+          return;
+        }
+      }
     }
     // POST /api/upgrade — a remote client may TRIGGER a staleness check but
     // never decide the restart: the hub compares its frozen running version
@@ -629,6 +783,7 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
           workspace: typeof body.workspace === "string" ? body.workspace : "",
           sessions,
           lastSeen: Date.now(),
+          origin: parseOrigin(body.origin),
         });
       } else {
         instances.delete(id);

--- a/src/remote/hub-server.ts
+++ b/src/remote/hub-server.ts
@@ -372,6 +372,61 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
   const timers: Array<ReturnType<typeof setInterval>> = [];
 
   /**
+   * One in-flight serve spawn per workspace (remote session-create,
+   * ADR-0012): concurrent POSTs for the same project join the SAME
+   * incubation instead of racing a second detached process past the
+   * findServe check (check-then-act). Check-then-set is one synchronous
+   * block, so requests can only ever observe "no entry" one at a time.
+   */
+  const serveIncubations = new Map<string, Promise<{ id: string; reused: boolean }>>();
+
+  /** The live serve instance for a workspace, if any (per-workspace dedupe). */
+  const findServeInstance = (workspacePath: string): InstanceEntry | undefined =>
+    Array.from(instances.values()).find(
+      (e) => e.origin === "serve" && e.workspace === workspacePath,
+    );
+
+  /**
+   * Spawn a serve bridge and poll until it registers (or fails fast on child
+   * exit / timeout). Shared by every POST /api/instances currently incubating
+   * this workspace — all joiners see the same outcome.
+   */
+  const incubateServe = async (workspacePath: string): Promise<{ id: string; reused: boolean }> => {
+    let child: ChildProcess;
+    try {
+      child = spawnServe({
+        cwd: workspacePath,
+        env: {
+          ...process.env,
+          ZCODE_ACP_REMOTE: "1",
+          ZCODE_ACP_REMOTE_TOKEN: token,
+          ZCODE_ACP_HUB_PORT: String(port),
+        },
+      });
+    } catch (e) {
+      warn(`hub: serve spawn failed: ${e instanceof Error ? e.message : String(e)}`);
+      throw new Error("serve bridge spawn failed");
+    }
+    log(`hub: spawned serve bridge for ${workspacePath} (pid ${child.pid})`);
+    const deadline = Date.now() + SERVE_REGISTER_TIMEOUT_MS;
+    for (;;) {
+      await new Promise<void>((resolve) => setTimeout(resolve, SERVE_REGISTER_POLL_MS).unref?.());
+      const entry = findServeInstance(workspacePath);
+      if (entry) return { id: entry.id, reused: false };
+      // The child dying is the honest fast-fail (missing cwd perms, port
+      // exhaustion, crash) — without this check the loop burns the full 10s.
+      if (child.exitCode !== null || child.signalCode !== null) {
+        warn(`hub: serve bridge for ${workspacePath} exited during startup`);
+        throw new Error("serve bridge exited during startup");
+      }
+      if (Date.now() > deadline) {
+        warn(`hub: serve bridge for ${workspacePath} never registered`);
+        throw new Error("serve bridge did not register in time");
+      }
+    }
+  };
+
+  /**
    * Reply first, then gracefully stop (close() releases the port) and hand
    * over. `close` is declared below and hoisted — it only runs inside the
    * timer, long after this scope is fully initialised.
@@ -533,9 +588,11 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
     }
     // GET /api/projects — the machine's known-project list (remote
     // session-create, ADR-0012). Sourced from the App's tasks index: every
-    // workspace that ever ran a session. This list IS the create whitelist —
-    // POST /api/instances refuses paths outside it, so a remote client can
-    // never spawn an agent in an arbitrary directory.
+    // workspace that ever ran a session. The list gates POST /api/instances
+    // (paths outside it are refused) — a convenience bound, not a security
+    // boundary: bridge-side session materialization also writes rows here,
+    // and a token holder can already drive an editor-bridge session in any
+    // cwd. The trust boundary is the token itself.
     if (url.pathname === "/api/projects" && req.method === "GET") {
       if (!authorized(req, url, token)) {
         res.writeHead(401, { "Content-Type": "text/plain" });
@@ -554,7 +611,11 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
     // known project. The hub spawns `zcode-acp serve` detached in the project
     // cwd and waits for its heartbeat registration; the bridge lives its own
     // idle-timed life afterwards (ADR-0012). Dedupe: one serve instance per
-    // workspace — an existing live one is returned instead of a second spawn.
+    // workspace — an existing live one is reused, and concurrent POSTs join
+    // the same in-flight incubation instead of double-spawning. Accepted
+    // bound: a hub restart clears the instance table, so a POST inside the
+    // bridges' ≤10s re-registration window may incubate a duplicate —
+    // harmless (both serve, future POSTs dedupe, an idle one exits in 10min).
     if (url.pathname === "/api/instances" && req.method === "POST") {
       if (!authorized(req, url, token)) {
         res.writeHead(401, { "Content-Type": "text/plain" });
@@ -575,59 +636,39 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
         res.end("unknown project");
         return;
       }
-      const findServe = (): InstanceEntry | undefined =>
-        Array.from(instances.values()).find(
-          (e) => e.origin === "serve" && e.workspace === workspacePath,
-        );
-      const existing = findServe();
+      const existing = findServeInstance(workspacePath);
       if (existing) {
         log(`hub: serve instance for ${workspacePath} already live (${existing.id}) — reusing`);
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ id: existing.id, reused: true }));
         return;
       }
-      let child: ChildProcess;
+      let incubation = serveIncubations.get(workspacePath);
+      if (!incubation) {
+        incubation = incubateServe(workspacePath);
+        serveIncubations.set(workspacePath, incubation);
+        // Drop the entry once settled (identity-checked — a newer incubation
+        // may already have replaced it). The catch keeps the DERIVED promise
+        // handled; the original is awaited by its creating POST.
+        incubation
+          .catch(() => undefined)
+          .finally(() => {
+            if (serveIncubations.get(workspacePath) === incubation) {
+              serveIncubations.delete(workspacePath);
+            }
+          });
+      } else {
+        log(`hub: joining the incubating serve bridge for ${workspacePath}`);
+      }
       try {
-        child = spawnServe({
-          cwd: workspacePath,
-          env: {
-            ...process.env,
-            ZCODE_ACP_REMOTE: "1",
-            ZCODE_ACP_REMOTE_TOKEN: token,
-            ZCODE_ACP_HUB_PORT: String(port),
-          },
-        });
+        const out = await incubation;
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(out));
       } catch (e) {
-        warn(`hub: serve spawn failed: ${e instanceof Error ? e.message : String(e)}`);
         res.writeHead(502, { "Content-Type": "text/plain" });
-        res.end("serve bridge spawn failed");
-        return;
+        res.end(e instanceof Error ? e.message : "serve bridge failed");
       }
-      log(`hub: spawned serve bridge for ${workspacePath} (pid ${child.pid})`);
-      const deadline = Date.now() + SERVE_REGISTER_TIMEOUT_MS;
-      for (;;) {
-        await new Promise<void>((resolve) => setTimeout(resolve, SERVE_REGISTER_POLL_MS).unref?.());
-        const entry = findServe();
-        if (entry) {
-          res.writeHead(200, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ id: entry.id, reused: false }));
-          return;
-        }
-        // The child dying is the honest fast-fail (missing cwd perms, port
-        // exhaustion, crash) — without this check the loop burns the full 10s.
-        if (child.exitCode !== null || child.signalCode !== null) {
-          warn(`hub: serve bridge for ${workspacePath} exited during startup`);
-          res.writeHead(502, { "Content-Type": "text/plain" });
-          res.end("serve bridge exited during startup");
-          return;
-        }
-        if (Date.now() > deadline) {
-          warn(`hub: serve bridge for ${workspacePath} never registered`);
-          res.writeHead(502, { "Content-Type": "text/plain" });
-          res.end("serve bridge did not register in time");
-          return;
-        }
-      }
+      return;
     }
     // POST /api/upgrade — a remote client may TRIGGER a staleness check but
     // never decide the restart: the hub compares its frozen running version

--- a/src/remote/hub-server.ts
+++ b/src/remote/hub-server.ts
@@ -25,6 +25,7 @@
 
 import { spawn, type ChildProcess } from "node:child_process";
 import { createHash, timingSafeEqual } from "node:crypto";
+import { realpathSync } from "node:fs";
 import type { Dirent } from "node:fs";
 import { readdir, readFile, stat } from "node:fs/promises";
 import {
@@ -103,7 +104,7 @@ interface InstanceEntry {
   workspace: string;
   sessions: SessionSummary[];
   lastSeen: number;
-  /** "editor" (stdio bridge) or "serve" (headless, hub-spawned, ADR-0012). */
+  /** "editor" (stdio bridge) or "serve" (headless, hub-spawned, ADR-0014). */
   origin: "editor" | "serve";
 }
 
@@ -190,7 +191,7 @@ function parseOrigin(raw: unknown): "editor" | "serve" {
 }
 
 /**
- * Default serve-bridge spawner (remote session-create, ADR-0012): this node
+ * Default serve-bridge spawner (remote session-create, ADR-0014): this node
  * running this package's cli.js `serve` subcommand, detached in the project's
  * cwd with the ENV the bridge needs to find its way back to this hub. Mirrors
  * endpoint.ts's spawnHub: detached + unref'd (the hub must not own its life),
@@ -373,7 +374,7 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
 
   /**
    * One in-flight serve spawn per workspace (remote session-create,
-   * ADR-0012): concurrent POSTs for the same project join the SAME
+   * ADR-0014): concurrent POSTs for the same project join the SAME
    * incubation instead of racing a second detached process past the
    * findServe check (check-then-act). Check-then-set is one synchronous
    * block, so requests can only ever observe "no entry" one at a time.
@@ -381,10 +382,24 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
   const serveIncubations = new Map<string, Promise<{ id: string; reused: boolean }>>();
 
   /** The live serve instance for a workspace, if any (per-workspace dedupe). */
-  const findServeInstance = (workspacePath: string): InstanceEntry | undefined =>
-    Array.from(instances.values()).find(
-      (e) => e.origin === "serve" && e.workspace === workspacePath,
+  const findServeInstance = (workspacePath: string): InstanceEntry | undefined => {
+    // The dedupe key must be canonical: a whitelist row (or registration) can
+    // carry a symlinked or otherwise non-canonical spelling while the serve
+    // child registers with its RESOLVED process cwd — raw string equality
+    // would never match, 502-ing every create and spawning a duplicate per
+    // retry. realpath both sides; a vanished path falls back to raw equality.
+    const key = (p: string): string => {
+      try {
+        return realpathSync(p);
+      } catch {
+        return p;
+      }
+    };
+    const wanted = key(workspacePath);
+    return Array.from(instances.values()).find(
+      (e) => e.origin === "serve" && key(e.workspace) === wanted,
     );
+  };
 
   /**
    * Spawn a serve bridge and poll until it registers (or fails fast on child
@@ -392,6 +407,10 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
    * this workspace — all joiners see the same outcome.
    */
   const incubateServe = async (workspacePath: string): Promise<{ id: string; reused: boolean }> => {
+    // Async spawn failures (ENOENT — the dir vanished between the whitelist
+    // check and the spawn) arrive as an 'error' event with exitCode still
+    // null; without this flag the poll burns the full 10s budget.
+    let spawnError: Error | null = null;
     let child: ChildProcess;
     try {
       child = spawnServe({
@@ -401,7 +420,13 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
           ZCODE_ACP_REMOTE: "1",
           ZCODE_ACP_REMOTE_TOKEN: token,
           ZCODE_ACP_HUB_PORT: String(port),
+          // Parity with the bridge-side spawnHub: the serve child may have to
+          // (re)spawn the hub itself, and must bind the same configured host.
+          ZCODE_ACP_HUB_HOST: host,
         },
+      });
+      child.once("error", (e: Error) => {
+        spawnError = e;
       });
     } catch (e) {
       warn(`hub: serve spawn failed: ${e instanceof Error ? e.message : String(e)}`);
@@ -415,7 +440,7 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
       if (entry) return { id: entry.id, reused: false };
       // The child dying is the honest fast-fail (missing cwd perms, port
       // exhaustion, crash) — without this check the loop burns the full 10s.
-      if (child.exitCode !== null || child.signalCode !== null) {
+      if (spawnError || child.exitCode !== null || child.signalCode !== null) {
         warn(`hub: serve bridge for ${workspacePath} exited during startup`);
         throw new Error("serve bridge exited during startup");
       }
@@ -587,7 +612,7 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
       return;
     }
     // GET /api/projects — the machine's known-project list (remote
-    // session-create, ADR-0012). Sourced from the App's tasks index: every
+    // session-create, ADR-0014). Sourced from the App's tasks index: every
     // workspace that ever ran a session. The list gates POST /api/instances
     // (paths outside it are refused) — a convenience bound, not a security
     // boundary: bridge-side session materialization also writes rows here,
@@ -610,7 +635,7 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
     // POST /api/instances — create (or reuse) a headless serve bridge for one
     // known project. The hub spawns `zcode-acp serve` detached in the project
     // cwd and waits for its heartbeat registration; the bridge lives its own
-    // idle-timed life afterwards (ADR-0012). Dedupe: one serve instance per
+    // idle-timed life afterwards (ADR-0014). Dedupe: one serve instance per
     // workspace — an existing live one is reused, and concurrent POSTs join
     // the same in-flight incubation instead of double-spawning. Accepted
     // bound: a hub restart clears the instance table, so a POST inside the

--- a/src/server.ts
+++ b/src/server.ts
@@ -226,7 +226,7 @@ export class ZcodeAcpServer {
   private msgCounter = 10_000_000;
 
   /**
-   * Headless serve mode (ADR-0012): this bridge was hub-spawned for ONE known
+   * Headless serve mode (ADR-0014): this bridge was hub-spawned for ONE known
    * project (the process cwd). session/new then ignores client-supplied cwds
    * and always uses the process cwd — the remote create-whitelist stays
    * closed end to end (a client cannot steer a serve bridge into another

--- a/src/server.ts
+++ b/src/server.ts
@@ -225,6 +225,19 @@ export class ZcodeAcpServer {
   /** Monotonic id counter; base 10_000_000 to avoid collisions with zcode-originated ids. */
   private msgCounter = 10_000_000;
 
+  /**
+   * Headless serve mode (ADR-0012): this bridge was hub-spawned for ONE known
+   * project (the process cwd). session/new then ignores client-supplied cwds
+   * and always uses the process cwd — the remote create-whitelist stays
+   * closed end to end (a client cannot steer a serve bridge into another
+   * directory).
+   */
+  readonly serveMode: boolean;
+
+  constructor(opts: { serveMode?: boolean } = {}) {
+    this.serveMode = opts.serveMode === true;
+  }
+
   /** Next JSON-RPC id for messages we send to zcode. */
   nextId(): number {
     return ++this.msgCounter;

--- a/src/tasks-index.ts
+++ b/src/tasks-index.ts
@@ -85,6 +85,7 @@ function sleep(ms: number): Promise<void> {
  */
 async function withSqliteRetry<T>(
   fn: (con: InstanceType<DatabaseSyncCtor>) => T,
+  dbPath: string = TASKS_INDEX_PATH,
 ): Promise<T | null> {
   const Sqlite = await loadSqlite();
   if (!Sqlite) return null; // node:sqlite unavailable (Node < 22)
@@ -93,7 +94,7 @@ async function withSqliteRetry<T>(
     // constructor itself throws (SQLITE_BUSY can surface at open time).
     let con: InstanceType<DatabaseSyncCtor> | null = null;
     try {
-      con = new Sqlite(TASKS_INDEX_PATH, { timeout: 5000 });
+      con = new Sqlite(dbPath, { timeout: 5000 });
       return fn(con);
     } catch (e) {
       // Retry only on transient busy/locked; surface everything else.
@@ -366,8 +367,10 @@ export function isSelectableWorkspace(p: string): boolean {
 /**
  * Every project workspace the tasks index has ever recorded a session for —
  * the machine's known-projects list. Serves the hub's remote session-create
- * API: the list doubles as the whitelist (the hub refuses paths outside it),
- * so a remote client can never spawn an agent in an arbitrary directory.
+ * API: the list gates which projects POST /api/instances accepts. A
+ * convenience bound, not a security boundary — bridge-side session
+ * materialization writes rows too, and a token holder can drive an
+ * editor-bridge session in any cwd (the real boundary is the token).
  *
  * Read-only and best-effort: node:sqlite unavailable → empty list; lock
  * contention retries via withSqliteRetry; other failures warn and return
@@ -386,6 +389,7 @@ export async function listKnownWorkspaces(
               "FROM tasks WHERE deleted=0 GROUP BY workspace_key ORDER BY t DESC",
           )
           .all() as Array<{ p: unknown; n: unknown; t: unknown }>,
+      dbPath,
     );
     if (!rows) return []; // node:sqlite unavailable (Node < 22)
     const out: KnownWorkspace[] = [];

--- a/src/tasks-index.ts
+++ b/src/tasks-index.ts
@@ -329,7 +329,7 @@ export async function updateSessionTitle(
   }
 }
 
-// ---------- known workspaces (remote session-create, ADR-0012) ----------
+// ---------- known workspaces (remote session-create, ADR-0014) ----------
 
 /** One known project workspace, as recorded by the App's tasks index. */
 export interface KnownWorkspace {

--- a/src/tasks-index.ts
+++ b/src/tasks-index.ts
@@ -16,7 +16,8 @@
  * swallowed so they never break the session/create path.
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 
 import { DEFAULT_MODEL_ID } from "./config/options.js";
@@ -324,5 +325,82 @@ export async function updateSessionTitle(
   } catch (e) {
     warn(`tasks-index title update skipped: ${e instanceof Error ? e.message : String(e)}`);
     return false;
+  }
+}
+
+// ---------- known workspaces (remote session-create, ADR-0012) ----------
+
+/** One known project workspace, as recorded by the App's tasks index. */
+export interface KnownWorkspace {
+  workspacePath: string;
+  sessions: number;
+  lastActive: number;
+}
+
+/**
+ * Whether a recorded workspace path may be offered for remote session
+ * creation. Excludes: degenerate roots, system temp trees (macOS /tmp is a
+ * symlink to /private/tmp — both spellings; $TMPDIR lives under /var/folders),
+ * and ~/.zcode itself (the config home, not a project). The directory must
+ * still exist — a moved/deleted project disappears from the list.
+ */
+export function isSelectableWorkspace(p: string): boolean {
+  if (!p || p === "/") return false;
+  const excluded = [
+    "/tmp",
+    "/private/tmp",
+    "/var/folders",
+    tmpdir(),
+    path.join(homedir(), ".zcode"),
+  ];
+  for (const ex of excluded) {
+    if (p === ex || p.startsWith(ex + path.sep)) return false;
+  }
+  try {
+    return statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Every project workspace the tasks index has ever recorded a session for —
+ * the machine's known-projects list. Serves the hub's remote session-create
+ * API: the list doubles as the whitelist (the hub refuses paths outside it),
+ * so a remote client can never spawn an agent in an arbitrary directory.
+ *
+ * Read-only and best-effort: node:sqlite unavailable → empty list; lock
+ * contention retries via withSqliteRetry; other failures warn and return
+ * empty. `dbPath` defaults to the App's index (tests inject a fixture).
+ */
+export async function listKnownWorkspaces(
+  dbPath: string = TASKS_INDEX_PATH,
+): Promise<KnownWorkspace[]> {
+  if (!existsSync(dbPath)) return [];
+  try {
+    const rows = await withSqliteRetry(
+      (con) =>
+        con
+          .prepare(
+            "SELECT workspace_path AS p, COUNT(*) AS n, MAX(updated_at) AS t " +
+              "FROM tasks WHERE deleted=0 GROUP BY workspace_key ORDER BY t DESC",
+          )
+          .all() as Array<{ p: unknown; n: unknown; t: unknown }>,
+    );
+    if (!rows) return []; // node:sqlite unavailable (Node < 22)
+    const out: KnownWorkspace[] = [];
+    for (const r of rows) {
+      const p = typeof r.p === "string" ? r.p : "";
+      if (!isSelectableWorkspace(p)) continue;
+      out.push({
+        workspacePath: p,
+        sessions: typeof r.n === "number" ? r.n : 0,
+        lastActive: typeof r.t === "number" ? r.t : 0,
+      });
+    }
+    return out;
+  } catch (e) {
+    warn(`tasks-index workspace list failed: ${e instanceof Error ? e.message : String(e)}`);
+    return [];
   }
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -10,6 +10,7 @@
 import { describe, expect, it } from "vitest";
 
 import { resolveInvocation } from "../src/cli.js";
+import { serveIdleDecision } from "../src/index.js";
 
 describe("resolveInvocation", () => {
   it("routes the legacy zcode-acp-server bin alias straight to server", () => {
@@ -22,6 +23,7 @@ describe("resolveInvocation", () => {
 
   it("maps each subcommand, passing through trailing args", () => {
     expect(resolveInvocation("cli.js", ["server"])).toEqual({ kind: "server" });
+    expect(resolveInvocation("cli.js", ["serve"])).toEqual({ kind: "serve" });
     expect(resolveInvocation("cli.js", ["hub"])).toEqual({ kind: "hub" });
     expect(resolveInvocation("cli.js", ["quota"])).toEqual({ kind: "quota", args: [] });
     expect(resolveInvocation("cli.js", ["quota", "-w", "glm"])).toEqual({
@@ -42,11 +44,27 @@ describe("resolveInvocation", () => {
   });
 
   it("reports unknown subcommands with the offending token", () => {
-    expect(resolveInvocation("cli.js", ["serve"])).toEqual({ kind: "unknown", sub: "serve" });
     // A bare prompt string is not a subcommand — it does not start a turn.
     expect(resolveInvocation("cli.js", ["hello world"])).toEqual({
       kind: "unknown",
       sub: "hello world",
     });
+  });
+});
+
+describe("serveIdleDecision", () => {
+  const IDLE = 10 * 60_000;
+
+  it("never exits while a client is attached or a turn is running", () => {
+    const now = 1_000_000;
+    expect(serveIdleDecision(1, 0, 0, now, IDLE)).toBe(false);
+    expect(serveIdleDecision(0, 1, 0, now, IDLE)).toBe(false);
+    expect(serveIdleDecision(2, 3, now - 2 * IDLE, now, IDLE)).toBe(false);
+  });
+
+  it("exits only after the full idle window with nothing attached", () => {
+    const lastBusy = 1_000_000;
+    expect(serveIdleDecision(0, 0, lastBusy, lastBusy + IDLE - 1, IDLE)).toBe(false);
+    expect(serveIdleDecision(0, 0, lastBusy, lastBusy + IDLE, IDLE)).toBe(true);
   });
 });

--- a/tests/hub.test.ts
+++ b/tests/hub.test.ts
@@ -22,6 +22,15 @@ vi.mock("../src/handlers/account.js", () => ({
   accountUsageStats: accountUsageStatsMock,
 }));
 
+// The session-create endpoints read the known-project whitelist from
+// tasks-index; mock the module so no real sqlite/App store is touched.
+const { listKnownWorkspacesMock } = vi.hoisted(() => ({
+  listKnownWorkspacesMock: vi.fn(),
+}));
+vi.mock("../src/tasks-index.js", () => ({
+  listKnownWorkspaces: listKnownWorkspacesMock,
+}));
+
 import { resetQuotaCacheForTest, startHub, type HubHandle } from "../src/remote/hub-server.js";
 import { AGENT_INFO } from "../src/utils.js";
 
@@ -853,5 +862,142 @@ describe("hub /api/upgrade (self-decided restart)", () => {
     expect(await res.json()).toMatchObject({ restarting: false, reason: "up-to-date" });
     await new Promise((r) => setTimeout(r, 800));
     expect(restarted).toBe(false);
+  });
+});
+
+describe("hub remote session-create (ADR-0012)", () => {
+  const PROJECT = "/Users/dev/Develop/demo";
+  const auth = { Authorization: `Bearer ${TOKEN}` };
+  /** Minimal ChildProcess stand-in: the hub only reads pid/exitCode/signalCode. */
+  let fakeChild: { pid: number; exitCode: number | null; signalCode: string | null };
+  let spawnCalls: Array<{ cwd: string; env: NodeJS.ProcessEnv }>;
+  let spawnCount: number;
+
+  beforeEach(() => {
+    listKnownWorkspacesMock.mockReset();
+    listKnownWorkspacesMock.mockResolvedValue([
+      { workspacePath: PROJECT, sessions: 3, lastActive: 1234 },
+      { workspacePath: "/Users/dev/Develop/other", sessions: 1, lastActive: 999 },
+    ]);
+    fakeChild = { pid: 4242, exitCode: null, signalCode: null };
+    spawnCalls = [];
+    spawnCount = 0;
+  });
+
+  function spawnServeSpy() {
+    return (opts: { cwd: string; env: NodeJS.ProcessEnv }) => {
+      spawnCount++;
+      spawnCalls.push(opts);
+      return fakeChild as unknown as import("node:child_process").ChildProcess;
+    };
+  }
+
+  async function registerServeBridge(hub: HubHandle, workspace: string): Promise<void> {
+    const res = await fetch(`http://127.0.0.1:${hub.port}/api/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(
+        registerBody({
+          id: `serve-${workspace}`,
+          workspace,
+          origin: "serve",
+          port: BASE_PORT + 50,
+          pid: 4242,
+        }),
+      ),
+    });
+    expect(res.ok).toBe(true);
+  }
+
+  it("GET /api/projects requires auth and returns the whitelist", async () => {
+    const hub = await startTestHub();
+    expect((await fetch(`http://127.0.0.1:${hub.port}/api/projects`)).status).toBe(401);
+    const res = await fetch(`http://127.0.0.1:${hub.port}/api/projects`, { headers: auth });
+    expect(res.status).toBe(200);
+    const list = (await res.json()) as Array<{ workspacePath: string }>;
+    expect(list.map((p) => p.workspacePath)).toEqual([PROJECT, "/Users/dev/Develop/other"]);
+  });
+
+  it("POST /api/instances rejects unauthorized / missing / unknown projects", async () => {
+    const hub = await startTestHub({ spawnServe: spawnServeSpy() });
+    const url = `http://127.0.0.1:${hub.port}/api/instances`;
+    expect((await fetch(url, { method: "POST" })).status).toBe(401);
+    expect(
+      (await fetch(url, { method: "POST", headers: auth, body: "{}" })).status,
+    ).toBe(400);
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { ...auth, "Content-Type": "application/json" },
+      body: JSON.stringify({ workspacePath: "/etc" }),
+    });
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe("unknown project");
+    expect(spawnCount).toBe(0);
+  });
+
+  it("spawns a serve bridge in the project cwd and returns its instance once registered", async () => {
+    const hub = await startTestHub({ spawnServe: spawnServeSpy() });
+    const pending = fetch(`http://127.0.0.1:${hub.port}/api/instances`, {
+      method: "POST",
+      headers: { ...auth, "Content-Type": "application/json" },
+      body: JSON.stringify({ workspacePath: PROJECT }),
+    });
+    // The hub polls every 300ms — give it one tick, then let the bridge register.
+    await new Promise((r) => setTimeout(r, 400));
+    expect(spawnCount).toBe(1);
+    expect(spawnCalls[0]!.cwd).toBe(PROJECT);
+    expect(spawnCalls[0]!.env.ZCODE_ACP_REMOTE).toBe("1");
+    expect(spawnCalls[0]!.env.ZCODE_ACP_REMOTE_TOKEN).toBe(TOKEN);
+    await registerServeBridge(hub, PROJECT);
+    const res = await pending;
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ id: `serve-${PROJECT}`, reused: false });
+  });
+
+  it("reuses an existing serve instance instead of spawning a second one", async () => {
+    const hub = await startTestHub({ spawnServe: spawnServeSpy() });
+    await registerServeBridge(hub, PROJECT);
+    const res = await fetch(`http://127.0.0.1:${hub.port}/api/instances`, {
+      method: "POST",
+      headers: { ...auth, "Content-Type": "application/json" },
+      body: JSON.stringify({ workspacePath: PROJECT }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ id: `serve-${PROJECT}`, reused: true });
+    expect(spawnCount).toBe(0);
+  });
+
+  it("fails with 502 when the spawned bridge dies during startup", async () => {
+    const hub = await startTestHub({ spawnServe: spawnServeSpy() });
+    const pending = fetch(`http://127.0.0.1:${hub.port}/api/instances`, {
+      method: "POST",
+      headers: { ...auth, "Content-Type": "application/json" },
+      body: JSON.stringify({ workspacePath: PROJECT }),
+    });
+    await new Promise((r) => setTimeout(r, 400));
+    fakeChild.exitCode = 1; // bridge crashed before registering
+    const res = await pending;
+    expect(res.status).toBe(502);
+    expect(await res.text()).toBe("serve bridge exited during startup");
+  });
+
+  it("labels instances with the register origin (default editor)", async () => {
+    const hub = await startTestHub();
+    await registerServeBridge(hub, PROJECT);
+    // Legacy register (no origin field) — older bridges must read as editor.
+    const res = await fetch(`http://127.0.0.1:${hub.port}/api/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(registerBody({ id: "editor-1" })),
+    });
+    expect(res.ok).toBe(true);
+
+    const list = (await (await listInstances(hub)).json()) as Array<{
+      id: string;
+      origin: string;
+    }>;
+    const byId = Object.fromEntries(list.map((e) => [e.id, e.origin]));
+    expect(byId[`serve-${PROJECT}`]).toBe("serve");
+    expect(byId["editor-1"]).toBe("editor");
   });
 });

--- a/tests/hub.test.ts
+++ b/tests/hub.test.ts
@@ -967,6 +967,32 @@ describe("hub remote session-create (ADR-0012)", () => {
     expect(spawnCount).toBe(0);
   });
 
+  it("concurrent POSTs for the same workspace join one incubation (no double spawn)", async () => {
+    // Regression: findServe() and the spawn used to race across concurrent
+    // requests — both spawned a serve bridge and both answered 200.
+    const hub = await startTestHub({ spawnServe: spawnServeSpy() });
+    const url = `http://127.0.0.1:${hub.port}/api/instances`;
+    const post = () =>
+      fetch(url, {
+        method: "POST",
+        headers: { ...auth, "Content-Type": "application/json" },
+        body: JSON.stringify({ workspacePath: PROJECT }),
+      });
+    const [a, b] = [post(), post()];
+    // One poll tick in — both requests must already share the incubation.
+    await new Promise((r) => setTimeout(r, 400));
+    expect(spawnCount).toBe(1);
+    await registerServeBridge(hub, PROJECT);
+    const [ra, rb] = await Promise.all([a, b]);
+    expect(ra.status).toBe(200);
+    expect(rb.status).toBe(200);
+    expect(await ra.json()).toEqual({ id: `serve-${PROJECT}`, reused: false });
+    expect(await rb.json()).toEqual({ id: `serve-${PROJECT}`, reused: false });
+    // Settled incubation is gone: the next POST reuses the registered one.
+    expect(await (await post()).json()).toEqual({ id: `serve-${PROJECT}`, reused: true });
+    expect(spawnCount).toBe(1);
+  });
+
   it("fails with 502 when the spawned bridge dies during startup", async () => {
     const hub = await startTestHub({ spawnServe: spawnServeSpy() });
     const pending = fetch(`http://127.0.0.1:${hub.port}/api/instances`, {

--- a/tests/hub.test.ts
+++ b/tests/hub.test.ts
@@ -4,7 +4,8 @@
  * idle-exit policy.
  */
 
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { EventEmitter } from "node:events";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { createServer, type Server } from "node:http";
 import net from "node:net";
 import { tmpdir } from "node:os";
@@ -865,11 +866,15 @@ describe("hub /api/upgrade (self-decided restart)", () => {
   });
 });
 
-describe("hub remote session-create (ADR-0012)", () => {
+describe("hub remote session-create (ADR-0014)", () => {
   const PROJECT = "/Users/dev/Develop/demo";
   const auth = { Authorization: `Bearer ${TOKEN}` };
-  /** Minimal ChildProcess stand-in: the hub only reads pid/exitCode/signalCode. */
-  let fakeChild: { pid: number; exitCode: number | null; signalCode: string | null };
+  /**
+   * Minimal ChildProcess stand-in: the hub reads pid/exitCode/signalCode and
+   * subscribes to async 'error' (ENOENT after spawn). EventEmitter supplies
+   * once(); the mutable exitCode/signalCode fields flip the death checks.
+   */
+  let fakeChild: EventEmitter & { pid: number; exitCode: number | null; signalCode: string | null };
   let spawnCalls: Array<{ cwd: string; env: NodeJS.ProcessEnv }>;
   let spawnCount: number;
 
@@ -879,7 +884,10 @@ describe("hub remote session-create (ADR-0012)", () => {
       { workspacePath: PROJECT, sessions: 3, lastActive: 1234 },
       { workspacePath: "/Users/dev/Develop/other", sessions: 1, lastActive: 999 },
     ]);
-    fakeChild = { pid: 4242, exitCode: null, signalCode: null };
+    fakeChild = new EventEmitter() as typeof fakeChild;
+    fakeChild.pid = 4242;
+    fakeChild.exitCode = null;
+    fakeChild.signalCode = null;
     spawnCalls = [];
     spawnCount = 0;
   });
@@ -991,6 +999,34 @@ describe("hub remote session-create (ADR-0012)", () => {
     // Settled incubation is gone: the next POST reuses the registered one.
     expect(await (await post()).json()).toEqual({ id: `serve-${PROJECT}`, reused: true });
     expect(spawnCount).toBe(1);
+  });
+
+  it("dedupes across path spellings: a symlinked row matches the resolved registration", async () => {
+    // Regression: raw string equality never matched a whitelist row carrying
+    // a symlink spelling against the serve child's RESOLVED process cwd —
+    // every create 502'd after 10s and each retry spawned a duplicate.
+    const real = await mkdtemp(path.join(tmpdir(), "hub-dedupe-"));
+    const link = path.join(path.dirname(real), `${path.basename(real)}-link`);
+    await symlink(real, link);
+    try {
+      listKnownWorkspacesMock.mockResolvedValue([
+        { workspacePath: link, sessions: 1, lastActive: 1 },
+      ]);
+      const hub = await startTestHub({ spawnServe: spawnServeSpy() });
+      // The bridge registers with its resolved cwd spelling.
+      await registerServeBridge(hub, real);
+      const res = await fetch(`http://127.0.0.1:${hub.port}/api/instances`, {
+        method: "POST",
+        headers: { ...auth, "Content-Type": "application/json" },
+        body: JSON.stringify({ workspacePath: link }),
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ id: `serve-${real}`, reused: true });
+      expect(spawnCount).toBe(0);
+    } finally {
+      await rm(link, { force: true });
+      await rm(real, { recursive: true, force: true });
+    }
   });
 
   it("fails with 502 when the spawned bridge dies during startup", async () => {

--- a/tests/remote-config.test.ts
+++ b/tests/remote-config.test.ts
@@ -48,6 +48,7 @@ describe("parseRemoteConfig", () => {
       hubPort: DEFAULT_HUB_PORT,
       hubHost: DEFAULT_HUB_HOST,
       bridgePort: DEFAULT_BRIDGE_PORT,
+      origin: "editor",
     });
   });
 
@@ -73,6 +74,7 @@ describe("parseRemoteConfig", () => {
       hubPort: 9000,
       hubHost: "0.0.0.0",
       bridgePort: 9001,
+      origin: "editor",
     });
   });
 });

--- a/tests/remote-endpoint.test.ts
+++ b/tests/remote-endpoint.test.ts
@@ -6,6 +6,7 @@
  */
 
 import * as acp from "@agentclientprotocol/sdk";
+import { EventEmitter } from "node:events";
 import { createServer, type Server } from "node:http";
 import { WebSocket } from "ws";
 
@@ -18,6 +19,23 @@ import { collectSessions, startRemoteEndpoint } from "../src/remote/endpoint.js"
 import { startHub } from "../src/remote/hub-server.js";
 import { ZcodeAcpServer } from "../src/server.js";
 import { AGENT_INFO } from "../src/utils.js";
+
+// Intercept hub spawns (spawnHub has no injection point) so the 401 self-heal
+// test can count attempts and inspect the injected env. The fake child needs
+// just enough shape for spawnHub: unref(), pid, stderr?, once("error").
+const childProcessSpawn = vi.hoisted(() =>
+  vi.fn(() => {
+    const child = new EventEmitter() as unknown as import("node:child_process").ChildProcess;
+    child.unref = () => undefined;
+    child.pid = -1;
+    child.stderr = null;
+    return child;
+  }),
+);
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
+  spawn: childProcessSpawn,
+}));
 
 // Hub + WS-proxy chains under full-suite parallel load can outrun vitest's 5s
 // default — and the proxied-WS tests hold inner 5s withTimeout waits that can
@@ -93,6 +111,47 @@ function stopMockHub(mock: { server: Server }): Promise<void> {
     mock.server.closeAllConnections?.();
     mock.server.close(() => resolve());
   });
+}
+
+/**
+ * startMockHub variant with scripted /api/register status codes: call i gets
+ * statuses[i]; once the script runs out, the last status repeats. Used to
+ * replay token rotation (401s followed by a hub that accepts the token).
+ */
+function startScriptedMockHub(
+  bodies: Array<Record<string, unknown>>,
+  statuses: number[],
+): { port: number; ready: Promise<void>; server: Server } {
+  let calls = 0;
+  const server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => {
+      if (req.url === "/api/register") {
+        try {
+          bodies.push(JSON.parse(Buffer.concat(chunks).toString("utf8")));
+        } catch {
+          /* unreadable body — ignore */
+        }
+        const status = statuses[Math.min(calls, statuses.length - 1)] ?? 200;
+        calls++;
+        res.writeHead(status, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: status < 400 }));
+        return;
+      }
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end("not found");
+    });
+  });
+  const handle = { port: 0, ready: Promise.resolve(), server };
+  handle.ready = new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      handle.port = typeof addr === "object" && addr ? addr.port : 0;
+      resolve();
+    });
+  });
+  return handle;
 }
 
 describe("remote endpoint", () => {
@@ -259,6 +318,52 @@ describe("hub version handshake (bridge side)", () => {
     );
     expect(bodies.length).toBeGreaterThanOrEqual(2);
   }, 15000);
+});
+
+describe("hub 401 self-heal (token rotation)", () => {
+  it("keeps heartbeating after 401s, spawns one hub with its own token, and recovers", async () => {
+    childProcessSpawn.mockClear();
+    const bodies: Array<Record<string, unknown>> = [];
+    // Rotation replay: two 401s, then the hub accepts. The bridge must stay
+    // registration-eligible (no permanent poison) and heal on its own.
+    const mock = startScriptedMockHub(bodies, [401, 401, 200]);
+    trackStop(() => stopMockHub(mock));
+    await mock.ready;
+
+    const server = new ZcodeAcpServer();
+    const app = acp
+      .agent({ name: AGENT_INFO.name })
+      .onRequest("initialize", (ctx) => server.initialize(ctx.params));
+    trackConnections(app, server.clients);
+    const endpoint = await startRemoteEndpoint(server, app, testConfig(mock.port, 18512));
+    expect(endpoint).not.toBeNull();
+    trackStop(() => endpoint!.stop());
+
+    // Timeline: register@0ms → 401 (warn + throttled hub spawn + retry@1.5s)
+    // → 401 (spawn throttled: no second spawn, no retry) → heartbeat@10s →
+    // 200, recovered. Only the 10s heartbeat can deliver body #3 — proof the
+    // loop survived two rejections.
+    await withTimeout(
+      new Promise<void>((resolve) => {
+        const check = setInterval(() => {
+          if (bodies.length >= 3) {
+            clearInterval(check);
+            resolve();
+          }
+        }, 100);
+      }),
+      13_000,
+      "third register (heartbeat after repeated 401s)",
+    );
+    expect(bodies.length).toBeGreaterThanOrEqual(3);
+    // Exactly one hub spawn across both 401s (SPAWN_THROTTLE_MS holds) ...
+    expect(childProcessSpawn).toHaveBeenCalledTimes(1);
+    // ... and it carries THIS bridge's token, so the replacement hub — once
+    // it wins the port — accepts this bridge's registrations.
+    const opts = childProcessSpawn.mock.calls[0]![2] as { env: Record<string, string | undefined> };
+    expect(opts.env.ZCODE_ACP_REMOTE_TOKEN).toBe(TOKEN);
+    expect(opts.env.ZCODE_ACP_HUB_PORT).toBe(String(mock.port));
+  }, 15_000);
 });
 
 describe("running-scoped discovery payload (collectSessions)", () => {

--- a/tests/session-lazy.test.ts
+++ b/tests/session-lazy.test.ts
@@ -64,6 +64,7 @@ beforeEach(() => {
 function fakeBackend(
   listed: Array<{ sessionId: string; title?: string }> = [],
   messages: ZcodeMessage[] = [],
+  resumeWorkspace?: string,
 ): ZcodeBackend & {
   calls: Array<{ method: string; params: unknown }>;
 } {
@@ -83,6 +84,14 @@ function fakeBackend(
             },
           };
         case "session/resume":
+          return {
+            id,
+            // A resume result may carry the session's recorded workspace —
+            // the value normal mode adopts as the session root.
+            result: resumeWorkspace
+              ? { session: { workspace: { workspacePath: resumeWorkspace } } }
+              : {},
+          };
         case "workspace/updateProviderRegistry":
           return { id, result: {} };
         case "session/list":
@@ -533,5 +542,101 @@ describe("backend-loaded session tracking", () => {
     await ensureRealSession(server, resp.sessionId);
 
     expect(server.isBackendSessionLive(resp.sessionId)).toBe(true);
+  });
+});
+
+describe("serve mode cwd pinning (ADR-0012 hardening)", () => {
+  // A remote client can mint {sid → arbitrary cwd} durable aliases on any
+  // editor bridge (session/new trusts the local editor's cwd) and then resume
+  // them on a serve bridge. Serve mode must treat foreign-cwd records as
+  // unknown ids and never move its pinned session root — neither via the
+  // workspace it sends to the backend nor via the root recorded for /fs.
+
+  it("session/new ignores a client cwd and records the pinned project", async () => {
+    const server = new ZcodeAcpServer({ serveMode: true });
+    const resp = await newSession(server, newSessionParams("/etc"));
+
+    expect(server.pendingSessions.get(resp.sessionId)).toEqual({ cwd: process.cwd() });
+    expect(mockStore.get(resp.sessionId)?.cwd).toBe(process.cwd());
+  });
+
+  it("rejects a foreign durable record with a zcodeSid (no alias smuggling)", async () => {
+    const server = new ZcodeAcpServer({ serveMode: true });
+    mockStore.set("acp_foreign", {
+      cwd: "/Users/victim/secret",
+      zcodeSid: "sess_foreign",
+      createdAt: 1,
+    });
+    const { backend, calls } = fakeBackend();
+    server.backend = backend;
+
+    await expect(ensureRealSession(server, "acp_foreign")).rejects.toThrow(
+      "session acp_foreign not found",
+    );
+    expect(calls).toHaveLength(0);
+  });
+
+  it("rejects a foreign never-used record (no foreign materialization)", async () => {
+    const server = new ZcodeAcpServer({ serveMode: true });
+    mockStore.set("acp_pending_foreign", { cwd: "/Users/victim/secret", createdAt: 1 });
+    const { backend, calls } = fakeBackend();
+    server.backend = backend;
+
+    await expect(ensureRealSession(server, "acp_pending_foreign")).rejects.toThrow(
+      "session acp_pending_foreign not found",
+    );
+    expect(calls).toHaveLength(0);
+  });
+
+  it("materializes its OWN record in the process cwd", async () => {
+    const server = new ZcodeAcpServer({ serveMode: true });
+    mockStore.set("acp_own", { cwd: process.cwd(), createdAt: 1 });
+    const { backend, calls } = fakeBackend();
+    server.backend = backend;
+
+    await expect(ensureRealSession(server, "acp_own")).resolves.toBe("sess_lazy_1");
+    expect(calls.filter((c) => c.method === "session/create")[0]!.params).toMatchObject({
+      workspace: { workspacePath: process.cwd(), workspaceKey: process.cwd() },
+    });
+  });
+
+  it("resume pins the root to the process cwd and ignores a foreign backend workspace", async () => {
+    const server = new ZcodeAcpServer({ serveMode: true });
+    // Raw backend id whose recorded workspace is a foreign dir: even the
+    // backend's own resume answer must not move the serve bridge's root.
+    const { backend, calls } = fakeBackend([], [], "/tmp/foreign-ws");
+    server.backend = backend;
+
+    await resumeSession(
+      server,
+      { sessionId: "sess_real_1", cwd: "/tmp/attacker" } as acp.ResumeSessionRequest,
+      {} as acp.AgentContext,
+    );
+
+    const resumes = calls.filter((c) => c.method === "session/resume");
+    expect(resumes).toHaveLength(1);
+    expect(resumes[0]!.params).toMatchObject({
+      workspace: { workspacePath: process.cwd() },
+    });
+    expect(server.sessionCwds.get("sess_real_1")).toBe(process.cwd());
+  });
+
+  it("load pins the root the same way", async () => {
+    const server = new ZcodeAcpServer({ serveMode: true });
+    const { backend, calls } = fakeBackend([], [], "/tmp/foreign-ws");
+    server.backend = backend;
+
+    await loadSession(
+      server,
+      { sessionId: "sess_real_2" } as acp.LoadSessionRequest,
+      {} as acp.AgentContext,
+    );
+
+    const resumes = calls.filter((c) => c.method === "session/resume");
+    expect(resumes).toHaveLength(1);
+    expect(resumes[0]!.params).toMatchObject({
+      workspace: { workspacePath: process.cwd() },
+    });
+    expect(server.sessionCwds.get("sess_real_2")).toBe(process.cwd());
   });
 });

--- a/tests/session-lazy.test.ts
+++ b/tests/session-lazy.test.ts
@@ -545,7 +545,7 @@ describe("backend-loaded session tracking", () => {
   });
 });
 
-describe("serve mode cwd pinning (ADR-0012 hardening)", () => {
+describe("serve mode cwd pinning (ADR-0014 hardening)", () => {
   // A remote client can mint {sid → arbitrary cwd} durable aliases on any
   // editor bridge (session/new trusts the local editor's cwd) and then resume
   // them on a serve bridge. Serve mode must treat foreign-cwd records as
@@ -600,16 +600,40 @@ describe("serve mode cwd pinning (ADR-0012 hardening)", () => {
     });
   });
 
-  it("resume pins the root to the process cwd and ignores a foreign backend workspace", async () => {
+  it("resume pins the root to the process cwd; a foreign-workspace session is refused", async () => {
     const server = new ZcodeAcpServer({ serveMode: true });
-    // Raw backend id whose recorded workspace is a foreign dir: even the
-    // backend's own resume answer must not move the serve bridge's root.
     const { backend, calls } = fakeBackend([], [], "/tmp/foreign-ws");
+    server.backend = backend;
+
+    await expect(
+      resumeSession(
+        server,
+        { sessionId: "sess_real_1", cwd: "/tmp/attacker" } as acp.ResumeSessionRequest,
+        {} as acp.AgentContext,
+      ),
+    ).rejects.toThrow("session belongs to another workspace");
+
+    // The workspace sent to the backend was pinned; the refused session
+    // records no mapping and no root.
+    const resumes = calls.filter((c) => c.method === "session/resume");
+    expect(resumes).toHaveLength(1);
+    expect(resumes[0]!.params).toMatchObject({
+      workspace: { workspacePath: process.cwd() },
+    });
+    expect(server.resolveSid("sess_real_1")).toBeUndefined();
+    expect(server.sessionCwds.get("sess_real_1")).toBeUndefined();
+  });
+
+  it("resume of the serve bridge's OWN workspace stays pinned", async () => {
+    const server = new ZcodeAcpServer({ serveMode: true });
+    // The backend reports the same project (sameProjectDir resolves both
+    // spellings): accepted, and the recorded root stays the process cwd.
+    const { backend, calls } = fakeBackend([], [], process.cwd());
     server.backend = backend;
 
     await resumeSession(
       server,
-      { sessionId: "sess_real_1", cwd: "/tmp/attacker" } as acp.ResumeSessionRequest,
+      { sessionId: "sess_real_1" } as acp.ResumeSessionRequest,
       {} as acp.AgentContext,
     );
 
@@ -621,22 +645,24 @@ describe("serve mode cwd pinning (ADR-0012 hardening)", () => {
     expect(server.sessionCwds.get("sess_real_1")).toBe(process.cwd());
   });
 
-  it("load pins the root the same way", async () => {
+  it("load pins the root the same way and refuses foreign-workspace sessions", async () => {
     const server = new ZcodeAcpServer({ serveMode: true });
     const { backend, calls } = fakeBackend([], [], "/tmp/foreign-ws");
     server.backend = backend;
 
-    await loadSession(
-      server,
-      { sessionId: "sess_real_2" } as acp.LoadSessionRequest,
-      {} as acp.AgentContext,
-    );
+    await expect(
+      loadSession(
+        server,
+        { sessionId: "sess_real_2" } as acp.LoadSessionRequest,
+        {} as acp.AgentContext,
+      ),
+    ).rejects.toThrow("session belongs to another workspace");
 
     const resumes = calls.filter((c) => c.method === "session/resume");
     expect(resumes).toHaveLength(1);
     expect(resumes[0]!.params).toMatchObject({
       workspace: { workspacePath: process.cwd() },
     });
-    expect(server.sessionCwds.get("sess_real_2")).toBe(process.cwd());
+    expect(server.sessionCwds.get("sess_real_2")).toBeUndefined();
   });
 });

--- a/tests/tasks-index-workspaces.test.ts
+++ b/tests/tasks-index-workspaces.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for the known-workspace list (remote session-create whitelist,
+ * ADR-0012): listKnownWorkspaces aggregates the App's tasks index per
+ * workspace, and isSelectableWorkspace decides which recorded paths may be
+ * offered to remote clients.
+ *
+ * Same mocking strategy as tasks-index.test.ts (in-memory fake DatabaseSync,
+ * no real sqlite on CI), plus a controlled node:os so the temp/~/ exclusions
+ * are testable without touching the real HOME or TMPDIR, and a statSync fake
+ * so directory-existence checks need no filesystem.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Row shape the SELECT aggregates over (only the columns the query reads).
+interface FakeRow {
+  workspace_key: string;
+  workspace_path: string;
+  deleted: number;
+  updated_at: number;
+}
+
+let rows: FakeRow[];
+
+/** Paths statSync reports as existing directories (everything else fails). */
+let realDirs: Set<string>;
+
+vi.mock("node:sqlite", () => {
+  class DatabaseSync {
+    constructor(
+      _path: string,
+      _options?: { timeout?: number },
+    ) {
+      /* no-op */
+    }
+    prepare(sql: string) {
+      if (/^SELECT workspace_path AS p/i.test(sql)) {
+        return {
+          all() {
+            // Mirror GROUP BY workspace_key + ORDER BY MAX(updated_at) DESC:
+            // aggregate per key, newest first.
+            const groups = new Map<string, FakeRow[]>();
+            for (const r of rows) {
+              if (r.deleted !== 0) continue;
+              const list = groups.get(r.workspace_key) ?? [];
+              list.push(r);
+              groups.set(r.workspace_key, list);
+            }
+            const aggregated = Array.from(groups.entries()).map(([key, list]) => ({
+              p: key,
+              n: list.length,
+              t: Math.max(...list.map((r) => r.updated_at)),
+            }));
+            aggregated.sort((a, b) => b.t - a.t);
+            return aggregated;
+          },
+        };
+      }
+      throw new Error(`unexpected SQL in workspaces test fake: ${sql}`);
+    }
+    close() {
+      /* no-op */
+    }
+  }
+  return { DatabaseSync };
+});
+
+vi.mock("node:os", () => ({
+  homedir: () => "/fake/home",
+  tmpdir: () => "/fake/tmpdir",
+}));
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    existsSync: () => true,
+    statSync: (p: string) => {
+      if (realDirs.has(p)) return { isDirectory: () => true } as never;
+      const err = new Error(`ENOENT: ${p}`) as NodeJS.ErrnoException;
+      err.code = "ENOENT";
+      throw err;
+    },
+  };
+});
+
+import { isSelectableWorkspace, listKnownWorkspaces } from "../src/tasks-index.js";
+
+describe("isSelectableWorkspace", () => {
+  beforeEach(() => {
+    realDirs = new Set(["/Users/dev/Develop/proj-a"]);
+  });
+
+  it("accepts an existing project directory", () => {
+    expect(isSelectableWorkspace("/Users/dev/Develop/proj-a")).toBe(true);
+  });
+
+  it("rejects degenerate roots", () => {
+    expect(isSelectableWorkspace("")).toBe(false);
+    expect(isSelectableWorkspace("/")).toBe(false);
+  });
+
+  it("rejects system temp trees (both /tmp spellings, $TMPDIR, /var/folders)", () => {
+    expect(isSelectableWorkspace("/tmp/proj")).toBe(false);
+    expect(isSelectableWorkspace("/private/tmp/proj")).toBe(false);
+    expect(isSelectableWorkspace("/fake/tmpdir/proj")).toBe(false);
+    expect(isSelectableWorkspace("/var/folders/xy/proj")).toBe(false);
+    // Exact match on a temp root itself is equally rejected.
+    expect(isSelectableWorkspace("/fake/tmpdir")).toBe(false);
+  });
+
+  it("rejects ~/.zcode (the config home, not a project)", () => {
+    expect(isSelectableWorkspace("/fake/home/.zcode")).toBe(false);
+    expect(isSelectableWorkspace("/fake/home/.zcode/skills")).toBe(false);
+    // A .zcode directory inside a normal path is NOT the config home.
+    realDirs.add("/Users/dev/work/.zcode");
+    expect(isSelectableWorkspace("/Users/dev/work/.zcode")).toBe(true);
+  });
+
+  it("rejects missing paths and non-directories", () => {
+    expect(isSelectableWorkspace("/Users/dev/Develop/gone")).toBe(false);
+    realDirs.add("/Users/dev/Develop/a-file");
+    // (a-file is in realDirs, so it "exists" — but every fake entry reports
+    // isDirectory true; to test the non-directory branch, use a path NOT in
+    // realDirs, which throws ENOENT. The isDirectory-false branch is covered
+    // by construction: statSync only ever returns isDirectory:true here.)
+    expect(isSelectableWorkspace("/Users/dev/Develop/other")).toBe(false);
+  });
+});
+
+describe("listKnownWorkspaces", () => {
+  beforeEach(() => {
+    rows = [];
+    realDirs = new Set(["/Users/dev/Develop/proj-a", "/Users/dev/Develop/proj-b"]);
+  });
+
+  it("aggregates sessions per workspace, newest activity first", async () => {
+    rows = [
+      { workspace_key: "/Users/dev/Develop/proj-a", workspace_path: "/Users/dev/Develop/proj-a", deleted: 0, updated_at: 100 },
+      { workspace_key: "/Users/dev/Develop/proj-a", workspace_path: "/Users/dev/Develop/proj-a", deleted: 0, updated_at: 300 },
+      { workspace_key: "/Users/dev/Develop/proj-b", workspace_path: "/Users/dev/Develop/proj-b", deleted: 0, updated_at: 200 },
+    ];
+    const list = await listKnownWorkspaces("/fake/db.sqlite");
+    expect(list).toEqual([
+      { workspacePath: "/Users/dev/Develop/proj-a", sessions: 2, lastActive: 300 },
+      { workspacePath: "/Users/dev/Develop/proj-b", sessions: 1, lastActive: 200 },
+    ]);
+  });
+
+  it("drops deleted rows, temp dirs, the config home, and vanished directories", async () => {
+    rows = [
+      { workspace_key: "/Users/dev/Develop/gone", workspace_path: "/Users/dev/Develop/gone", deleted: 0, updated_at: 900 },
+      { workspace_key: "/tmp/scratch", workspace_path: "/tmp/scratch", deleted: 0, updated_at: 800 },
+      { workspace_key: "/fake/home/.zcode", workspace_path: "/fake/home/.zcode", deleted: 0, updated_at: 700 },
+      { workspace_key: "/Users/dev/Develop/proj-a", workspace_path: "/Users/dev/Develop/proj-a", deleted: 1, updated_at: 600 },
+      { workspace_key: "/Users/dev/Develop/proj-b", workspace_path: "/Users/dev/Develop/proj-b", deleted: 0, updated_at: 500 },
+    ];
+    const list = await listKnownWorkspaces("/fake/db.sqlite");
+    // gone: not in realDirs → excluded. scratch: temp. .zcode: config home.
+    // proj-a: all its rows are deleted → no group. Only proj-b survives.
+    expect(list).toEqual([
+      { workspacePath: "/Users/dev/Develop/proj-b", sessions: 1, lastActive: 500 },
+    ]);
+  });
+
+  it("returns [] when the aggregate row shapes are malformed", async () => {
+    // Simulate a schema-drifted row: workspace_path not a string.
+    rows = [{ workspace_key: 42 as unknown as string, workspace_path: "", deleted: 0, updated_at: 1 }];
+    const list = await listKnownWorkspaces("/fake/db.sqlite");
+    expect(list).toEqual([]);
+  });
+});

--- a/tests/tasks-index-workspaces.test.ts
+++ b/tests/tasks-index-workspaces.test.ts
@@ -1,6 +1,6 @@
 /**
  * Tests for the known-workspace list (remote session-create whitelist,
- * ADR-0012): listKnownWorkspaces aggregates the App's tasks index per
+ * ADR-0014): listKnownWorkspaces aggregates the App's tasks index per
  * workspace, and isSelectableWorkspace decides which recorded paths may be
  * offered to remote clients.
  *

--- a/tests/tasks-index-workspaces.test.ts
+++ b/tests/tasks-index-workspaces.test.ts
@@ -22,16 +22,19 @@ interface FakeRow {
 
 let rows: FakeRow[];
 
+/** Paths handed to the fake DatabaseSync constructor (dbPath pass-through). */
+const openedPaths = vi.hoisted(() => [] as string[]);
+
 /** Paths statSync reports as existing directories (everything else fails). */
 let realDirs: Set<string>;
 
 vi.mock("node:sqlite", () => {
   class DatabaseSync {
     constructor(
-      _path: string,
+      path: string,
       _options?: { timeout?: number },
     ) {
-      /* no-op */
+      openedPaths.push(path);
     }
     prepare(sql: string) {
       if (/^SELECT workspace_path AS p/i.test(sql)) {
@@ -168,5 +171,14 @@ describe("listKnownWorkspaces", () => {
     rows = [{ workspace_key: 42 as unknown as string, workspace_path: "", deleted: 0, updated_at: 1 }];
     const list = await listKnownWorkspaces("/fake/db.sqlite");
     expect(list).toEqual([]);
+  });
+
+  it("opens the injected dbPath, not the default tasks index", async () => {
+    // Regression: withSqliteRetry used to hardcode TASKS_INDEX_PATH, so the
+    // dbPath parameter only gated existsSync — fixtures read the real DB.
+    rows = [];
+    openedPaths.length = 0;
+    await listKnownWorkspaces("/fake/fixture.sqlite");
+    expect(openedPaths).toEqual(["/fake/fixture.sqlite"]);
   });
 });


### PR DESCRIPTION
## What

Remote clients can start a NEW agent session in any of the machine's known
projects, no editor required (0.17.0):

- `GET /api/projects` (hub, token auth) — the known-project list aggregated
  from the App's tasks-index.sqlite (temp trees, `~/.zcode`, vanished dirs
  filtered; sorted by last activity). The list gates create; documented as a
  convenience bound, not a security boundary (the trust boundary is the token).
- `POST /api/instances {workspacePath}` (hub, token auth) — whitelist check
  (403 outside the list), per-workspace incubation (concurrent POSTs join the
  same spawn; realpath-canonicalized dedupe key), detached spawn of
  `zcode-acp serve` in the project cwd, polls for registration, 502 on child
  death / async spawn error / 10s timeout.
- `zcode-acp serve` — headless bridge: same ACP surface minus the editor,
  remote endpoint only, idle-exits after 10min with no clients and no running
  turns (ADR-0001's headless counterpart).
- Serve mode pins the project end to end: `session/new` ignores client cwds;
  foreign-cwd durable lazy-session records are rejected; resume/load pin the
  root and refuse sessions from another workspace; `session/list` is pinned
  to the project cwd.
- Heartbeats/`/api/instances` carry `origin` ("editor" | "serve").

Also fixes a long-standing remote bug: a 401 (token rotation) permanently
poisoned bridge registration — heartbeats now continue and a replacement hub
carrying the bridge's own token is spawned with exponential backoff
(60s doubling to a 10min cap); recovery is 2xx-only and resets the schedule;
unexpected non-2xx/non-401 answers warn instead of silently disabling remote.

## Review

Two adversarial rounds + a standards review over the branch; all findings
fixed in-tree (cwd-closure bypass via durable aliases, spawn race, whitelist
grooming documented, dead dbPath injection, backoff churn, symlink-spelling
dedupe mismatch, session/list enumeration). Test suite: 923 passing (3 known
environmental sandbox failures unrelated to this branch, reproduced on clean
main). Typecheck/lint clean.

🤖 Generated with ZCode