### PR TITLE
fix: recover sandbox continuation cold starts and stream REPL tool output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,6 +212,13 @@ ZCode protocol types into ACP notifications directly — always translate.
   call site (see `handlers/server-requests.ts`) when sending server→client
   requests; the SDK types also require the `toolCall` field on permission
   requests (Zed renders the popup against it).
+- **Releases are fully automated** (release-please + npm OIDC trusted
+  publishing, zero npm secrets): land conventional commits on `main`, merge
+  the `chore(main): release X.Y.Z` PR, and tag + GitHub Release + npm publish
+  happen by themselves. Never hand-bump `package.json` version. A publish
+  failure with 404 on PUT is an npm-side trusted-publisher mismatch, not the
+  workflow. Public doc: `docs/RELEASING.md`; setup + troubleshooting runbook:
+  `.zcode/docs/releasing-runbook.md` (gitignored).
 
 ## Docs to read before sensitive changes
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,29 @@
+# Releasing
+
+Releases are fully automated: [release-please](https://github.com/googleapis/release-please)
+turns Conventional Commits on `main` into a release PR, and merging that PR
+tags the release, creates the GitHub Release and publishes to npm — no manual
+version bumps, no npm token.
+
+## How to cut a release
+
+1. Land Conventional Commits on `main` (`feat:` → minor, `fix:`/`perf:` →
+   patch, `feat!:` or `BREAKING CHANGE:` footer → major). Squash-merge PRs
+   with a conventional title, or the change is invisible to release-please.
+2. release-please opens or updates a `chore(main): release X.Y.Z` PR
+   (version bump in `package.json` + `CHANGELOG.md` entry). It rewrites
+   itself as more commits land.
+3. Merge that PR. The `Release` workflow (`.github/workflows/release.yml`)
+   tags `vX.Y.Z`, creates the GitHub Release, then builds, runs the test
+   suite and publishes the package to npm. npmmirror follows on its own
+   sync schedule.
+
+There is no manual tagging step. `package.json` version and
+`.release-please-manifest.json` are maintained by release-please — never edit
+them by hand.
+
+## Registry
+
+The ACP Registry entry (`agentclientprotocol/registry`, id `zcode-acp`) pins
+an explicit `package@version` for first inclusion, but its sync bot follows
+new npm versions automatically afterwards — a release needs no registry PR.

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -915,6 +915,9 @@ async function runPrompt(
       // in-flight one) and the stop-recovery window after a manual cancel.
       const SEND_RETRY_INTERVAL_MS = 500;
       const SEND_RETRY_TIMEOUT_MS = 30_000;
+      // Cold-start rejections recover in seconds (observed); a longer budget
+      // would spin pointlessly when the model is PERMANENTLY unavailable.
+      const WARMUP_RETRY_TIMEOUT_MS = 10_000;
       const sendParams =
         attachments.length > 0
           ? { sessionId: zcodeSid, content: sendText, attachments }
@@ -962,9 +965,10 @@ async function runPrompt(
           // resume path); the cold-start form is transient and retries below.
           throw new Error(`zcode send failed: ${sendResp.error.message ?? ""}`);
         }
-        if (Date.now() - sendT0 > SEND_RETRY_TIMEOUT_MS) {
+        const budget = isBusy ? SEND_RETRY_TIMEOUT_MS : WARMUP_RETRY_TIMEOUT_MS;
+        if (Date.now() - sendT0 > budget) {
           throw new Error(
-            `zcode send failed: backend still ${isBusy ? "busy" : "warming up"} after ${Math.round(SEND_RETRY_TIMEOUT_MS / 1000)}s (${sendResp.error.message ?? ""})`,
+            `zcode send failed: ${isBusy ? "backend still busy" : "send keeps being rejected"} after ${Math.round(budget / 1000)}s (${sendResp.error.message ?? ""})`,
           );
         }
         log(

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -647,13 +647,32 @@ export async function prompt(
     // (ensureBackend respawns; ensureRealSession/subscribe-recovery reloads
     // the session into it). The user's preempt/ESC during the continuation
     // still cancels it — the round registers itself in pendingTurns.
-    return runPrompt(
-      server,
-      { sessionId: params.sessionId, prompt: [{ type: "text", text: continuation }] },
-      cx,
-      `sandbox-cont-${randomUUID()}`,
-      true,
-    );
+    try {
+      return await runPrompt(
+        server,
+        { sessionId: params.sessionId, prompt: [{ type: "text", text: continuation }] },
+        cx,
+        `sandbox-cont-${randomUUID()}`,
+        true,
+      );
+    } catch (e) {
+      // The chained round runs right after a sandbox-allow respawn, inside
+      // the fresh backend's warm-up window. A failure here used to propagate
+      // as an RPC error and leave the session dead-silent with the
+      // continuation lost — the user had to blindly resend to recover
+      // (observed in production logs: "历史任务使用的模型已不可用" rejected
+      // the automatic send, a manual resend a minute later went through).
+      // Tell the user what happened and how to resume instead.
+      const err = e instanceof Error ? e.message : String(e);
+      warn(`sandbox: continuation prompt failed: ${err}`);
+      await sendTextChunk(
+        cx,
+        params.sessionId,
+        messages().sandboxContinuationFailed(err),
+        randomUUID(),
+      ).catch(() => undefined);
+      return { stopReason: "cancelled" };
+    }
   }
   return result;
 }
@@ -935,19 +954,21 @@ async function runPrompt(
           sendErrCode === 1308 ||
           sendErrMsg.includes("prompt is running") ||
           sendErrMsg.includes("already running");
-        if (!isBusy) {
-          // Non-busy error (auth, malformed, stale model, etc.) — don't
-          // retry, surface it. The stale-history-model case is repaired
-          // before the send (repairUnavailableModel on every resume path).
+        const isWarming = isTransientSendError(sendResp.error.message ?? "");
+        if (!isBusy && !isWarming) {
+          // Permanent error (auth, malformed, a truly removed model, …) —
+          // don't retry, surface it. The stale-history-model case is
+          // repaired before the send (repairUnavailableModel on every
+          // resume path); the cold-start form is transient and retries below.
           throw new Error(`zcode send failed: ${sendResp.error.message ?? ""}`);
         }
         if (Date.now() - sendT0 > SEND_RETRY_TIMEOUT_MS) {
           throw new Error(
-            `zcode send failed: backend still busy after ${Math.round(SEND_RETRY_TIMEOUT_MS / 1000)}s (${sendResp.error.message ?? ""})`,
+            `zcode send failed: backend still ${isBusy ? "busy" : "warming up"} after ${Math.round(SEND_RETRY_TIMEOUT_MS / 1000)}s (${sendResp.error.message ?? ""})`,
           );
         }
         log(
-          `  [send] backend busy (${sendResp.error.message ?? ""}), retrying in ${SEND_RETRY_INTERVAL_MS}ms`,
+          `  [send] backend ${isBusy ? "busy" : "cold-start reject"} (${sendResp.error.message ?? ""}), retrying in ${SEND_RETRY_INTERVAL_MS}ms`,
         );
       }
 
@@ -1724,6 +1745,20 @@ async function repairUnavailableModel(server: ZcodeAcpServer, zcodeSid: string):
   } catch (e) {
     warn(`model repair check failed: ${e instanceof Error ? e.message : String(e)}`);
   }
+}
+
+/**
+ * Cold-start send rejection worth retrying: right after a sandbox-allow
+ * respawn, the reloaded session's recorded model briefly reads as
+ * unavailable while the fresh backend finishes loading its model list — the
+ * same send succeeds seconds later (verified in production: the automatic
+ * continuation was rejected with "历史任务使用的模型已不可用", a manual
+ * resend a minute later went through). Matches the backend's Chinese wording
+ * plus a generic English form.
+ */
+export function isTransientSendError(message: string): boolean {
+  const m = message.toLowerCase();
+  return m.includes("模型已不可用") || /model .*(unavailable|no longer available)/.test(m);
 }
 
 /** Get or create the session-level ProjectionDiffer (persists across turns). */

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -90,6 +90,8 @@ export interface Messages {
   sandboxRejectOnceHint: (path: string) => string;
   /** Continuation prompt sent to the model after an allow restart. */
   sandboxContinuationPrompt: (path: string) => string;
+  /** The chained continuation round itself failed (backend warm-up window). */
+  sandboxContinuationFailed: (err: string) => string;
   sandboxRestartHint: (path: string) => string;
   sandboxResumedStatus: string;
   /** EPERM seen in tool output but no path could be extracted. */
@@ -182,6 +184,8 @@ const zh: Messages = {
   sandboxRejectOnceHint: (p) =>
     `[已拒绝沙箱放行 ${p},未保存任何决定,同类写入会再次询问;如需放行,可编辑 .zcode/acp/sandbox.json 的 allow 列表(由桥写入,Agent 不可改)。]`,
   sandboxContinuationPrompt: (p) => `[沙箱已放行 ${p},请继续刚才的任务。]`,
+  sandboxContinuationFailed: (err) =>
+    `[沙箱已放行,但自动续接失败:${err}。这是后端重启后的短暂预热期错误——请重新发送一条消息(例如"继续刚才的任务")即可恢复。]`,
   sandboxRestartHint: (p) => `[沙箱已放行 ${p},正在重启后端以应用新权限,随后自动继续…]`,
   sandboxResumedStatus: "[沙箱后端已重启,会话已恢复,自动继续刚才的任务…]",
   sandboxGenericDenialHint:
@@ -268,6 +272,8 @@ const en: Messages = {
   sandboxRejectOnceHint: (p) =>
     `[Sandbox grant rejected for ${p}; no decision was saved and the same write will ask again. To grant, edit the allow list in .zcode/acp/sandbox.json (bridge-written, not agent-writable).]`,
   sandboxContinuationPrompt: (p) => `[Sandbox granted ${p}; please continue the previous task.]`,
+  sandboxContinuationFailed: (err) =>
+    `[Sandbox granted, but the automatic continuation failed: ${err}. Transient error from the backend restart warm-up — resend a message (e.g. "continue the previous task") to resume.]`,
   sandboxRestartHint: (p) =>
     `[Sandbox granted ${p}; restarting the backend to apply the new permission, then continuing automatically…]`,
   sandboxResumedStatus: "[Sandbox backend restarted, session restored; continuing the task…]",

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -185,7 +185,7 @@ const zh: Messages = {
     `[已拒绝沙箱放行 ${p},未保存任何决定,同类写入会再次询问;如需放行,可编辑 .zcode/acp/sandbox.json 的 allow 列表(由桥写入,Agent 不可改)。]`,
   sandboxContinuationPrompt: (p) => `[沙箱已放行 ${p},请继续刚才的任务。]`,
   sandboxContinuationFailed: (err) =>
-    `[沙箱已放行,但自动续接失败:${err}。这是后端重启后的短暂预热期错误——请重新发送一条消息(例如"继续刚才的任务")即可恢复。]`,
+    `[沙箱已放行,但自动续接失败:${err}。请重新发送一条消息(例如"继续刚才的任务")以恢复工作。]`,
   sandboxRestartHint: (p) => `[沙箱已放行 ${p},正在重启后端以应用新权限,随后自动继续…]`,
   sandboxResumedStatus: "[沙箱后端已重启,会话已恢复,自动继续刚才的任务…]",
   sandboxGenericDenialHint:
@@ -273,7 +273,7 @@ const en: Messages = {
     `[Sandbox grant rejected for ${p}; no decision was saved and the same write will ask again. To grant, edit the allow list in .zcode/acp/sandbox.json (bridge-written, not agent-writable).]`,
   sandboxContinuationPrompt: (p) => `[Sandbox granted ${p}; please continue the previous task.]`,
   sandboxContinuationFailed: (err) =>
-    `[Sandbox granted, but the automatic continuation failed: ${err}. Transient error from the backend restart warm-up — resend a message (e.g. "continue the previous task") to resume.]`,
+    `[Sandbox granted, but the automatic continuation failed: ${err}. Resend a message (e.g. "continue the previous task") to resume the work.]`,
   sandboxRestartHint: (p) =>
     `[Sandbox granted ${p}; restarting the backend to apply the new permission, then continuing automatically…]`,
   sandboxResumedStatus: "[Sandbox backend restarted, session restored; continuing the task…]",

--- a/src/repl/App.tsx
+++ b/src/repl/App.tsx
@@ -22,6 +22,7 @@ import {
   isConfigArgumentMenu,
   isConfigCommand,
   isOneShotCommandValue,
+  lastToolTail,
   locateCaret,
   pickerWindow,
   relativeTime,
@@ -662,26 +663,6 @@ function entryHeight(entry: ReplEntry, width: number): number {
     default:
       return estimateLines(entry.text, width);
   }
-}
-
-/**
- * One-line live tail of the LAST tool row's output (collapsed whitespace,
- * last 160 chars — same convention as the thinking tail). Returned for the
- * most recent tool entry only; older tools' tails are stale context.
- */
-function toolTailLine(tail: string): string {
-  return `⎿ ${tail.replace(/\s+/g, " ").slice(-160)}`;
-}
-
-/** The last tool entry's live output tail, or null when it has none. */
-function lastToolTail(turn: TurnState): string | null {
-  for (let i = turn.entries.length - 1; i >= 0; i--) {
-    const e = turn.entries[i]!;
-    if (e.kind !== "tool") continue;
-    const tail = e.id ? (turn.toolTails[e.id] ?? "") : "";
-    return tail.trim() ? toolTailLine(tail) : null;
-  }
-  return null;
 }
 
 /**

--- a/src/repl/App.tsx
+++ b/src/repl/App.tsx
@@ -11,7 +11,7 @@
 import { Box, Static, Text, useInput, usePaste, type Key } from "ink";
 import Spinner from "ink-spinner";
 import { Chalk } from "chalk";
-import { useCallback, useEffect, useRef, useState, type ReactElement } from "react";
+import { Fragment, useCallback, useEffect, useRef, useState, type ReactElement } from "react";
 import stringWidth from "string-width";
 
 import {
@@ -665,6 +665,26 @@ function entryHeight(entry: ReplEntry, width: number): number {
 }
 
 /**
+ * One-line live tail of the LAST tool row's output (collapsed whitespace,
+ * last 160 chars — same convention as the thinking tail). Returned for the
+ * most recent tool entry only; older tools' tails are stale context.
+ */
+function toolTailLine(tail: string): string {
+  return `⎿ ${tail.replace(/\s+/g, " ").slice(-160)}`;
+}
+
+/** The last tool entry's live output tail, or null when it has none. */
+function lastToolTail(turn: TurnState): string | null {
+  for (let i = turn.entries.length - 1; i >= 0; i--) {
+    const e = turn.entries[i]!;
+    if (e.kind !== "tool") continue;
+    const tail = e.id ? (turn.toolTails[e.id] ?? "") : "";
+    return tail.trim() ? toolTailLine(tail) : null;
+  }
+  return null;
+}
+
+/**
  * Height of the live-turn block (entries + streaming buffers + spinner).
  * Deliberately biased HIGH: an underestimate makes the whole layout exceed
  * the terminal and ink clips from the bottom — the input box disappears. A
@@ -673,6 +693,8 @@ function entryHeight(entry: ReplEntry, width: number): number {
 function turnHeight(turn: TurnState | null, width: number): number {
   if (!turn) return 0;
   let h = turn.entries.reduce((n, e) => n + entryHeight(e, width), 0);
+  const tail = lastToolTail(turn);
+  if (tail) h += estimateLines(tail, width);
   if (turn.thinkBuf.trim()) {
     // The render collapses whitespace and keeps only the tail, but even that
     // can wrap (CJK especially) — measure it instead of assuming one line.
@@ -963,9 +985,25 @@ export function App(props: AppProps): ReactElement {
           overflow="hidden"
           justifyContent="flex-end"
         >
-          {turn.entries.map((e, i) => (
-            <EntryView key={i} entry={e} />
-          ))}
+          {(() => {
+            // Attach the live output tail to the LAST tool row: a long silent
+            // tool (build, sleep, sub-agent work) otherwise shows nothing but
+            // its title and the spinner seconds for minutes on end.
+            let tailIdx = -1;
+            for (let i = turn.entries.length - 1; i >= 0; i--) {
+              if (turn.entries[i]!.kind === "tool") {
+                tailIdx = i;
+                break;
+              }
+            }
+            const tail = lastToolTail(turn);
+            return turn.entries.map((e, i) => (
+              <Fragment key={i}>
+                <EntryView entry={e} />
+                {i === tailIdx && tail ? <Text dimColor>{tail}</Text> : null}
+              </Fragment>
+            ));
+          })()}
           {turn.thinkBuf.trim() ? (
             <Text dimColor>⎿ thinking · {turn.thinkBuf.replace(/\s+/g, " ").slice(-120)}</Text>
           ) : null}

--- a/src/repl/model.ts
+++ b/src/repl/model.ts
@@ -222,6 +222,30 @@ export function createTurnState(): TurnState {
   return { entries: [], textBuf: "", thinkBuf: "", toolTails: {} };
 }
 
+/**
+ * One-line live tail of a tool's output (collapsed whitespace, last 160
+ * chars — same convention as the thinking tail). Exported so the footer
+ * render and its height estimate share one string.
+ */
+export function toolTailLine(tail: string): string {
+  return `⎿ ${tail.replace(/\s+/g, " ").slice(-160)}`;
+}
+
+/**
+ * The LAST tool entry's live output tail (wrapped by toolTailLine), or null
+ * when it has none. Older tools' tails are stale context and are ignored —
+ * only the most recent tool row gets the live tail.
+ */
+export function lastToolTail(turn: TurnState): string | null {
+  for (let i = turn.entries.length - 1; i >= 0; i--) {
+    const e = turn.entries[i]!;
+    if (e.kind !== "tool") continue;
+    const tail = e.id ? (turn.toolTails[e.id] ?? "") : "";
+    return tail.trim() ? toolTailLine(tail) : null;
+  }
+  return null;
+}
+
 /** Extract displayable text from any content block shape (text/thought). */
 function blockText(content: unknown): string {
   if (content && typeof content === "object" && "text" in content) {

--- a/src/repl/model.ts
+++ b/src/repl/model.ts
@@ -209,10 +209,17 @@ export interface TurnState {
   entries: ReplEntry[];
   textBuf: string;
   thinkBuf: string;
+  /**
+   * Newest output tail per toolCallId (from tool_call_update.rawOutput). The
+   * tool row itself renders only title+status by design; this is what lets
+   * the footer stream a long silent tool's progress (build, sleep, a
+   * sub-agent's work) instead of showing a frozen row + spinner seconds.
+   */
+  toolTails: Record<string, string>;
 }
 
 export function createTurnState(): TurnState {
-  return { entries: [], textBuf: "", thinkBuf: "" };
+  return { entries: [], textBuf: "", thinkBuf: "", toolTails: {} };
 }
 
 /** Extract displayable text from any content block shape (text/thought). */
@@ -251,6 +258,7 @@ export function applyUpdate(state: TurnState, update: SessionUpdate): TurnState 
     entries: state.entries,
     textBuf: state.textBuf,
     thinkBuf: state.thinkBuf,
+    toolTails: state.toolTails,
   };
   switch (update.sessionUpdate) {
     case "agent_message_chunk": {
@@ -276,6 +284,15 @@ export function applyUpdate(state: TurnState, update: SessionUpdate): TurnState 
     case "tool_call":
     case "tool_call_update": {
       const id = update.toolCallId ?? "";
+      // Capture the newest output tail so the footer can stream a running
+      // tool's progress (the row renders title+status only). Progress updates
+      // carry the backend's CUMULATIVE output snapshot, so a plain overwrite
+      // is the latest state; updates without output (pure status flips) keep
+      // the previous tail.
+      const raw = (update as { rawOutput?: unknown }).rawOutput;
+      if (id && typeof raw === "string" && raw.trim()) {
+        next.toolTails = { ...next.toolTails, [id]: raw };
+      }
       const title = update.title ?? id;
       const status = update.status ?? "pending";
       const idx = next.entries.findIndex((e) => e.kind === "tool" && e.id === id && id !== "");

--- a/tests/repl-model.test.ts
+++ b/tests/repl-model.test.ts
@@ -24,11 +24,13 @@ import {
   handleLocalCommand,
   isConfigArgumentMenu,
   isOneShotCommandValue,
+  lastToolTail,
   parseCommand,
   relativeTime,
   parseQuestionForm,
   selectLabel,
   seedStatusFromNewSession,
+  toolTailLine,
   type SessionUpdateLike,
 } from "../src/repl/model.js";
 
@@ -182,7 +184,47 @@ describe("applyUpdate", () => {
       status: "completed",
       rawOutput: "first done",
     } as SessionUpdateLike);
-    expect(s.toolTails).toEqual({ b1: "first done" });
+    s = applyUpdate(s, {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "b2",
+      status: "in_progress",
+      rawOutput: "second running",
+    } as SessionUpdateLike);
+    // A later tool's update must never clobber the earlier tool's tail.
+    expect(s.toolTails).toEqual({ b1: "first done", b2: "second running" });
+  });
+
+  it("lastToolTail renders only the newest tool row's captured output", () => {
+    let s = createTurnState();
+    expect(lastToolTail(s)).toBeNull(); // no tool rows at all
+    s = applyUpdate(s, {
+      sessionUpdate: "tool_call",
+      toolCallId: "b1",
+      title: "Bash: one",
+      status: "completed",
+      rawOutput: "first done",
+    } as SessionUpdateLike);
+    s = applyUpdate(s, {
+      sessionUpdate: "tool_call",
+      toolCallId: "b2",
+      title: "Bash: two",
+      status: "in_progress",
+    } as SessionUpdateLike);
+    expect(lastToolTail(s)).toBeNull(); // newest tool row has no tail — even though b1 does
+    s = applyUpdate(s, chunk("agent_message_chunk", "after the tools"));
+    s = applyUpdate(s, {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "b2",
+      status: "in_progress",
+      rawOutput: "second running",
+    } as SessionUpdateLike);
+    expect(lastToolTail(s)).toBe("⎿ second running"); // non-tool entries after don't matter
+  });
+
+  it("toolTailLine collapses whitespace and keeps the last 160 chars", () => {
+    expect(toolTailLine("a\n  b\t\tc")).toBe("⎿ a b c");
+    const long = "x".repeat(300);
+    expect(toolTailLine(long)).toBe(`⎿ ${"x".repeat(160)}`);
   });
 
   it("flushes prose before a plan note", () => {

--- a/tests/repl-model.test.ts
+++ b/tests/repl-model.test.ts
@@ -107,6 +107,84 @@ describe("applyUpdate", () => {
     ]);
   });
 
+  it("captures the newest output tail per tool (progress snapshots overwrite)", () => {
+    let s = createTurnState();
+    s = applyUpdate(s, {
+      sessionUpdate: "tool_call",
+      toolCallId: "b1",
+      title: "Bash: npm run build",
+      status: "in_progress",
+    } as SessionUpdateLike);
+    s = applyUpdate(s, {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "b1",
+      status: "in_progress",
+      rawOutput: "compiling…",
+    } as SessionUpdateLike);
+    expect(s.toolTails["b1"]).toBe("compiling…");
+    // Progress carries the backend's cumulative snapshot — overwrite is the
+    // latest state, not an append.
+    s = applyUpdate(s, {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "b1",
+      status: "in_progress",
+      rawOutput: "compiling… done in 3s",
+    } as SessionUpdateLike);
+    expect(s.toolTails["b1"]).toBe("compiling… done in 3s");
+  });
+
+  it("keeps the previous tail on output-less status flips", () => {
+    let s = createTurnState();
+    s = applyUpdate(s, {
+      sessionUpdate: "tool_call",
+      toolCallId: "b1",
+      title: "Bash: sleep 200",
+      status: "in_progress",
+    } as SessionUpdateLike);
+    s = applyUpdate(s, {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "b1",
+      status: "in_progress",
+      rawOutput: "waiting…",
+    } as SessionUpdateLike);
+    // Empty/absent rawOutput (a silent progress heartbeat, a pure status
+    // flip) must not clear the tail the footer is streaming.
+    s = applyUpdate(s, {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "b1",
+      status: "in_progress",
+      rawOutput: "",
+    } as SessionUpdateLike);
+    s = applyUpdate(s, {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "b1",
+      status: "completed",
+    } as SessionUpdateLike);
+    expect(s.toolTails).toEqual({ b1: "waiting…" });
+  });
+
+  it("tails are independent per toolCallId", () => {
+    let s = createTurnState();
+    for (const [id, title] of [
+      ["b1", "Bash: one"],
+      ["b2", "Bash: two"],
+    ] as const) {
+      s = applyUpdate(s, {
+        sessionUpdate: "tool_call",
+        toolCallId: id,
+        title,
+        status: "in_progress",
+      } as SessionUpdateLike);
+    }
+    s = applyUpdate(s, {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "b1",
+      status: "completed",
+      rawOutput: "first done",
+    } as SessionUpdateLike);
+    expect(s.toolTails).toEqual({ b1: "first done" });
+  });
+
   it("flushes prose before a plan note", () => {
     let s = createTurnState();
     s = applyUpdate(s, chunk("agent_message_chunk", "here comes the plan"));

--- a/tests/send-retry.test.ts
+++ b/tests/send-retry.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { isTransientSendError } from "../src/handlers/session.js";
+
+describe("isTransientSendError", () => {
+  it("matches the real backend cold-start wording (observed in production)", () => {
+    expect(
+      isTransientSendError(
+        "历史任务使用的模型已不可用，请从当前模型列表中选择一个可用模型后继续。",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches generic English model-unavailable forms", () => {
+    expect(isTransientSendError("model glm-4 is unavailable")).toBe(true);
+    expect(isTransientSendError("The requested model is no longer available")).toBe(true);
+  });
+
+  it("rejects busy and permanent errors", () => {
+    expect(isTransientSendError("Cannot send while a prompt is running")).toBe(false);
+    // "not found" is a permanent condition — must not match the unavailable form.
+    expect(isTransientSendError("model not found")).toBe(false);
+    expect(isTransientSendError("authentication failed")).toBe(false);
+    expect(isTransientSendError("")).toBe(false);
+  });
+});


### PR DESCRIPTION
Two user-facing stalls failed silently:

**Sandbox allow → continuation cold start (editor).** After a permission allow restarts the backend, the continuation prompt can hit the new backend's warm-up window and be rejected with the transient "历史任务使用的模型已不可用" error. The non-busy path threw immediately, leaving the session dead-quiet right after an allow — the user had to resend manually (observed 3x in logs).

- `isTransientSendError()` gates send retries: warm-up rejections retry on a separate 10s budget (busy keeps 30s); permanent rejections fail fast with the server's message.
- A failed continuation is no longer swallowed: it warns, sends a visible "sandbox allowed but continuation failed — resend a message to recover" notice, and returns `cancelled` instead of throwing into the prompt loop.

**REPL long turns showed nothing (CLI).** The REPL never declares terminal capabilities, so Bash tool output arrives as accumulated `rawOutput` snapshots — which `applyUpdate` dropped entirely. Long agent runs looked frozen.

- `TurnState.toolTails` keeps the latest raw output per tool call; `model.ts` exports `lastToolTail`/`toolTailLine` (160-char tail, whitespace-collapsed) and the live-turn block renders it under the last tool row.

Also documents the fully automated release process (`docs/RELEASING.md` + AGENTS.md gotcha) — no version bump in this PR; release-please cuts 0.17.2 on merge.

Review follow-ups in e96f15b: separate warm-up retry budget with neutral timeout copy, neutralized continuation-failure message, tail helpers moved to `model.ts` with strengthened tests.