### PR TITLE
fix: forward authoritative progress during silent turns

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -265,7 +265,7 @@ editor still has it open).
     | turn.cancelled      | -> cancelled
     | no protocol         |
     | progress (120s)     | -> check read watermark
-    |   watermark moved   | -> defer decision (alive)
+    |   watermark moved   | -> forward throttled usage -> defer (alive)
     |   frozen < 10 min   | -> defer decision
     |   frozen >= 10 min  | -> fetch reply -> end_turn
     |                       |   no reply, no output -> max_turn_requests
@@ -282,8 +282,13 @@ the turn runs; the lock is only held during finalisation. Instead the 15s
 stall-reconcile reads feed a liveness watermark
 (`contextUsed`/`totalTokenCount`/`turnCount`/`currentTurnId` from
 `session/read`): an advancing watermark proves a silently-working turn
-(typically a sub-agent) and defers the terminal decision indefinitely, while
-a watermark frozen for 10 minutes (STALE_FREEZE_MS) marks the projection as
+(typically a sub-agent) and defers the terminal decision indefinitely. Because
+an upstream ACP client can have a shorter idle deadline than this bridge, the
+bridge also forwards authoritative progress at most once per minute: a
+`usage_update` when the watermark advances, or an `in_progress` refresh for a
+known active tool while its watermark is temporarily quiet. These updates are
+state-bearing; the bridge never fabricates transcript text as a heartbeat. A
+watermark frozen for 10 minutes (STALE_FREEZE_MS) still marks the projection as
 truly stale — the turn then ends gently (reply fetch first, bounded stop only
 when nothing was ever delivered). Already-queued events win the deadline race
 and are consumed first.

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -1844,16 +1844,29 @@ export async function runEventTurn(
   // never kills: only a freeze sustained past STALE_FREEZE_MS ends the turn,
   // reply-fetch first, stop as the last resort.
   const STALE_FREEZE_MS = 600_000;
+  // Upstream ACP clients commonly enforce their own idle deadline (some use
+  // 300s). A session/read watermark can prove that ZCode is still
+  // working even when its event stream is quiet, but that proof is otherwise
+  // invisible beyond this bridge.  Forward a state-bearing update at a modest
+  // cadence so the client's deadline observes the same authoritative progress.
+  const UPSTREAM_PROGRESS_INTERVAL_MS = 60_000;
   let lastProtocolProgressAt = Date.now();
   let nextNoProgressDecisionAt = lastProtocolProgressAt + NO_PROGRESS_MS;
   let lastWatermarkAdvanceAt = Date.now();
-  let watermark = "";
+  let lastUpstreamProgressAt = Date.now();
+  let watermark: string | null = null;
+  let pendingWatermarkProgress: ZcodeProjection | null = null;
   const noteWatermark = (proj: ZcodeProjection | null): void => {
     if (!proj) return;
     const next = `${proj.contextUsed ?? 0}/${proj.totalTokenCount ?? 0}/${proj.turnCount ?? 0}/${proj.currentTurnId ?? ""}`;
+    if (watermark === null) {
+      watermark = next;
+      return;
+    }
     if (next !== watermark) {
       watermark = next;
       lastWatermarkAdvanceAt = Date.now();
+      pendingWatermarkProgress = proj;
     }
   };
   let lastStallCheck = Date.now();
@@ -1873,6 +1886,48 @@ export async function runEventTurn(
   const recordProtocolProgress = (): void => {
     lastProtocolProgressAt = Date.now();
     nextNoProgressDecisionAt = lastProtocolProgressAt + NO_PROGRESS_MS;
+    lastUpstreamProgressAt = lastProtocolProgressAt;
+    pendingWatermarkProgress = null;
+  };
+
+  const forwardAuthoritativeProgress = async (): Promise<void> => {
+    if (Date.now() - lastUpstreamProgressAt < UPSTREAM_PROGRESS_INTERVAL_MS) return;
+
+    const proj = pendingWatermarkProgress;
+    const used = proj ? proj.contextUsed || proj.totalTokenCount || 0 : 0;
+    const activeToolId = [...translator.seenToolIds].find(
+      (toolId) => !translator.finalToolIds.has(toolId),
+    );
+    if (!proj && !activeToolId) return;
+
+    try {
+      if (proj) {
+        // Reuse normal UsageDelta dispatch so a projection that reports a zero
+        // contextWindow gets the configured model limit instead of emitting an
+        // invalid/empty context bar.  The token count itself comes directly
+        // from the authoritative session/read projection.
+        await dispatchEvent(
+          server,
+          cx,
+          acpSid,
+          { kind: "UsageDelta", used, size: proj.contextWindow ?? 0 },
+          chunkMsgId,
+        );
+      } else if (activeToolId) {
+        await sendSessionUpdate(cx, acpSid, {
+          sessionUpdate: "tool_call_update",
+          toolCallId: activeToolId,
+          status: "in_progress",
+        });
+      }
+      lastUpstreamProgressAt = Date.now();
+      pendingWatermarkProgress = null;
+    } catch (e) {
+      // Liveness forwarding is best-effort.  A detached client must not kill
+      // the ZCode turn; normal event dispatch or the stale policy will still
+      // settle it through the existing paths.
+      warn(`authoritative progress update failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
   };
 
   while (true) {
@@ -1999,6 +2054,7 @@ export async function runEventTurn(
         lastStallCheck = Date.now();
         const proj = await monitor.pollOnce();
         noteWatermark(proj);
+        await forwardAuthoritativeProgress();
         if (proj?.status === "idle") {
           // A single idle probe can also fire mid-work: the backend is silent
           // during the model's thinking/connection phase and may report idle
@@ -2013,6 +2069,7 @@ export async function runEventTurn(
           }
           const proj2 = await monitor.pollOnce();
           noteWatermark(proj2);
+          await forwardAuthoritativeProgress();
           if (proj2?.status === "idle" && !listener.hasQueuedEvents()) {
             // Turn completed but the event was lost (double-confirmed).
             if (!emittedText) {

--- a/tests/stale-running-recovery.test.ts
+++ b/tests/stale-running-recovery.test.ts
@@ -160,6 +160,91 @@ describe("stall termination policy (watermark-based)", () => {
     expect(control.backend.send).not.toHaveBeenCalled();
   });
 
+  it("forwards evidence-backed progress during an ACP-visible silent window", async () => {
+    // An upstream ACP client may enforce an idle deadline shorter than this
+    // bridge's 10-minute stale-freeze budget.  The bridge's authoritative
+    // session/read probes must therefore surface real progress before that
+    // client gives up: usage when the watermark advances, or an in-progress
+    // refresh for a known active tool.  Transcript text is not a heartbeat.
+    const control = staleRunningBackend();
+    control.setWatermarkMode("advance");
+    const turn = prompt(setup(control.backend), params, cx, 4);
+    let settled = false;
+    void turn.then(() => {
+      settled = true;
+    });
+    await waitForSend(control.sendRequests);
+
+    control.emit({
+      type: "tool.updated",
+      payload: { kind: "started", toolCallId: "tool-live", toolName: "Bash" },
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    vi.mocked(cx.notify).mockClear();
+
+    // Omnigent's default ACP idle deadline is 300 seconds.  At least four
+    // throttled, state-bearing updates over this interval leave comfortable
+    // scheduling headroom without flooding clients.
+    await vi.advanceTimersByTimeAsync(301_000);
+
+    const updates = vi
+      .mocked(cx.notify)
+      .mock.calls.map(([, payload]) => (payload as { update?: acp.SessionUpdate }).update);
+    const progress = updates.filter(
+      (update) =>
+        update?.sessionUpdate === "usage_update" ||
+        (update?.sessionUpdate === "tool_call_update" && update.status === "in_progress"),
+    );
+    expect(progress.length).toBeGreaterThanOrEqual(4);
+    expect(
+      updates.some(
+        (update) =>
+          update?.sessionUpdate === "agent_message_chunk" ||
+          update?.sessionUpdate === "agent_thought_chunk",
+      ),
+    ).toBe(false);
+    expect(settled).toBe(false);
+
+    control.emit({ type: "turn.completed", payload: { resultType: "success" } });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await expect(turn).resolves.toEqual({ stopReason: "end_turn" });
+  });
+
+  it("refreshes a known active tool while its watermark is inside the stale budget", async () => {
+    // A long quiet tool may not consume tokens, so its watermark can remain
+    // frozen legitimately for part of the 10-minute grace period.  Refreshing
+    // the existing card is state-bearing and must keep a shorter upstream ACP
+    // idle deadline alive without creating transcript rows.
+    const control = staleRunningBackend();
+    control.setWatermarkMode("frozen");
+    const turn = prompt(setup(control.backend), params, cx, 5);
+    await waitForSend(control.sendRequests);
+
+    control.emit({
+      type: "tool.updated",
+      payload: { kind: "started", toolCallId: "tool-quiet", toolName: "Bash" },
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    vi.mocked(cx.notify).mockClear();
+
+    await vi.advanceTimersByTimeAsync(301_000);
+
+    const updates = vi
+      .mocked(cx.notify)
+      .mock.calls.map(([, payload]) => (payload as { update?: acp.SessionUpdate }).update);
+    const refreshes = updates.filter(
+      (update) =>
+        update?.sessionUpdate === "tool_call_update" &&
+        update.toolCallId === "tool-quiet" &&
+        update.status === "in_progress",
+    );
+    expect(refreshes.length).toBeGreaterThanOrEqual(4);
+
+    control.emit({ type: "turn.completed", payload: { resultType: "success" } });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await expect(turn).resolves.toEqual({ stopReason: "end_turn" });
+  });
+
   it("ends a watermark-frozen turn after the stale-freeze budget (no output → stop)", async () => {
     // PR #85's original goal stays: a projection stuck at `running` whose
     // watermark never advances must eventually converge instead of hanging


### PR DESCRIPTION
## Summary

- forward throttled ACP usage updates when the authoritative session/read watermark advances
- refresh an existing in-progress tool during a legitimate quiet interval
- keep the existing 10-minute frozen-watermark convergence policy unchanged
- never fabricate assistant or thought transcript chunks as heartbeats

## Root cause

zcode-acp used session/read progress only for its internal stale-turn decision. During a quiet ZCode turn, the watermark could keep advancing while no session/update reached the Primary Client. An upstream client with a shorter idle deadline could therefore time out a healthy turn even though the bridge had authoritative evidence of progress.

## TDD evidence

Before the implementation, the new 301-second advancing-watermark test failed with zero ACP progress updates:

    expected 0 to be greater than or equal to 4

The active-tool quiet-window test also failed before the second vertical slice.

## Verification

- TypeScript build
- focused stale-running recovery suite: 5/5
- full Vitest suite: 950/950
- ESLint
- stdio smoke test
- git diff --check

Fixes #109