### PR TITLE
feat: quit the REPL on bare exit/quit/q without slash

### DIFF
--- a/src/repl/model.ts
+++ b/src/repl/model.ts
@@ -376,6 +376,9 @@ export type ReplCommand = "exit" | "sessions" | "new" | null;
 export function parseCommand(text: string): ReplCommand {
   const t = text.trim();
   if (t === "/exit" || t === "/quit" || t === "/q") return "exit";
+  // Shell muscle memory types `exit` without the slash — accept the bare
+  // forms too (no whitespace-separated args: "exit now" stays a prompt).
+  if (t === "exit" || t === "quit" || t === "q") return "exit";
   if (t === "/sessions") return "sessions";
   if (t === "/new") return "new";
   return null;

--- a/tests/repl-model.test.ts
+++ b/tests/repl-model.test.ts
@@ -304,6 +304,16 @@ describe("parseCommand", () => {
     expect(parseCommand("")).toBe(null);
   });
 
+  it("recognizes bare shell-style quit words", () => {
+    expect(parseCommand("exit")).toBe("exit");
+    expect(parseCommand("  exit  ")).toBe("exit");
+    expect(parseCommand("quit")).toBe("exit");
+    expect(parseCommand("q")).toBe("exit");
+    // With arguments it is a prompt, not a quit.
+    expect(parseCommand("exit now")).toBe(null);
+    expect(parseCommand("Exit")).toBe(null);
+  });
+
   it("recognizes the sessions picker command", () => {
     expect(parseCommand("/sessions")).toBe("sessions");
     expect(parseCommand(" /sessions ")).toBe("sessions");


### PR DESCRIPTION
Shell muscle memory types `exit` without the slash — until now only `/exit` quit the REPL, so bare `exit` went to the model as a prompt.

`parseCommand` now accepts the bare forms `exit`/`quit`/`q` (mirroring the slash aliases). With arguments (`exit now`) it stays a prompt; case-sensitive like a shell (`Exit` is not a command). Queued prompts route through the same parse, so a queued bare `exit` quits after the turn ends.