### PR TITLE
chore: align registry agent.json with published 0.17.1

### DIFF
--- a/registry/zcode-acp/agent.json
+++ b/registry/zcode-acp/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "zcode-acp",
   "name": "ZCode ACP",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Community bridge that drives the real ZCode app-server (GLM) over ACP — the full official harness in Zed and JetBrains, no editor-side API keys.",
   "repository": "https://github.com/william0wang/zcode-acp",
   "website": "https://github.com/william0wang/zcode-acp",
@@ -10,7 +10,7 @@
   "icon": "icon.svg",
   "distribution": {
     "npx": {
-      "package": "zcode-acp-server@0.17.0"
+      "package": "zcode-acp-server@0.17.1"
     }
   }
 }


### PR DESCRIPTION
One-line follow-up to #95: point the ACP registry submission assets at the actually published version (0.17.1; 0.17.0 was tagged but never reached npm).