### PR TITLE
fix(sandbox): batch allow-restarts into one window with cooldown asks and chained continuations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,8 +187,15 @@ ZCode protocol types into ACP notifications directly — always translate.
   /private/tmp, $TMPDIR under /var/folders) silently fails to match. The
   sandbox design lives in ADR-0011 (`.zcode/docs/adr/`): writes-only model,
   per-project config in `.zcode/acp/sandbox.json` (deny island — only the
-  bridge may write it), dynamic allow = ask → persist → backend restart →
-  continuation prompt. Well-known system temp trees (/tmp → /private/tmp,
+  bridge may write it), dynamic allow = ask → persist → BATCHED backend
+  restart (3s window: grants collect, then one cancel-wave + continuation
+  + close — a per-approval restart killed sibling popups still pending on
+  other denied paths; the flush sets a continuation ONLY for sessions with
+  a turn still in flight, orphans would hijack a later cancelled prompt).
+  Ask debounce marks are timestamps: a user decision (or a structural
+  hint) pins forever; a FAILED ask (timeout / killed by another grant's
+  restart / instantly-rejecting client) cools down 60s and may re-ask —
+  the old permanent mute left the model on a bare EPERM with no way out. Well-known system temp trees (/tmp → /private/tmp,
   /var/tmp, /private/var/folders) are DEFAULT-ALLOWED — tools hardcode /tmp
   and $TMPDIR names only the per-user /var/folders leaf; don't "tighten"
   them back into popup storms (verify-sandbox.sh fixtures moved to HOME for

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -42,7 +42,9 @@ that file — the sandbox denies
 writes to `.zcode/acp/` inside the workspace while the bridge (outside the
 sandbox) writes it on your behalf. After an allow, the backend restarts with
 the widened profile (a few seconds; the bridge auto-continues the interrupted
-task). Set `"strictGit": true` in the config to also put `.git` behind the
+task). Approvals are batched for a short window, so several pending popups
+granted in a row share ONE restart instead of each killing the others. Set
+`"strictGit": true` in the config to also put `.git` behind the
 popup.
 
 Ordinary filesystem permission failures (`Permission denied`, EACCES — a

--- a/src/handlers/sandbox-allow.ts
+++ b/src/handlers/sandbox-allow.ts
@@ -26,7 +26,7 @@ import {
 } from "../backend/sandbox.js";
 import { messages } from "../i18n.js";
 import { log, warn } from "../utils.js";
-import type { PendingTurn, ZcodeAcpServer } from "../server.js";
+import type { ZcodeAcpServer } from "../server.js";
 import { sendTextChunk } from "./io.js";
 
 /** A sandbox write-denial observed in tool output. */
@@ -99,6 +99,128 @@ export function extractSandboxDenial(text: string): SandboxDenial | null {
 const ASK_TIMEOUT_MS = 120_000;
 
 /**
+ * How long approvals collect into one restart batch (ADR-0011). The old flow
+ * restarted the backend on EVERY approval; a second popup still pending on
+ * another denied path was killed by that restart and — worse — its debounce
+ * mark permanently muted the re-ask, so the model kept hitting a bare EPERM
+ * with no way out. Approvals inside one window now share a single restart
+ * and continuation.
+ */
+export const SANDBOX_RESTART_BATCH_MS = 3000;
+
+/**
+ * Cooldown before a FAILED ask (timeout, dead channel, killed by another
+ * grant's restart) may re-ask the same path. No cooldown at all would storm
+ * on instantly-rejecting clients; the old permanent mute left the model
+ * hitting a bare EPERM with no way out. A USER decision pins the path
+ * forever instead (see handleSandboxDenial).
+ */
+const SANDBOX_ASK_RETRY_MS = 60_000;
+export { SANDBOX_ASK_RETRY_MS };
+
+/**
+ * Collects approved grants and fires ONE flush per batch window. Kept here
+ * (not in server.ts) so tests drive the batching against a stub flush
+ * without constructing a whole ZcodeAcpServer.
+ */
+export class SandboxRestartBatcher {
+  private readonly grants = new Map<string, string[]>();
+  private timer: NodeJS.Timeout | null = null;
+
+  constructor(
+    private readonly flush: (grants: Map<string, string[]>) => void,
+    private readonly batchMs: number = SANDBOX_RESTART_BATCH_MS,
+  ) {}
+
+  /** Add one approved path for a session; the first add arms the window. */
+  add(acpSid: string, grantedReal: string): void {
+    const list = this.grants.get(acpSid) ?? [];
+    if (!list.includes(grantedReal)) list.push(grantedReal);
+    this.grants.set(acpSid, list);
+    if (this.timer) return;
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      if (this.grants.size === 0) return;
+      const batch = new Map(this.grants);
+      this.grants.clear();
+      this.flush(batch);
+    }, this.batchMs);
+    this.timer.unref?.();
+  }
+}
+
+/**
+ * What flushSandboxGrants needs from the server (satisfied structurally by
+ * ZcodeAcpServer; tests stub it). Keeping the flush standalone makes the
+ * cancel-wave / continuation / kill sequencing unit-testable without a
+ * whole server.
+ */
+export interface SandboxFlushTarget {
+  cancelAllPendingTurns(): void;
+  readonly sandboxContinuations: Map<string, string>;
+  /** acpSid → live zcode session id. */
+  readonly sessionMap: Map<string, string>;
+  /** In-flight turns; entries are deleted when the turn's prompt returns. */
+  readonly pendingTurns: Map<number | string, { zcodeSid: string }>;
+  /** The backend to close; the flush nulls it (respawn stays lazy). */
+  backend: { close(): Promise<void>; readonly isDead: boolean } | null;
+}
+
+/**
+ * One batched sandbox allow-restart (ADR-0011; driven by
+ * SandboxRestartBatcher): cancel every in-flight turn — they share the
+ * backend and would otherwise hang on the dead reader — queue one
+ * continuation per session listing ALL granted paths, and close the backend
+ * once. The next ensureBackend() respawns under the widened profile
+ * (persisted config entries + bridge-lifetime once-allows).
+ */
+export function flushSandboxGrants(
+  target: SandboxFlushTarget,
+  grants: Map<string, string[]>,
+): void {
+  const m = messages();
+  const count = [...grants.values()].reduce((n, ps) => n + ps.length, 0);
+  target.cancelAllPendingTurns();
+  // Continuations ONLY for sessions with a turn still in flight: those turn
+  // loops unwind on the cancelled flag and prompt() consumes the
+  // continuation as it returns. A session whose turn already finished
+  // naturally during the batch window has nobody to consume the entry — an
+  // orphan would later hijack an UNRELATED cancelled prompt (ESC, preempt,
+  // drain gate) into an automatic "continue" round.
+  const liveZcode = new Set<string>();
+  for (const t of target.pendingTurns.values()) liveZcode.add(t.zcodeSid);
+  for (const [sid, paths] of grants) {
+    const z = target.sessionMap.get(sid);
+    if (z !== undefined && liveZcode.has(z)) {
+      target.sandboxContinuations.set(sid, m.sandboxContinuationPrompt(paths));
+    } else {
+      log(`sandbox: no in-flight turn — ${paths.length} grant(s) apply on next spawn`);
+    }
+  }
+  const dying = target.backend;
+  if (!dying || dying.isDead) {
+    // Already gone (e.g. a late approval after an earlier batch restarted):
+    // the grants live in the config / once-allows, and the next
+    // ensureBackend() spawns with them — respawning here just to close the
+    // new process again would churn.
+    log(`sandbox: backend already gone — ${count} grant(s) apply on next spawn`);
+    return;
+  }
+  // Drop the reference BEFORE the async kill: the turn loops unwind on the
+  // cancelled flag while the kill is still in flight, and prompt()'s
+  // continuation round reaches ensureBackend() the moment its first round
+  // returns — with the old reference still held it would adopt the dying
+  // backend instead of respawning under the widened profile.
+  target.backend = null;
+  log(`sandbox: restarting backend with ${count} granted path(s)`);
+  dying
+    .close()
+    .catch((e: unknown) =>
+      warn(`sandbox: backend kill failed: ${e instanceof Error ? e.message : String(e)}`),
+    );
+}
+
+/**
  * Extract the path from an ordinary filesystem-permission failure (EACCES —
  * "Permission denied"), as printed by POSIX tools (`ls: /a/b: Permission
  * denied`) and zsh redirects (`zsh:1: permission denied: /a/b`). Unlike a
@@ -163,15 +285,14 @@ function underAny(target: string, bases: string[]): boolean {
 
 /**
  * Ask the user to allow the directory behind a sandbox denial and, on
- * approval, arm the restart (kill backend, flag the turn cancelled, queue
- * the continuation prompt). Best-effort: any failure keeps the sandbox
- * exactly as it was.
+ * approval, queue the grant into the batched restart (see
+ * SandboxRestartBatcher — one restart per window, not one per approval).
+ * Best-effort: any failure keeps the sandbox exactly as it was.
  */
 export async function handleSandboxDenial(
   server: ZcodeAcpServer,
   cx: acp.AgentContext,
   acpSid: string,
-  turn: PendingTurn,
   denial: SandboxDenial,
   toolCallId: string,
 ): Promise<void> {
@@ -188,20 +309,30 @@ export async function handleSandboxDenial(
     path.isAbsolute(raw) ? raw : path.resolve(cwd ?? process.cwd(), raw),
   );
 
-  // Debounce: one ask per path per session — the model retries the same
-  // denied path and must not spam the popup; rejected/timeout asks count.
+  // Debounce: one ask per path per session. The mark carries the ask
+  // timestamp — a USER decision pins it forever (Infinity); an ask that died
+  // of the environment merely cools down for SANDBOX_ASK_RETRY_MS and may
+  // re-ask afterwards.
   let asked = server.sandboxAskedPaths.get(acpSid);
   if (!asked) {
-    asked = new Set();
+    asked = new Map();
     server.sandboxAskedPaths.set(acpSid, asked);
   }
-  if (asked.has(targetReal)) return;
-  asked.add(targetReal);
+  const prior = asked.get(targetReal);
+  if (
+    prior !== undefined &&
+    (prior === Number.POSITIVE_INFINITY || Date.now() - prior < SANDBOX_ASK_RETRY_MS)
+  ) {
+    return;
+  }
+  asked.set(targetReal, Date.now());
 
   // Island / strictGit denials are unallowable by construction (their denies
   // win the last-match). Tell the USER why instead of a doomed popup — the
-  // model only ever sees the bare EPERM in its tool output.
+  // model only ever sees the bare EPERM in its tool output. Structural:
+  // hinted once, pinned forever.
   if (underAny(targetReal, protectedSandboxPaths(server.sandboxRoots()))) {
+    asked.set(targetReal, Number.POSITIVE_INFINITY);
     await sendTextChunk(cx, acpSid, m.sandboxProtectedHint, randomUUID());
     return;
   }
@@ -212,6 +343,7 @@ export async function handleSandboxDenial(
   // the config is the only way to grant something this broad.
   const home = resolveReal(os.homedir());
   if (targetReal === "/" || targetReal === home || home.startsWith(targetReal + path.sep)) {
+    asked.set(targetReal, Number.POSITIVE_INFINITY);
     await sendTextChunk(cx, acpSid, m.sandboxOverBroadHint(targetReal), randomUUID());
     return;
   }
@@ -219,6 +351,7 @@ export async function handleSandboxDenial(
   // A persisted "永不放行" decision — VISIBLE config, never hidden bridge
   // memory: no popup, and the asked-mark above keeps later repeats silent.
   if (wsRoot && underAny(targetReal, readSandboxConfig(wsRoot).deny.map(resolveReal))) {
+    asked.set(targetReal, Number.POSITIVE_INFINITY);
     await sendTextChunk(cx, acpSid, m.sandboxDenyListedHint(targetReal), randomUUID());
     return;
   }
@@ -275,13 +408,21 @@ export async function handleSandboxDenial(
     else if (oid === "sandbox_reject_always") decision = "reject_always";
     else if (oid === "sandbox_reject_once") decision = "reject_once";
   } catch (e) {
-    // Popup failed/timed out or the client rejected the request itself —
-    // keep the sandbox unchanged; the asked-mark prevents a retry loop.
+    // Popup failed/timed out or the client channel died — including a kill
+    // by ANOTHER grant's batched restart. This ask never got a user
+    // decision; the timestamp stays as-is, so the path merely cools down
+    // (SANDBOX_ASK_RETRY_MS) and may re-ask afterwards — never permanently
+    // muted, never free to storm.
     warn(
       `sandbox: allow ask for ${targetReal} failed: ${e instanceof Error ? e.message : String(e)}`,
     );
     return;
   }
+
+  // A real outcome reached the client and came back (including an unknown
+  // optionId the user picked): the user SAW this ask — pin the debounce
+  // forever, whatever they chose.
+  asked.set(targetReal, Number.POSITIVE_INFINITY);
 
   if (decision === "reject_always") {
     // The user's denial is persisted VISIBLY into the project config — never
@@ -319,21 +460,12 @@ export async function handleSandboxDenial(
     server.sandboxOnceAllows.add(targetReal);
   }
 
-  // Arm the restart: flag the turn so the loop unwinds as cancelled instead
-  // of polling a dead reader, queue the continuation prompt, kill the
-  // backend process group (next ensureBackend() respawns with the widened
-  // profile — once-allows and the persisted config are both folded in).
-  // Other sessions' in-flight turns are cancelled too — they share this
-  // backend and would otherwise hang on the dead reader.
-  turn.cancelled = true;
-  turn.stopSent = true; // no stop pair needed: the whole process group dies
-  server.cancelAllPendingTurns();
-  server.sandboxContinuations.set(acpSid, m.sandboxContinuationPrompt(targetReal));
+  // Arm the BATCHED restart: this grant joins the current window; the flush
+  // (see SandboxRestartBatcher) cancels every pending turn, queues a
+  // continuation per session listing ALL granted paths, and closes the
+  // backend once (next ensureBackend() respawns with the widened profile —
+  // once-allows and the persisted config are both folded in).
+  server.sandboxRestartBatcher.add(acpSid, targetReal);
   await sendTextChunk(cx, acpSid, m.sandboxRestartHint(targetReal), randomUUID());
-  log(`sandbox: allow granted for ${targetReal} (${decision}) — restarting backend`);
-  try {
-    await server.ensureBackend().close();
-  } catch (e) {
-    warn(`sandbox: backend kill failed: ${e instanceof Error ? e.message : String(e)}`);
-  }
+  log(`sandbox: allow granted for ${targetReal} (${decision}) — restart batched`);
 }

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -648,16 +648,26 @@ export async function prompt(
   cx: acp.AgentContext,
   requestId: number | string,
 ): Promise<acp.PromptResponse> {
-  const result = await runPrompt(server, params, cx, requestId);
-  const continuation = server.sandboxContinuations.get(params.sessionId);
-  if (continuation && result.stopReason === "cancelled") {
+  let result = await runPrompt(server, params, cx, requestId);
+  // Sandbox-allow continuation chaining, BOUNDED: each batched restart
+  // cancels the in-flight round and queues a continuation for prompt() to
+  // consume. A LATER batch (the user approving a second popup seconds after
+  // the first window flushed) cancels the continuation round itself and
+  // queues its own continuation — with single-shot consumption that entry
+  // would be orphaned and later hijack an UNRELATED cancelled prompt (ESC,
+  // preempt, drain gate). Loop so each cancelled round adopts the newest
+  // continuation; the bound keeps a pathological cycle from chaining
+  // forever.
+  for (let hop = 0; hop < 3; hop++) {
+    const continuation = server.sandboxContinuations.get(params.sessionId);
+    if (!continuation || result.stopReason !== "cancelled") break;
     server.sandboxContinuations.delete(params.sessionId);
     // Same request, fresh round: runPrompt re-enters the whole machinery
     // (ensureBackend respawns; ensureRealSession/subscribe-recovery reloads
     // the session into it). The user's preempt/ESC during the continuation
     // still cancels it — the round registers itself in pendingTurns.
     try {
-      return await runPrompt(
+      result = await runPrompt(
         server,
         { sessionId: params.sessionId, prompt: [{ type: "text", text: continuation }] },
         cx,
@@ -680,9 +690,18 @@ export async function prompt(
         messages().sandboxContinuationFailed(err),
         randomUUID(),
       ).catch(() => undefined);
+      // A leftover continuation for THIS cancelled round is now orphaned —
+      // drop it rather than let a later cancelled prompt adopt it.
+      server.sandboxContinuations.delete(params.sessionId);
       return { stopReason: "cancelled" };
     }
   }
+  // prompt() is returning: nothing may consume this session's continuation
+  // afterwards, so unconditionally drop any entry that slipped in late
+  // (e.g. a flush timer firing inside the end_turn epilogue window, before
+  // the finally deletes the pendingTurns entry) — leaving it would let an
+  // unrelated cancelled prompt adopt it later.
+  server.sandboxContinuations.delete(params.sessionId);
   return result;
 }
 
@@ -2112,17 +2131,17 @@ export async function runEventTurn(
         // ordinary filesystem permissions.
         const denial = extractSandboxDenial(outputText);
         if (denial) {
-          await handleSandboxDenial(server, cx, acpSid, turn, denial, toolCallId);
+          await handleSandboxDenial(server, cx, acpSid, denial, toolCallId);
           if (turn.cancelled) return { stopReason: "cancelled" };
         } else {
           // No path parsed — one generic hint per session, not one per retry.
           let asked = server.sandboxAskedPaths.get(acpSid);
           if (!asked) {
-            asked = new Set();
+            asked = new Map();
             server.sandboxAskedPaths.set(acpSid, asked);
           }
-          if (!asked.has(GENERIC_HINT_KEY)) {
-            asked.add(GENERIC_HINT_KEY);
+          if (asked.get(GENERIC_HINT_KEY) === undefined) {
+            asked.set(GENERIC_HINT_KEY, Number.POSITIVE_INFINITY);
             await sendTextChunk(cx, acpSid, messages().sandboxGenericDenialHint, chunkMsgId);
           }
         }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -88,8 +88,9 @@ export interface Messages {
   sandboxRejectAlwaysPersisted: (path: string) => string;
   sandboxRejectAlwaysUnpersisted: (path: string) => string;
   sandboxRejectOnceHint: (path: string) => string;
-  /** Continuation prompt sent to the model after an allow restart. */
-  sandboxContinuationPrompt: (path: string) => string;
+  /** Continuation prompt sent to the model after an allow restart (all
+   *  paths granted in one restart batch are listed together). */
+  sandboxContinuationPrompt: (paths: string[]) => string;
   /** The chained continuation round itself failed (backend warm-up window). */
   sandboxContinuationFailed: (err: string) => string;
   sandboxRestartHint: (path: string) => string;
@@ -183,10 +184,11 @@ const zh: Messages = {
     `[已拒绝 ${p}(配置不可写,未持久化,同类写入下次仍会询问。)]`,
   sandboxRejectOnceHint: (p) =>
     `[已拒绝沙箱放行 ${p},未保存任何决定,同类写入会再次询问;如需放行,可编辑 .zcode/acp/sandbox.json 的 allow 列表(由桥写入,Agent 不可改)。]`,
-  sandboxContinuationPrompt: (p) => `[沙箱已放行 ${p},请继续刚才的任务。]`,
+  sandboxContinuationPrompt: (ps) => `[沙箱已放行 ${ps.join("、")},请继续刚才的任务。]`,
   sandboxContinuationFailed: (err) =>
     `[沙箱已放行,但自动续接失败:${err}。请重新发送一条消息(例如"继续刚才的任务")以恢复工作。]`,
-  sandboxRestartHint: (p) => `[沙箱已放行 ${p},正在重启后端以应用新权限,随后自动继续…]`,
+  sandboxRestartHint: (p) =>
+    `[沙箱已放行 ${p},数秒内将合并重启后端以应用新权限;若重启后任务未自动继续,请重新发送一条消息(例如"继续刚才的任务")。]`,
   sandboxResumedStatus: "[沙箱后端已重启,会话已恢复,自动继续刚才的任务…]",
   sandboxGenericDenialHint:
     "[沙箱拒绝了白名单外的写入。可放行目录:在弹窗中选择允许,或编辑 .zcode/acp/sandbox.json 后重启会话。]",
@@ -271,11 +273,12 @@ const en: Messages = {
     `[Rejected ${p} (config not writable, nothing persisted; the same write will ask again.)]`,
   sandboxRejectOnceHint: (p) =>
     `[Sandbox grant rejected for ${p}; no decision was saved and the same write will ask again. To grant, edit the allow list in .zcode/acp/sandbox.json (bridge-written, not agent-writable).]`,
-  sandboxContinuationPrompt: (p) => `[Sandbox granted ${p}; please continue the previous task.]`,
+  sandboxContinuationPrompt: (ps) =>
+    `[Sandbox granted ${ps.join(", ")}; please continue the previous task.]`,
   sandboxContinuationFailed: (err) =>
     `[Sandbox granted, but the automatic continuation failed: ${err}. Resend a message (e.g. "continue the previous task") to resume the work.]`,
   sandboxRestartHint: (p) =>
-    `[Sandbox granted ${p}; restarting the backend to apply the new permission, then continuing automatically…]`,
+    `[Sandbox granted ${p}; the backend restarts in a few seconds to apply it (approvals meanwhile join the same restart). If the task does not auto-continue after the restart, resend a message (e.g. "continue the previous task").]`,
   sandboxResumedStatus: "[Sandbox backend restarted, session restored; continuing the task…]",
   sandboxGenericDenialHint:
     "[The sandbox denied a write outside the whitelist. To grant a directory: choose Allow in the popup, or edit .zcode/acp/sandbox.json and restart the session.]",

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,7 @@ import {
 import { armSandboxArgv, collectSandboxWorkspaces, sandboxActive } from "./backend/sandbox.js";
 import { BackgroundTaskListener } from "./handlers/background-tasks.js";
 import { enqueueSessionSend } from "./handlers/io.js";
+import { SandboxRestartBatcher, flushSandboxGrants } from "./handlers/sandbox-allow.js";
 import { ClientRegistry } from "./remote/broadcast.js";
 import { AGENT_INFO, PROTOCOL_VERSION, log, warn } from "./utils.js";
 
@@ -116,9 +117,12 @@ export class ZcodeAcpServer {
   /**
    * Deny paths already asked about, per ACP session — the debounce behind
    * the allow popup (the model retries the same path and must not re-ask).
-   * Includes rejected/timed-out asks.
+   * Value is the ask timestamp: Infinity after a user decision or a
+   * structural hint; a FAILED ask (timeout / dead channel / killed by
+   * another grant's restart) keeps its timestamp and re-asks after the
+   * cooldown (see handleSandboxDenial).
    */
-  readonly sandboxAskedPaths = new Map<string, Set<string>>();
+  readonly sandboxAskedPaths = new Map<string, Map<string, number>>();
   /**
    * EACCES ("Permission denied") paths already hinted, per ACP session — the
    * model routinely probes unreadable directories and each real path gets
@@ -129,11 +133,21 @@ export class ZcodeAcpServer {
   readonly fsDeniedPaths = new Map<string, Set<string>>();
   /**
    * Continuation prompts waiting to run after a sandbox allow restart, per
-   * ACP session — set by the allow flow, consumed by prompt() after the
+   * ACP session — set by the batch flush, consumed by prompt() after the
    * interrupted turn unwinds (the new turn tells the model the write is now
    * permitted and to resume the task).
    */
   readonly sandboxContinuations = new Map<string, string>();
+  /**
+   * Batched sandbox allow-restarts (ADR-0011): approvals collect for one
+   * window, then flushSandboxGrants() (handlers/sandbox-allow.ts) performs a
+   * single cancel-wave + continuation + backend close. One restart per
+   * popup used to kill the sibling popups still pending on other denied
+   * paths.
+   */
+  readonly sandboxRestartBatcher = new SandboxRestartBatcher((grants) =>
+    flushSandboxGrants(this, grants),
+  );
   /**
    * Whether the current backend subprocess was spawned under sandbox-exec.
    * Process-level fact (not config wish): EPERM in tool output can only come

--- a/tests/sandbox-allow.test.ts
+++ b/tests/sandbox-allow.test.ts
@@ -22,7 +22,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   extractPermDeniedPath,
   extractSandboxDenial,
+  flushSandboxGrants,
   handleSandboxDenial,
+  SandboxRestartBatcher,
+  SANDBOX_ASK_RETRY_MS,
+  SANDBOX_RESTART_BATCH_MS,
 } from "../src/handlers/sandbox-allow.js";
 import {
   readSandboxConfig,
@@ -167,6 +171,7 @@ describe("extractPermDeniedPath", () => {
 /** Server + context stubs shared by the handleSandboxDenial cases. */
 function makeStubs(decisionOptionId: string) {
   const closed = vi.fn().mockResolvedValue(undefined);
+  const batchFlush = vi.fn();
   const server = {
     // The live process is sandboxed — the flow's process-level gate.
     backendSandboxed: true,
@@ -177,13 +182,14 @@ function makeStubs(decisionOptionId: string) {
     },
     cancelAllPendingTurns: vi.fn(),
     sandboxOnceAllows: new Set<string>(),
-    sandboxAskedPaths: new Map<string, Set<string>>(),
+    sandboxAskedPaths: new Map<string, Map<string, number>>(),
     sandboxContinuations: new Map<string, string>(),
+    sandboxRestartBatcher: new SandboxRestartBatcher(batchFlush),
   } as unknown as ZcodeAcpServer;
   const request = vi.fn().mockResolvedValue({ outcome: { optionId: decisionOptionId } });
   const notify = vi.fn().mockResolvedValue(undefined);
   const cx = { request, notify } as unknown as acp.AgentContext;
-  return { server, cx, closed, request, notify };
+  return { server, cx, closed, request, notify, batchFlush };
 }
 
 describe("handleSandboxDenial", () => {
@@ -191,14 +197,17 @@ describe("handleSandboxDenial", () => {
 
   beforeEach(() => {
     wsRoot = realpathSync(mkdtempSync(path.join(os.tmpdir(), "sb-allow-")));
+    // The restart-batching window runs on a timer; drive it deterministically.
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     rmSync(wsRoot, { recursive: true, force: true });
   });
 
-  it("always-allow persists to the project config, arms restart + continuation", async () => {
-    const { server, cx, closed, request } = makeStubs("sandbox_allow_always");
+  it("always-allow persists to the project config, arms the batched restart", async () => {
+    const { server, cx, closed, request, batchFlush } = makeStubs("sandbox_allow_always");
     server.sessionCwds.set("acp_a", wsRoot);
     const turn: PendingTurn = { zcodeSid: "sess_z", cancelled: false };
 
@@ -206,7 +215,6 @@ describe("handleSandboxDenial", () => {
       server,
       cx,
       "acp_a",
-      turn,
       {
         path: path.join(wsRoot, "..", "outside", "decoy.txt"),
         isMkdir: false,
@@ -223,22 +231,27 @@ describe("handleSandboxDenial", () => {
     expect(readSandboxConfig(wsRoot).allow).toEqual([
       path.dirname(path.join(wsRoot, "..", "outside", "decoy.txt")),
     ]);
-    expect(turn.cancelled).toBe(true);
-    expect(turn.stopSent).toBe(true);
-    expect(server.sandboxContinuations.get("acp_a")).toContain("请继续刚才的任务");
-    expect(closed).toHaveBeenCalledTimes(1);
+    // The restart is BATCHED: the grant is queued, but nothing is cancelled
+    // or closed until the window flushes (other pending popups survive).
+    expect(turn.cancelled).toBe(false);
+    expect(closed).not.toHaveBeenCalled();
+    expect(batchFlush).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(SANDBOX_RESTART_BATCH_MS);
+    expect(batchFlush).toHaveBeenCalledTimes(1);
+    const batch = batchFlush.mock.calls[0]?.[0] as Map<string, string[]>;
+    expect(batch.get("acp_a")).toEqual([
+      path.dirname(path.join(wsRoot, "..", "outside", "decoy.txt")),
+    ]);
   });
 
   it("relative denial paths resolve against the session cwd before the ask", async () => {
     const { server, cx, request } = makeStubs("sandbox_allow_once");
     server.sessionCwds.set("acp_a", wsRoot);
-    const turn: PendingTurn = { zcodeSid: "sess_z", cancelled: false };
 
     await handleSandboxDenial(
       server,
       cx,
       "acp_a",
-      turn,
       { path: "../outside/f.txt", isMkdir: false },
       "tc_rel",
     );
@@ -265,7 +278,6 @@ describe("handleSandboxDenial", () => {
       server,
       cx,
       "acp_a",
-      turn,
       { path: path.join(wsRoot, "..", "outside", "f.txt"), isMkdir: false },
       "tc_reject",
     );
@@ -291,7 +303,6 @@ describe("handleSandboxDenial", () => {
       server,
       cx,
       "acp_a",
-      turn,
       { path: path.join(wsRoot, "..", "outside", "f.txt"), isMkdir: false },
       "tc_rejectonce",
     );
@@ -322,7 +333,6 @@ describe("handleSandboxDenial", () => {
       server,
       cx,
       "acp_a",
-      turn,
       { path: path.join(wsRoot, "..", "outside", "f.txt"), isMkdir: false },
       "tc_denyhit",
     );
@@ -336,13 +346,11 @@ describe("handleSandboxDenial", () => {
   it("timeout / unknown outcome persists NOTHING (no hidden rejection memory)", async () => {
     const { server, cx } = makeStubs("some_other_client_button");
     server.sessionCwds.set("acp_a", wsRoot);
-    const turn: PendingTurn = { zcodeSid: "sess_z", cancelled: false };
 
     await handleSandboxDenial(
       server,
       cx,
       "acp_a",
-      turn,
       { path: path.join(wsRoot, "..", "outside", "f.txt"), isMkdir: false },
       "tc_unknown",
     );
@@ -360,7 +368,6 @@ describe("handleSandboxDenial", () => {
       server,
       cx,
       "acp_a",
-      turn,
       { path: path.join(os.homedir(), "sbx-echoed.txt"), isMkdir: false },
       "tc_home",
     );
@@ -380,7 +387,6 @@ describe("handleSandboxDenial", () => {
       server,
       cx,
       "acp_a",
-      turn,
       { path: path.join(wsRoot, ".zcode", "acp", "sandbox.json"), isMkdir: false },
       "tc_island",
     );
@@ -405,7 +411,6 @@ describe("handleSandboxDenial", () => {
       server,
       cx,
       "acp_a",
-      turn,
       { path: path.join(wsRoot, ".git", "index.lock"), isMkdir: false },
       "tc_git",
     );
@@ -418,7 +423,6 @@ describe("handleSandboxDenial", () => {
   it("case-variant island paths (.ZCODE/ACP) are also protected on darwin", async () => {
     const { server, cx, request, closed } = makeStubs("sandbox_allow_always");
     server.sessionCwds.set("acp_a", wsRoot);
-    const turn: PendingTurn = { zcodeSid: "sess_z", cancelled: false };
     const real = process.platform;
     Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
     try {
@@ -426,7 +430,6 @@ describe("handleSandboxDenial", () => {
         server,
         cx,
         "acp_a",
-        turn,
         { path: path.join(wsRoot, ".ZCODE", "ACP", "sandbox.json"), isMkdir: false },
         "tc_case",
       );
@@ -444,13 +447,11 @@ describe("handleSandboxDenial", () => {
     writeFileSync(target, JSON.stringify({ enabled: true, allow: [] }));
     mkdirSync(path.join(wsRoot, ".zcode", "acp"), { recursive: true });
     symlinkSync(target, sandboxConfigPath(wsRoot));
-    const turn: PendingTurn = { zcodeSid: "sess_z", cancelled: false };
 
     await handleSandboxDenial(
       server,
       cx,
       "acp_a",
-      turn,
       {
         path: "/opt/data/file.txt",
         isMkdir: false,
@@ -465,15 +466,13 @@ describe("handleSandboxDenial", () => {
   });
 
   it("once-allow keeps the root in bridge-lifetime memory only", async () => {
-    const { server, cx, closed } = makeStubs("sandbox_allow_once");
+    const { server, cx, batchFlush } = makeStubs("sandbox_allow_once");
     server.sessionCwds.set("acp_a", wsRoot);
-    const turn: PendingTurn = { zcodeSid: "sess_z", cancelled: false };
 
     await handleSandboxDenial(
       server,
       cx,
       "acp_a",
-      turn,
       {
         path: "/opt/data/file.txt",
         isMkdir: false,
@@ -483,8 +482,8 @@ describe("handleSandboxDenial", () => {
 
     expect(server.sandboxOnceAllows.has("/opt/data")).toBe(true);
     expect(readSandboxConfig(wsRoot).allow).toEqual([]);
-    expect(turn.cancelled).toBe(true);
-    expect(closed).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(SANDBOX_RESTART_BATCH_MS);
+    expect(batchFlush).toHaveBeenCalledTimes(1);
   });
 
   it("rejection leaves everything untouched (no restart, no continuation)", async () => {
@@ -496,7 +495,6 @@ describe("handleSandboxDenial", () => {
       server,
       cx,
       "acp_a",
-      turn,
       {
         path: "/opt/data/file.txt",
         isMkdir: false,
@@ -511,13 +509,11 @@ describe("handleSandboxDenial", () => {
 
   it("debounces repeat asks for the same directory within a session", async () => {
     const { server, cx, request } = makeStubs("sandbox_reject");
-    const turn: PendingTurn = { zcodeSid: "sess_z", cancelled: false };
 
     await handleSandboxDenial(
       server,
       cx,
       "acp_a",
-      turn,
       {
         path: "/opt/data/one.txt",
         isMkdir: false,
@@ -528,7 +524,6 @@ describe("handleSandboxDenial", () => {
       server,
       cx,
       "acp_a",
-      turn,
       {
         path: "/opt/data/two.txt",
         isMkdir: false,
@@ -540,8 +535,9 @@ describe("handleSandboxDenial", () => {
     expect(request).toHaveBeenCalledTimes(1);
   });
 
-  it("a failed ask keeps the sandbox unchanged", async () => {
+  it("a failed ask keeps the sandbox unchanged; the path re-asks after a cooldown", async () => {
     const closed = vi.fn().mockResolvedValue(undefined);
+    const batchFlush = vi.fn();
     const server = {
       backendSandboxed: true,
       ensureBackend: () => ({ close: closed }),
@@ -551,30 +547,161 @@ describe("handleSandboxDenial", () => {
       },
       cancelAllPendingTurns: vi.fn(),
       sandboxOnceAllows: new Set<string>(),
-      sandboxAskedPaths: new Map<string, Set<string>>(),
+      sandboxAskedPaths: new Map<string, Map<string, number>>(),
       sandboxContinuations: new Map<string, string>(),
+      sandboxRestartBatcher: new SandboxRestartBatcher(batchFlush),
     } as unknown as ZcodeAcpServer;
+    const request = vi.fn().mockRejectedValue(new Error("client gone"));
     const cx = {
-      request: vi.fn().mockRejectedValue(new Error("client gone")),
+      request,
       notify: vi.fn().mockResolvedValue(undefined),
     } as unknown as acp.AgentContext;
     const turn: PendingTurn = { zcodeSid: "sess_z", cancelled: false };
 
+    const denial = { path: "/opt/data/file.txt", isMkdir: false } as const;
+    await handleSandboxDenial(server, cx, "acp_a", denial, "tc_1");
+
+    expect(turn.cancelled).toBe(false);
+    expect(closed).not.toHaveBeenCalled();
+    // The mark is a FINITE timestamp (a cooldown), not Infinity: the ask died
+    // of the environment (timeout, dead channel, or another grant's batched
+    // restart killing it), never a user decision — a permanent mute would
+    // leave the model hitting a bare EPERM with no way out.
+    const mark = server.sandboxAskedPaths.get("acp_a")?.get("/opt/data");
+    expect(mark).toBeDefined();
+    expect(mark).not.toBe(Number.POSITIVE_INFINITY);
+
+    // Inside the cooldown an instantly-rejecting client is NOT re-asked (no
+    // popup storm); after it, the same denial may ask again.
+    await handleSandboxDenial(server, cx, "acp_a", denial, "tc_2");
+    expect(request).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(SANDBOX_ASK_RETRY_MS + 1);
+    await handleSandboxDenial(server, cx, "acp_a", denial, "tc_3");
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it("two approvals inside one window share a single restart flush", async () => {
+    const { server, cx, closed, batchFlush } = makeStubs("sandbox_allow_always");
+    server.sessionCwds.set("acp_a", wsRoot);
+
+    // Two parallel denials on different paths, both approved (the popups
+    // would previously kill each other via per-approval restarts).
     await handleSandboxDenial(
       server,
       cx,
       "acp_a",
-      turn,
-      {
-        path: "/opt/data/file.txt",
-        isMkdir: false,
-      },
-      "tc_1",
+      { path: path.join(wsRoot, "..", "outside", "a.txt"), isMkdir: false },
+      "tc_a",
+    );
+    await handleSandboxDenial(
+      server,
+      cx,
+      "acp_a",
+      { path: "/opt/other/b.txt", isMkdir: false },
+      "tc_b",
     );
 
-    expect(turn.cancelled).toBe(false);
+    // Nothing restarted yet — both grants are only queued, so sibling
+    // popups (and the turns behind them) survive the window.
     expect(closed).not.toHaveBeenCalled();
-    // The asked-mark still landed — no retry loop hammering a dead client.
-    expect(server.sandboxAskedPaths.get("acp_a")?.size).toBe(1);
+    expect(server.cancelAllPendingTurns).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(SANDBOX_RESTART_BATCH_MS);
+    expect(batchFlush).toHaveBeenCalledTimes(1);
+    const batch = batchFlush.mock.calls[0]?.[0] as Map<string, string[]>;
+    expect(batch.get("acp_a")).toEqual([
+      path.dirname(path.join(wsRoot, "..", "outside", "a.txt")),
+      "/opt/other",
+    ]);
+  });
+});
+
+describe("SandboxRestartBatcher", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("dedupes the same path and flushes once per window", () => {
+    const flush = vi.fn();
+    const batcher = new SandboxRestartBatcher(flush, 1000);
+    batcher.add("s1", "/a");
+    batcher.add("s1", "/a"); // duplicate — ignored
+    batcher.add("s1", "/b");
+    batcher.add("s2", "/c"); // another session joins the same batch
+    expect(flush).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1000);
+    expect(flush).toHaveBeenCalledTimes(1);
+    const batch = flush.mock.calls[0]?.[0] as Map<string, string[]>;
+    expect(batch.get("s1")).toEqual(["/a", "/b"]);
+    expect(batch.get("s2")).toEqual(["/c"]);
+    // The window re-arms for grants arriving after a flush.
+    batcher.add("s1", "/d");
+    vi.advanceTimersByTime(1000);
+    expect(flush).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("flushSandboxGrants", () => {
+  /** Minimal SandboxFlushTarget: a fake backend + the server state maps. */
+  function makeTarget(backend: { close(): Promise<void>; isDead: boolean } | null) {
+    const closed = vi.fn().mockResolvedValue(undefined);
+    const target = {
+      cancelAllPendingTurns: vi.fn(),
+      sandboxContinuations: new Map<string, string>(),
+      sessionMap: new Map<string, string>(),
+      pendingTurns: new Map<number | string, { zcodeSid: string }>(),
+      backend: backend === null ? null : { close: closed, isDead: backend.isDead },
+    };
+    return { target, closed };
+  }
+
+  it("cancels all turns, sets one continuation for LIVE sessions, nulls + closes the backend", () => {
+    const { target, closed } = makeTarget({ close: async () => undefined, isDead: false });
+    target.sessionMap.set("acp_a", "z1");
+    target.pendingTurns.set(1, { zcodeSid: "z1" }); // in-flight turn for acp_a
+    target.sessionMap.set("acp_b", "z2"); // session exists, turn already finished
+
+    flushSandboxGrants(
+      target,
+      new Map([
+        ["acp_a", ["/a", "/b"]],
+        ["acp_b", ["/c"]],
+      ]),
+    );
+
+    expect(target.cancelAllPendingTurns).toHaveBeenCalledTimes(1);
+    expect(target.sandboxContinuations.get("acp_a")).toContain("/a");
+    expect(target.sandboxContinuations.get("acp_a")).toContain("/b");
+    // Non-live session: NO continuation — an orphaned entry would later be
+    // consumed by an unrelated cancelled prompt (ESC/preempt) as an automatic
+    // "continue" round.
+    expect(target.sandboxContinuations.has("acp_b")).toBe(false);
+    // The reference is dropped before the async kill so a racing
+    // ensureBackend() respawns instead of adopting the dying backend.
+    expect(target.backend).toBeNull();
+    expect(closed).toHaveBeenCalledTimes(1);
+  });
+
+  it("kills the backend even for non-live sessions — grants need the respawn to apply", () => {
+    const { target, closed } = makeTarget({ close: async () => undefined, isDead: false });
+    flushSandboxGrants(target, new Map([["acp_a", ["/a"]]]));
+    expect(target.backend).toBeNull();
+    expect(closed).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the kill when the backend is already gone (no respawn-then-kill churn)", () => {
+    const { target, closed } = makeTarget({ close: async () => undefined, isDead: true });
+    target.sessionMap.set("acp_a", "z1");
+    target.pendingTurns.set(1, { zcodeSid: "z1" });
+    flushSandboxGrants(target, new Map([["acp_a", ["/a"]]]));
+    // Continuation still lands for the live session; the dead backend is
+    // left alone for the lazy respawn to handle.
+    expect(target.sandboxContinuations.get("acp_a")).toContain("/a");
+    expect(target.backend).not.toBeNull();
+    expect(closed).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Problem

When a sandboxed turn hit several out-of-whitelist write paths at once, the dynamic-allow flow failed the popups after the first one:

- **Every approval restarted the backend immediately** (`cancelAllPendingTurns` + close). A sibling popup still pending on another denied path was killed by that restart.
- **The killed ask's debounce mark stayed forever** (`sandboxAskedPaths`, "Includes rejected/timed-out asks"), permanently muting the re-ask — the model then hit a bare `EPERM` with no popup and no way out. This is the "one approval restarts, the rest fail" failure reported in practice.

## Fix (three layers)

1. **Batched restarts** — new `SandboxRestartBatcher` (3s window): approvals collect, then one flush (`flushSandboxGrants`, now a standalone exported function) performs a single cancel-wave + one continuation per session (listing ALL granted paths) + one backend close. The backend reference is dropped *before* the async kill so the continuation round's `ensureBackend()` respawns under the widened profile instead of adopting a dying backend; an already-dead backend is left alone (no respawn-then-kill churn).
2. **Timestamped ask debounce** — a user decision (or a structural hint: deny island / `$HOME` guard / deny-list / generic) pins the path forever; a *failed* ask (timeout, dead channel, killed by another grant's restart) only cools down 60s and may re-ask — no permanent mute, no popup storm on instantly-rejecting clients.
3. **Bounded continuation chaining** — `prompt()` consumes continuations in a bounded loop (≤3 hops) with cleanup on every exit path, so a second batch cancelling an in-flight continuation round chains into the newest continuation instead of orphaning an entry that would later hijack an unrelated cancelled prompt (ESC / preempt / drain gate). The flush also sets continuations ONLY for sessions with a turn still in flight.

Also: `handleSandboxDenial` dropped its unused `turn` parameter; i18n continuation prompts take a path list and the restart hint no longer unconditionally promises auto-continue; AGENTS.md / docs/SANDBOX.md updated.

## Verification

- `pnpm typecheck` / `pnpm lint` / `pnpm build` green; new + updated tests in `tests/sandbox-allow.test.ts` (batching, flush liveness/isDead sequencing, cooldown semantics) — 61/61, plus session suites 77/77.
- Adversarial review: three rounds (report in `.zcode/scratch/review-sandbox-batching.md`); all findings (orphaned-continuation hijack, no rate limit on instantly-rejecting clients, zero flush coverage, single-shot continuation consumption) resolved — final verdict Critical 0 / Important 0.
