### PR TITLE
docs: credit contributors with an auto-generated wall in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,13 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for setup,
 code style, commit conventions, and the PR checklist. Notable changes are
 recorded in [CHANGELOG.md](CHANGELOG.md).
 
+Thanks to everyone who has contributed (updated automatically from the
+[contributors graph](https://github.com/william0wang/zcode-acp/graphs/contributors)):
+
+<a href="https://github.com/william0wang/zcode-acp/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=william0wang/zcode-acp" alt="Contributors" />
+</a>
+
 ## Related Projects
 
 - [glm-acp-agent](https://github.com/stefandevo/glm-acp-agent) — a self-contained ACP agent that calls the GLM API directly; zcode-acp instead bridges the real `zcode app-server`, inheriting its full official harness.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -344,6 +344,13 @@ CI 会在每次 push 和 pull request 时运行 `typecheck`、`lint`、`build` �
 欢迎贡献！请阅读 [CONTRIBUTING.md](CONTRIBUTING.md) 了解环境搭建、代码风格、
 commit 约定和 PR 检查清单。重要变更记录在 [CHANGELOG.md](CHANGELOG.md)。
 
+感谢每一位贡献者（由[贡献者图谱](https://github.com/william0wang/zcode-acp/graphs/contributors)
+自动生成，覆盖全部历史贡献者）：
+
+<a href="https://github.com/william0wang/zcode-acp/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=william0wang/zcode-acp" alt="贡献者" />
+</a>
+
 ## 相关项目
 
 - [glm-acp-agent](https://github.com/stefandevo/glm-acp-agent) —— 自包含的 ACP agent，直接调用 GLM API；zcode-acp 则桥接真实的 `zcode app-server`，继承其完整的官方 harness。


### PR DESCRIPTION
Adds a contributors avatar wall to the Contributing section of both READMEs, powered by [contrib.rocks](https://contrib.rocks). It updates itself from the repo's commit history — historical contributors and squash-merge `Co-authored-by` credits (e.g. adopted PR #87/#102) appear automatically, no manual upkeep.

Docs-only change: no version bump (release-please ignores `docs:` commits).