### PR TITLE
fix: upgrade npm in release publish job for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
       - uses: pnpm/action-setup@v4
         with:
           version: 10
+      # npm >= 11.5 is required for OIDC trusted publishing; Node 24 bundles 11.3.
+      - run: npm install -g npm@latest
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: pnpm test


### PR DESCRIPTION
The publish job failed with 404 on PUT: Node 24 bundles npm 11.3, but OIDC trusted publishing requires npm >= 11.5. Upgrade npm before publishing so the tag/release created for 0.17.0 is followed by an automated patch release (0.17.1) through the normal pipeline.