### PR TITLE
fix(registry): skip providers with zero models in provider registry

### DIFF
--- a/src/config/provider-registry.ts
+++ b/src/config/provider-registry.ts
@@ -126,12 +126,25 @@ function buildProviderElement(providerId: string, p: ProviderEntry): Record<stri
  * Unlike `loadAllModels` (dropdown, enabled-only), the registry pushes every
  * configured provider so the backend recognises any of them when a session
  * switches to it. The backend applies its own enable/availability rules.
+ *
+ * Providers with zero models are skipped: the backend's schema requires
+ * `models` to have >= 1 item and rejects the WHOLE payload otherwise, so a
+ * single empty provider (e.g. a plan tier with no models listed yet) would
+ * break the registry sync and every session would fail with
+ * `provider_not_configured` before auth is even tried.
  */
 export function buildProviderRegistry(): ProviderRegistryPayload {
   const cfg = JSON.parse(readFileSync(ZCODE_CREDS_PATH, "utf8")) as ConfigShape;
-  const providers = Object.entries(cfg.provider ?? {}).map(([pid, p]) =>
-    buildProviderElement(pid, p ?? {}),
-  );
+  const allEntries = Object.entries(cfg.provider ?? {});
+  const skipped: string[] = [];
+  const providers = [] as ReturnType<typeof buildProviderElement>[];
+  for (const [pid, p] of allEntries) {
+    if (Object.keys((p ?? {}).models ?? {}).length === 0) {
+      skipped.push(pid);
+      continue;
+    }
+    providers.push(buildProviderElement(pid, p ?? {}));
+  }
   const generatedAt = Date.now();
   // revision is a content hash; the backend skips unchanged revisions. A stable
   // JSON hash over provider ids+kinds+baseURLs is enough — apiKey changes are
@@ -139,7 +152,8 @@ export function buildProviderRegistry(): ProviderRegistryPayload {
   const revision = hashRevision(providers);
   log(
     `provider-registry: built ${providers.length} provider(s) ` +
-      `(ids: ${providers.map((p) => p.providerId).join(", ") || "none"})`,
+      `(ids: ${providers.map((p) => p.providerId).join(", ") || "none"})` +
+      (skipped.length > 0 ? `; skipped empty-model provider(s): ${skipped.join(", ")}` : ""),
   );
   return { providers, generatedAt, revision };
 }

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -129,6 +129,15 @@ function workspaceFromResumeResult(result: unknown): string | null {
 async function syncProviderRegistry(server: ZcodeAcpServer, cwd: string): Promise<void> {
   try {
     const registry = buildProviderRegistry();
+    if (registry.providers.length === 0) {
+      // Every configured provider lacks models (or none are configured). The
+      // empty payload is schema-valid, but the backend applies registries
+      // replace-style — pushing it would CLEAR providers synced earlier. Most
+      // users configure no third-party provider at all, so this is the common
+      // path, not an error.
+      log("provider-registry: no usable providers — skipping sync");
+      return;
+    }
     const resp = await server
       .ensureBackend()
       .request(

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -27,6 +27,20 @@ const FAKE_CONFIG = {
       options: { baseURL: "https://example.test/primary" },
       models: { "model-a": { limit: { context: 128000 } } },
     },
+    "builtin:empty-plan": {
+      name: "Empty Plan",
+      kind: "anthropic",
+      enabled: true,
+      source: "builtin",
+      options: { baseURL: "https://example.test/empty-plan" },
+      models: {},
+    },
+    "builtin:no-models-key": {
+      name: "No Models Key",
+      kind: "anthropic",
+      enabled: true,
+      source: "builtin",
+    },
     "custom-openai-kind": {
       name: "Custom One",
       kind: "openai-compatible",
@@ -78,6 +92,15 @@ describe("buildProviderRegistry", () => {
     expect(ids).toContain("builtin:primary");
     expect(ids).toContain("custom-openai-kind");
     expect(ids).toContain("custom-anthropic-kind");
+  });
+
+  it("skips providers with zero models — an empty models array is rejected by the backend's schema and would fail the whole registry sync", () => {
+    const reg = buildProviderRegistry();
+    const ids = reg.providers.map((p) => p.providerId);
+    expect(ids).not.toContain("builtin:empty-plan");
+    expect(ids).not.toContain("builtin:no-models-key");
+    // Non-empty providers still make it through.
+    expect(ids).toContain("builtin:primary");
   });
 
   it("wraps apiKey as the inline union {source:'inline', value}, never a bare string", () => {

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -6,14 +6,16 @@
  * `provider_not_configured`. These tests lock the payload schema derived from
  * the backend's `j7t` converter in zcode.cjs: apiKey is the inline union
  * `{source:"inline", value}`, apiFormat maps from kind, models is an array of
- * `{modelId}`, and every configured provider is included (registry is NOT
- * enabled-filtered like the dropdown).
+ * `{modelId}`, and every provider that HAS models is included (registry is NOT
+ * enabled-filtered like the dropdown). Providers with zero models are skipped:
+ * the backend schema requires a non-empty models array per provider and would
+ * otherwise reject the whole payload.
  *
  * All identifiers below are fictional test fixtures — no real provider names,
  * URLs, model ids, or keys are used.
  */
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ZCODE_CREDS_PATH } from "../src/utils.js";
 
@@ -68,15 +70,22 @@ const FAKE_CONFIG = {
   },
 };
 
+// Swap the creds-file contents per test; defaults to the shared FAKE_CONFIG.
+let credsFile = JSON.stringify(FAKE_CONFIG);
+
 vi.mock("node:fs", async () => {
   const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
   return {
     ...actual,
     readFileSync: (p: string) => {
-      if (p === ZCODE_CREDS_PATH) return JSON.stringify(FAKE_CONFIG);
+      if (p === ZCODE_CREDS_PATH) return credsFile;
       return actual.readFileSync(p);
     },
   };
+});
+
+afterEach(() => {
+  credsFile = JSON.stringify(FAKE_CONFIG);
 });
 
 const { buildProviderRegistry } = await import("../src/config/provider-registry.js");
@@ -86,7 +95,7 @@ function providerById(reg: ReturnType<typeof buildProviderRegistry>, id: string)
 }
 
 describe("buildProviderRegistry", () => {
-  it("includes ALL providers (not enabled-filtered like the dropdown)", () => {
+  it("includes every provider that has models (not enabled-filtered like the dropdown)", () => {
     const reg = buildProviderRegistry();
     const ids = reg.providers.map((p) => p.providerId);
     expect(ids).toContain("builtin:primary");
@@ -101,6 +110,23 @@ describe("buildProviderRegistry", () => {
     expect(ids).not.toContain("builtin:no-models-key");
     // Non-empty providers still make it through.
     expect(ids).toContain("builtin:primary");
+  });
+
+  it("builds an empty payload when every provider lacks models (caller must not push it)", () => {
+    credsFile = JSON.stringify({
+      provider: {
+        "builtin:only-empty": {
+          name: "Only Empty",
+          kind: "anthropic",
+          source: "builtin",
+          models: {},
+        },
+      },
+    });
+    // The payload itself stays schema-valid; the sync CALLER is responsible
+    // for not pushing it (an empty registry applies replace-style and would
+    // clear providers synced earlier).
+    expect(buildProviderRegistry().providers).toEqual([]);
   });
 
   it("wraps apiKey as the inline union {source:'inline', value}, never a bare string", () => {


### PR DESCRIPTION
Adopted from @haowei2000's #87 (rebased onto current main, authorship preserved), with one addition from review.

**The fix (commit 1, haowei2000):** the backend schema requires a non-empty models array per provider and rejects the WHOLE `workspace/updateProviderRegistry` payload otherwise, so a single empty provider (e.g. a plan tier with no models listed) broke the registry sync and every session failed `provider_not_configured`. Zero-model providers are now skipped when building the registry, with the skipped ids logged.

**Review addition (commit 2):** when EVERY provider lacks models, the built payload is `providers: []` — schema-valid (the outer array has no min(1)) but applied replace-style by the backend, so pushing it would CLEAR providers synced earlier. The sync now skips the RPC entirely in that case. This is also the common path (most users configure no third-party provider), so it only ever saved a pointless RPC.

Review verified the premise against the backend's actual schema (extracted from the local zcode.cjs bundle): `models: min(1)` per provider, `providers` unbounded, replace-style apply confirmed. Test coverage: mixed configs keep non-empty providers, all-empty configs build an empty payload (and must not be pushed).