### PR TITLE
fix: default-allow well-known system temp trees in the sandbox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,7 +188,11 @@ ZCode protocol types into ACP notifications directly — always translate.
   sandbox design lives in ADR-0011 (`.zcode/docs/adr/`): writes-only model,
   per-project config in `.zcode/acp/sandbox.json` (deny island — only the
   bridge may write it), dynamic allow = ask → persist → backend restart →
-  continuation prompt. Arming is dual-switch: `ZCODE_ACP_SANDBOX=1` globally
+  continuation prompt. Well-known system temp trees (/tmp → /private/tmp,
+  /var/tmp, /private/var/folders) are DEFAULT-ALLOWED — tools hardcode /tmp
+  and $TMPDIR names only the per-user /var/folders leaf; don't "tighten"
+  them back into popup storms (verify-sandbox.sh fixtures moved to HOME for
+  the same reason). Arming is dual-switch: `ZCODE_ACP_SANDBOX=1` globally
   or `enabled: true` in that config per project (auto-created template ships
   `false`; a malformed or non-object config reads as enabled — fail closed,
   never rewrite the user's bytes). `server.backendSandboxed` is the process

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -19,8 +19,10 @@ Seatbelt (`sandbox-exec`) profile that denies file writes everywhere except:
 
 - the workspace root(s) of your live sessions,
 - `~/.zcode*` (the backend's own sessions/db/logs),
-- the system temp directory and regenerable tool caches (`~/Library/Caches`,
-  `~/.cache`, `~/.npm`, `~/Library/pnpm`, `~/.node-gyp`),
+- the well-known system temp trees — `/tmp` (→ `/private/tmp`), `/var/tmp`,
+  and the per-user `/var/folders` tree that `$TMPDIR` lives in — plus
+  regenerable tool caches (`~/Library/Caches`, `~/.cache`, `~/.npm`,
+  `~/Library/pnpm`, `~/.node-gyp`),
 - paths granted via the per-project config or the allow popup.
 
 Reads and process execution stay open: deletion (`rm`, `mv`, truncation) is a

--- a/scripts/verify-sandbox.sh
+++ b/scripts/verify-sandbox.sh
@@ -15,12 +15,15 @@ set -euo pipefail
 command -v sandbox-exec >/dev/null || { echo "SKIP: sandbox-exec not available (non-macOS?)"; exit 0; }
 [ -f dist/backend/sandbox.js ] || { echo "FAIL: dist not built — run pnpm build first"; exit 1; }
 
-# Fixtures live under /tmp, NOT $TMPDIR — the profile allowlists TMPDIR, so
-# fixtures there would be swallowed by that rule and prove nothing. /tmp is
-# symlinked to /private/tmp on macOS; the generator realpaths it.
-WS=$(mktemp -d /tmp/sbv-ws-XXXXXX)/project && mkdir -p "$WS/.zcode/acp"
-OUTSIDE=$(mktemp -d /tmp/sbv-out-XXXXXX)
-DENIED=$(mktemp -d /tmp/sbv-denied-XXXXXX)
+# Fixtures live under HOME, outside every allowlist (~/.zcode*, caches, temp
+# trees) — writes there must be denied by the base rule. They used to live
+# under /tmp, but the system temp trees (/tmp → /private/tmp, /var/tmp,
+# /var/folders) are DEFAULT-ALLOWED now, so /tmp fixtures would prove nothing.
+# /tmp must NOT be used for denied fixtures NOR relied on as denied; the
+# tmp-allowed check below covers the default-allow side.
+WS=$(mktemp -d "$HOME/.sbv-ws-XXXXXX")/project && mkdir -p "$WS/.zcode/acp"
+OUTSIDE=$(mktemp -d "$HOME/.sbv-out-XXXXXX")
+DENIED=$(mktemp -d "$HOME/.sbv-denied-XXXXXX")
 ISLAND="$WS/.zcode/acp"
 echo "decoy" > "$DENIED/decoy.txt"
 
@@ -76,6 +79,11 @@ check "deny island write denied"   "$SANDBOX touch $ISLAND/nope.json" 1
 check "config allow honored"       "$SANDBOX touch $OUTSIDE/yes.txt" 0
 # /dev/null: git and shell redirect idioms break without this allow.
 check "/dev/null writable"         "$SANDBOX sh -c 'echo x > /dev/null'" 0
+# Well-known temp trees are default-allowed: tools hardcode /tmp and $TMPDIR
+# is only the per-user /var/folders leaf. Both spellings must work.
+check "/tmp writable"              "$SANDBOX touch /tmp/.sbv-tmp-allowed" 0
+check "/private/tmp writable"      "$SANDBOX touch /private/tmp/.sbv-tmp-allowed" 0
+rm -f /tmp/.sbv-tmp-allowed /private/tmp/.sbv-tmp-allowed
 # The profile self-denies its own dir: a sandboxed process must not be able
 # to race/symlink/occupy the next respawn's profile.
 check "profile self-denied"        "$SANDBOX sh -c 'echo evil > $PROFILE'" 1

--- a/src/backend/sandbox.ts
+++ b/src/backend/sandbox.ts
@@ -62,6 +62,19 @@ const DEFAULT_CACHE_DIRS = [
   "~/.node-gyp",
 ];
 
+/**
+ * Well-known system temp trees, default-writable. Tools hardcode `/tmp`
+ * (a symlink to /private/tmp) or use /var/tmp, and $TMPDIR only names the
+ * process's own /var/folders leaf — without these, `mktemp` in a script or a
+ * compiler scratch file hits an EPERM popup for plain scratch space
+ * (observed: /private/tmp/adv_backup). /private/var/folders is the per-user
+ * temp+cache tree ($TMPDIR's parent, includes DARWIN_USER_CACHE_DIR); the
+ * specific $TMPDIR leaf stays allowed for tightness. Listed in RESOLVED
+ * form — SBPL subpath filters match REAL paths, and /tmp and /var/tmp
+ * resolve into the /private entries.
+ */
+const DEFAULT_TEMP_DIRS = ["/private/tmp", "/private/var/tmp", "/private/var/folders"];
+
 /** Backend state roots that must stay writable for the bridge to function. */
 const ZCODE_STATE_DIRS = ["~/.zcode", "~/.zcode-beta", "~/.zcode-plugin"];
 
@@ -361,7 +374,7 @@ export function buildSandboxProfile(input: SandboxArmInput): string {
       allows.push(`(allow file-write* (subpath ${sb(resolveReal(allowed))}))`);
     }
   }
-  for (const p of [...ZCODE_STATE_DIRS, ...DEFAULT_CACHE_DIRS]) {
+  for (const p of [...ZCODE_STATE_DIRS, ...DEFAULT_CACHE_DIRS, ...DEFAULT_TEMP_DIRS]) {
     allows.push(`(allow file-write* (subpath ${sb(resolveReal(p))}))`);
   }
   for (const allowed of input.extraAllow) {

--- a/tests/sandbox.test.ts
+++ b/tests/sandbox.test.ts
@@ -290,6 +290,14 @@ describe("buildSandboxProfile", () => {
     // /dev/null must be writable — git and `2>/dev/null` idioms break without
     // it ("could not open '/dev/null'", observed in review probes).
     expect(profile).toContain('(allow file-write-data (literal "/dev/null"))');
+    // Well-known system temp trees are default-allowed in RESOLVED form:
+    // tools hardcode /tmp (symlink → /private/tmp) or /var/tmp, and $TMPDIR
+    // names only the per-user /var/folders leaf. An /tmp allow entry resolves
+    // to the same line — no duplicate alias emission.
+    expect(profile).toContain('(allow file-write* (subpath "/private/tmp"))');
+    expect(profile).toContain('(allow file-write* (subpath "/private/var/tmp"))');
+    expect(profile).toContain('(allow file-write* (subpath "/private/var/folders"))');
+    expect(profile.match(/subpath "\/private\/tmp"/g)).toHaveLength(1);
     // The profile's own dir self-denies LAST — the agent runs with $TMPDIR
     // writable and must not touch the next respawn's profile.
     const profile2 = buildSandboxProfile({


### PR DESCRIPTION
Tools hardcode `/tmp` (a symlink to `/private/tmp`) or use `/var/tmp`, and `/var/folders/3r/s8llvsqd6m75vkd2fkln90k80000gn/T/` names only the process's own `/var/folders/…` leaf — so a bare `mktemp` in a script or a compiler scratch file hit an EPERM ask popup for plain system scratch space (observed in the wild: `/private/tmp/adv_backup`). Same pitfall documented in coding-agent sandboxing writeups: macOS doesn't use /tmp for its own temp defaults, so allowlisting only `os.tmpdir()` misses every hardcoded path.

The profile now default-allows `/private/tmp`, `/private/var/tmp` and `/private/var/folders` (the per-user temp+cache tree, `/var/folders/3r/s8llvsqd6m75vkd2fkln90k80000gn/T/`'s parent, covering `DARWIN_USER_CACHE_DIR`), listed in resolved form — SBPL subpath filters match REAL paths, and the /tmp and /var/tmp symlinks resolve into the /private entries.

- `scripts/verify-sandbox.sh`: fixtures move from /tmp to HOME (they relied on /tmp being denied, which this reverses), plus new checks that /tmp and /private/tmp writes succeed under the sandbox.
- Tests assert the resolved subpath lines (and no duplicate alias emission); docs/AGENTS.md whitelist wording updated.