### PR TITLE
feat(remote): per-project session history and terminal-REPL session-create (ADR-0015, ADR-0016)

### DIFF
--- a/docs/REMOTE-CLIENTS.md
+++ b/docs/REMOTE-CLIENTS.md
@@ -46,17 +46,18 @@ ACP editor ────── stdio ──────────┘
 
 ## Discovery API
 
-| Endpoint                                              | Auth     | Purpose                                                                                      |
-| ----------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------- |
-| `GET /api/health`                                     | none     | Liveness probe; `200` body `ok`.                                                             |
-| `GET /api/instances`                                  | required | Registered bridge instances. Add `?probe=1` to verify first.                                 |
-| `GET /api/instances/{id}/status`                      | required | Real-time per-session running status of one bridge.                                          |
-| `POST /api/instances/{id}/sessions/{sessionId}/close` | required | Retire a session from remote discovery — see [Closing a session](#closing-a-session).        |
-| `POST /api/instances/{id}/sessions/{sessionId}/rename` | required | Rename a session — see [Renaming a session](#renaming-a-session).                            |
-| `GET /api/quota`                                      | required | Account-level usage stats — same payload as `account/usage_stats`, no ACP connection needed. |
-| `POST /api/upgrade`                                   | required | Trigger the hub's own staleness check — see [Hub self-upgrade](#hub-self-upgrade).           |
-| `GET /api/projects`                                   | required | Known-project list (remote session-create whitelist) — see below.                            |
-| `POST /api/instances {workspacePath}`                 | required | Create (or reuse) a headless serve bridge for one known project — see below.                 |
+| Endpoint                                               | Auth     | Purpose                                                                                                         |
+| ------------------------------------------------------ | -------- | --------------------------------------------------------------------------------------------------------------- |
+| `GET /api/health`                                      | none     | Liveness probe; `200` body `ok`.                                                                                |
+| `GET /api/instances`                                   | required | Registered bridge instances. Add `?probe=1` to verify first.                                                    |
+| `GET /api/instances/{id}/status`                       | required | Real-time per-session running status of one bridge.                                                             |
+| `POST /api/instances/{id}/sessions/{sessionId}/close`  | required | Retire a session from remote discovery — see [Closing a session](#closing-a-session).                           |
+| `POST /api/instances/{id}/sessions/{sessionId}/rename` | required | Rename a session — see [Renaming a session](#renaming-a-session).                                               |
+| `GET /api/quota`                                       | required | Account-level usage stats — same payload as `account/usage_stats`, no ACP connection needed.                    |
+| `POST /api/upgrade`                                    | required | Trigger the hub's own staleness check — see [Hub self-upgrade](#hub-self-upgrade).                              |
+| `GET /api/projects`                                    | required | Known-project list (remote session-create whitelist) — see below.                                               |
+| `GET /api/projects/sessions?workspacePath=`            | required | A project's full session store incl. closed ones — see [Resuming a closed session](#resuming-a-closed-session). |
+| `POST /api/instances {workspacePath}`                  | required | Create (or reuse) a headless serve bridge for one known project — see below.                                    |
 
 HTTP auth: `Authorization: Bearer <token>` or `?token=<token>`.
 
@@ -149,7 +150,8 @@ GET  {hub}/api/projects
 POST {hub}/api/instances  body {"workspacePath":"/Users/me/proj"}
    → 200 {"id":"47073","reused":false}
    → 403 "unknown project"          (path not on the known-project list)
-   → 502 (spawn failed / bridge died during startup / never registered, 10s budget)
+   → 502 (spawn failed / bridge died during startup / never registered;
+          ~10s headless, ~20s when a terminal window is opened)
 ```
 
 - `GET /api/projects` aggregates the App's tasks index: every workspace that
@@ -159,20 +161,80 @@ POST {hub}/api/instances  body {"workspacePath":"/Users/me/proj"}
   bound, not a security boundary: a token holder can already run any
   editor-bridge session in an arbitrary cwd; the trust boundary is the
   token itself.
-- On create the hub spawns `zcode-acp serve` — a headless bridge — detached
-  in the project's cwd and waits for its heartbeat registration (it appears
-  in `/api/instances` with `origin:"serve"` within seconds). Connect with
-  the normal `WS /acp?instance=<id>` and drive it like any instance; the
-  new conversation's cwd is the project directory regardless of what
-  `session/new` sends.
-- A live serve instance for the same workspace is reused (`reused:true`)
-  instead of spawning a second one; concurrent creates join the same
-  in-flight spawn instead of racing a duplicate.
-- Lifetime: the serve bridge exists for remote interest only. It exits ~10
-  minutes after the last client detaches AND the last running turn
-  finishes — a running turn always completes, even with all clients gone.
-  Treat a vanished serve instance like any other dead bridge: re-create it
-  on demand.
+- On create the hub incubates a VISIBLE interactive REPL in the machine's
+  terminal (ADR-0016, macOS): the project's owner gets a real local CLI
+  window, and its bridge registers with the hub like any serve instance (it
+  appears in `/api/instances` with `origin:"serve"` — allow up to ~20s for
+  the GUI round-trip). Headless machines, SSH sessions, or
+  `ZCODE_ACP_HUB_TERMINAL=0` fall back to the detached `zcode-acp serve`
+  bridge of the original design. Connect with the normal
+  `WS /acp?instance=<id>` and drive it like any instance; the new
+  conversation's cwd is the project directory regardless of what
+  `session/new` sends (session roots are pinned in both surfaces).
+- **Which terminal opens** (nothing is auto-detected — the hub is a
+  background process and macOS has no default-terminal setting):
+  `ZCODE_ACP_HUB_TERMINAL_COMMAND` (a shell command; `{script}` is replaced
+  by the quoted script path) wins over `ZCODE_ACP_HUB_TERMINAL_APP`, which
+  is matched against built-in launch recipes: Terminal and iTerm run the
+  script via `open -a` (both execute `.command`); WezTerm, kitty, Alacritty,
+  and Ghostty are driven by their own CLI (`open -na <app> --args … -e …`);
+  any other name passes through to `open -a` as-is. Default: Terminal.app.
+  Warp cannot execute scripts or commands programmatically at all
+  (warpdotdev/warp#1917, #3959, #9083) — naming it warns, and the flow
+  degrades to the headless bridge after the register timeout.
+- A live serve-origin instance for the same workspace is reused
+  (`reused:true`) instead of spawning a second one; concurrent creates join
+  the same in-flight spawn instead of racing a duplicate.
+- Lifetime depends on the surface: a terminal-REPL instance lives while its
+  window lives (the owner closing it retires the bridge — re-create on
+  demand); the headless fallback exists for remote interest only and exits
+  ~10 minutes after the last client detaches AND the last running turn
+  finishes. Treat any vanished instance like a dead bridge.
+
+## Resuming a closed session
+
+Discovery lists only currently-running conversations. To find and reopen a
+PREVIOUS one — including conversations no bridge currently holds — use the
+per-project history listing (ADR-0015):
+
+```text
+GET {hub}/api/projects/sessions?workspacePath=/Users/me/proj
+  → 200 {"workspacePath":"/Users/me/proj",
+         "instance":{"id":"47073","origin":"serve"},
+         "sessions":[
+           {"sessionId":"sess_9f2…","title":"Fix login bug",
+            "cwd":"/Users/me/proj","updatedAt":"2026-09-01T10:00:00.000Z",
+            "live":false,"running":false}, …],
+         "nextCursor":{"before":1723800000000,"beforeId":"sess_9f2…"}}
+  → 400 "workspacePath required" / "invalid limit/before …"
+  → 403 "unknown project"          (path not on the known-project list)
+  → 502 (spawn failed / bridge unreachable / broken list)
+```
+
+- The listing is the project's backend session store — closed conversations
+  included. `live` marks conversations currently advertised by a bridge (the
+  same membership as discovery); `running` marks an in-flight turn. Titles
+  are the store's authoritative ones.
+- **Pagination** (projects can hold dozens of sessions): rows come
+  newest-first (`updatedAt` descending). `?limit=<n>` sets the page size
+  (default 20, max 200); the previous response's `nextCursor` splits into
+  `?before=<ms-epoch>&beforeId=<sessionId>` for the next older page — the
+  composite cursor names the exact last row, so timestamps tied across a
+  page boundary are never skipped or repeated. `nextCursor: null` means
+  there are no older sessions. Order is total (id tiebreak), so
+  paging never repeats or skips rows.
+- The first listing of a cold project incubates its serve bridge (the same
+  machinery as remote session-create; budget ~12s) — later listings and the
+  follow-up load reuse it.
+- Resume with the existing flow: `POST /api/instances` (answers
+  `reused:true` with the listing's instance), attach
+  `WS /acp?instance=<id>`, then
+  `session/load {"sessionId":"<the listed id>"}` — history replays and the
+  conversation continues with `session/prompt`.
+- `sessionId` here is the backend store id (`sess_…`), which `session/load`
+  accepts as-is (pass-through resume). The same conversation may also appear
+  in discovery under a different (ACP) id — treat discovery as the
+  live-attention surface and this listing as the browse/resume surface.
 
 ## Connecting
 

--- a/docs/REMOTE.md
+++ b/docs/REMOTE.md
@@ -68,14 +68,36 @@ ran a session (system temp trees, `~/.zcode` itself, and vanished
 directories filtered out), newest activity first. The list gates the POST —
 paths outside it get 403 (a convenience bound, not a security boundary: a
 token holder can already drive an editor-bridge session in any cwd; the
-trust boundary is the token). On create the hub
-spawns `zcode-acp serve` — a headless bridge — in the project's cwd; it
-registers back within seconds and is reachable like any other instance. A
-live serve instance for the same workspace is reused instead of re-spawned
-(`reused:true`). The serve bridge lives for remote interest only: it exits
-~10 minutes after the last client detaches and the last turn finishes, and
-its `session/new` always uses the project cwd regardless of what a client
-sends.
+trust boundary is the token). On create the hub incubates a VISIBLE
+interactive REPL in the machine's terminal (ADR-0016, macOS; headless/SSH or
+`ZCODE_ACP_HUB_TERMINAL=0` falls back to the detached headless
+`zcode-acp serve`); its bridge registers back within seconds (budget ~20s)
+and is reachable like any other instance. The hub itself is a background
+process with no terminal, so nothing is auto-detected: the target terminal
+resolves as `ZCODE_ACP_HUB_TERMINAL_COMMAND` → `ZCODE_ACP_HUB_TERMINAL_APP`
+(built-in launch recipes for Terminal, iTerm, WezTerm, kitty, Alacritty,
+Ghostty; other names pass through to `open -a`) → plain Terminal.app. Warp
+cannot execute scripts or commands programmatically (warpdotdev/warp#1917,
+#3959) and is deliberately unsupported — it degrades to the headless bridge.
+A live serve-origin instance for
+the same workspace is reused instead of re-spawned (`reused:true`). A
+terminal-REPL instance lives while its window lives; the headless fallback
+exits ~10 minutes after the last client detaches and the last turn
+finishes. Session roots are pinned to the project cwd in both surfaces
+regardless of what a client sends.
+
+**Remote session-resume** (ADR-0015). Remote clients can also reopen a
+PREVIOUS conversation of a project — including closed ones no bridge
+currently advertises (discovery lists only running conversations):
+
+```text
+GET /api/projects/sessions?workspacePath=… → {workspacePath, instance, sessions}
+```
+
+The listing is the project's full backend session store; the hub incubates
+the project's serve bridge on first listing and reuses it after. Resume is
+the normal attach flow with `session/load` on a listed backend id. See
+`docs/REMOTE-CLIENTS.md` ("Resuming a closed session") for the client contract.
 
 `sessions` lists the project's **currently running** conversations (live
 editor tabs and remote attachments) under the same ACP session ids the

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,12 +78,16 @@ function buildAllCommands() {
 }
 
 export async function main(): Promise<void> {
+  // Remote config is parsed BEFORE the server exists: a hub-incubated REPL
+  // bridge (ADR-0016) arrives with ZCODE_ACP_REMOTE_PIN_CWD=1, and the pin
+  // must hold from the very first session/new — not from the endpoint start.
+  const remoteConfigEarly = parseRemoteConfig();
   // stdout is the outbound channel to the client; stdin is inbound.
   const outbound = Writable.toWeb(process.stdout);
   const inbound = Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>;
 
   const stream = acp.ndJsonStream(outbound, inbound);
-  const server = new ZcodeAcpServer();
+  const server = new ZcodeAcpServer({ serveMode: remoteConfigEarly?.pinCwd === true });
 
   // Load all commands once at startup (they don't change mid-session).
   const allCommands = buildAllCommands();
@@ -132,9 +136,8 @@ export async function main(): Promise<void> {
   // Remote access (opt-in via ENV): serve the same app on a loopback WS/HTTP
   // endpoint and register with the machine-level hub. Failures warn and leave
   // the stdio link untouched.
-  const remoteConfig = parseRemoteConfig();
-  if (remoteConfig) {
-    remoteHandle = await startRemoteEndpoint(server, app, remoteConfig);
+  if (remoteConfigEarly) {
+    remoteHandle = await startRemoteEndpoint(server, app, remoteConfigEarly);
   }
 }
 

--- a/src/remote/config.ts
+++ b/src/remote/config.ts
@@ -15,6 +15,16 @@
  *                                 containerized tunnel agent)
  *   ZCODE_ACP_REMOTE_PORT=8378    bridge endpoint start port (auto-increment
  *                                 when taken; loopback only)
+ *   ZCODE_ACP_REMOTE_ORIGIN=serve registration origin override (ADR-0016: a
+ *                                 REPL incubated by the hub in a visible
+ *                                 terminal registers as "serve" so the
+ *                                 per-workspace dedupe treats it as THE
+ *                                 project's remote bridge)
+ *   ZCODE_ACP_REMOTE_PIN_CWD=1    pin every session root to the process cwd
+ *                                 (bridge-wide serveMode; ADR-0016: keeps
+ *                                 ADR-0014's whitelist semantics for a
+ *                                 hub-incubated REPL, whose bridge would
+ *                                 otherwise trust a remote client's cwd)
  */
 
 import { warn } from "../utils.js";
@@ -31,6 +41,14 @@ export interface RemoteConfig {
    * instances per workspace and label them for remote clients.
    */
   origin: "editor" | "serve";
+  /**
+   * Pin every session root to the process cwd (serveMode for the bridge).
+   * Set by the hub when it incubates a REPL in a visible terminal
+   * (ADR-0016): the REPL bridge is a stdio bridge by lifecycle, but its
+   * sessions must obey ADR-0014's whitelist semantics — a remote client
+   * must not steer them into arbitrary directories.
+   */
+  pinCwd: boolean;
 }
 
 export const DEFAULT_HUB_PORT = 8377;
@@ -64,7 +82,8 @@ export function parseRemoteConfig(env: NodeJS.ProcessEnv = process.env): RemoteC
     hubPort: parsePort(env.ZCODE_ACP_HUB_PORT, DEFAULT_HUB_PORT, "ZCODE_ACP_HUB_PORT"),
     hubHost: (env.ZCODE_ACP_HUB_HOST ?? "").trim() || DEFAULT_HUB_HOST,
     bridgePort: parsePort(env.ZCODE_ACP_REMOTE_PORT, DEFAULT_BRIDGE_PORT, "ZCODE_ACP_REMOTE_PORT"),
-    origin: "editor",
+    origin: (env.ZCODE_ACP_REMOTE_ORIGIN ?? "").trim() === "serve" ? "serve" : "editor",
+    pinCwd: (env.ZCODE_ACP_REMOTE_PIN_CWD ?? "").trim() === "1",
   };
 }
 
@@ -81,5 +100,6 @@ export function parseHubConfig(env: NodeJS.ProcessEnv = process.env): RemoteConf
     hubHost: (env.ZCODE_ACP_HUB_HOST ?? "").trim() || DEFAULT_HUB_HOST,
     bridgePort: parsePort(env.ZCODE_ACP_REMOTE_PORT, DEFAULT_BRIDGE_PORT, "ZCODE_ACP_REMOTE_PORT"),
     origin: "editor",
+    pinCwd: false,
   };
 }

--- a/src/remote/endpoint.ts
+++ b/src/remote/endpoint.ts
@@ -30,6 +30,7 @@ import type { ZcodeAcpServer } from "../server.js";
 import { AGENT_INFO, log, warn } from "../utils.js";
 import { createFileHandler } from "./file-endpoint.js";
 import { createSessionCloseHandler } from "./session-close-endpoint.js";
+import { createSessionListHandler } from "./session-list-endpoint.js";
 import { createSessionRenameHandler } from "./session-rename-endpoint.js";
 import { createStatusHandler, runningZcodeSids, type SessionRunStatus } from "./status-endpoint.js";
 import type { RemoteConfig } from "./config.js";
@@ -204,6 +205,7 @@ export async function startRemoteEndpoint(
   const statusHandler = createStatusHandler(server);
   const sessionCloseHandler = createSessionCloseHandler(server);
   const sessionRenameHandler = createSessionRenameHandler(server);
+  const sessionListHandler = createSessionListHandler(server);
 
   const httpServer = createServer((req, res) => {
     const path = new URL(req.url ?? "/", "http://127.0.0.1").pathname;
@@ -214,6 +216,7 @@ export async function startRemoteEndpoint(
     else if (path === "/status") statusHandler(req, res);
     else if (closeMatch) sessionCloseHandler(req, res, closeMatch[1]!);
     else if (renameMatch) sessionRenameHandler(req, res, renameMatch[1]!);
+    else if (path === "/sessions") sessionListHandler(req, res);
     else {
       res.writeHead(404, { "Content-Type": "text/plain" });
       res.end("not found");

--- a/src/remote/hub-server.ts
+++ b/src/remote/hub-server.ts
@@ -25,7 +25,7 @@
 
 import { spawn, type ChildProcess } from "node:child_process";
 import { createHash, timingSafeEqual } from "node:crypto";
-import { realpathSync } from "node:fs";
+import { chmodSync, mkdtempSync, realpathSync, writeFileSync } from "node:fs";
 import type { Dirent } from "node:fs";
 import { readdir, readFile, stat } from "node:fs/promises";
 import {
@@ -36,9 +36,11 @@ import {
   type Server,
   type ServerResponse,
 } from "node:http";
+import { EventEmitter } from "node:events";
 import net from "node:net";
 import path from "node:path";
 import process from "node:process";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
 import { WebSocket, WebSocketServer, type RawData } from "ws";
@@ -77,10 +79,17 @@ export interface HubOptions {
    */
   projectsDbPath?: string;
   /**
-   * Override how POST /api/instances spawns the headless serve bridge (tests
-   * inject a fake). Default: this node + this package's dist/cli.js.
+   * Override how the remote session-create endpoints spawn a bridge (tests
+   * inject a fake). Default: this node + this package's dist/cli.js — an
+   * interactive REPL in a visible terminal for session-create ("repl"),
+   * a detached headless serve bridge for background queries ("serve").
    */
-  spawnServe?: (opts: { cwd: string; env: NodeJS.ProcessEnv }) => ChildProcess;
+  spawnServe?: (opts: {
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+    /** "repl" = visible terminal (session-create); "serve" = detached headless. */
+    kind: "repl" | "serve";
+  }) => ChildProcess | Promise<ChildProcess>;
 }
 
 export interface HubHandle {
@@ -191,14 +200,206 @@ function parseOrigin(raw: unknown): "editor" | "serve" {
 }
 
 /**
- * Default serve-bridge spawner (remote session-create, ADR-0014): this node
- * running this package's cli.js `serve` subcommand, detached in the project's
- * cwd with the ENV the bridge needs to find its way back to this hub. Mirrors
- * endpoint.ts's spawnHub: detached + unref'd (the hub must not own its life),
- * stderr piped and tail-logged so startup failures surface instead of
- * silently vanishing with an "ignore" pipe.
+ * The REPL-in-a-terminal incubation budget (ADR-0016): a visible terminal
+ * adds a GUI round-trip (Terminal app launch, REPL boot, its bridge child)
+ * ahead of the hub registration — double the headless budget.
  */
-function defaultSpawnServe(opts: { cwd: string; env: NodeJS.ProcessEnv }): ChildProcess {
+const REPL_REGISTER_TIMEOUT_MS = 20_000;
+/** `open -a <terminal>` must answer fast or the incubation falls back. */
+const TERMINAL_OPEN_TIMEOUT_MS = 3_000;
+/** Set ZCODE_ACP_HUB_TERMINAL=0 to keep remote session-create headless. */
+const TERMINAL_GATE_ENV = "ZCODE_ACP_HUB_TERMINAL";
+
+/** Single-quote for sh: ' → '\'' . */
+function shQuote(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+/** How the hub hands the .command script to a terminal (ADR-0016). */
+export type TerminalLaunch =
+  /** ZCODE_ACP_HUB_TERMINAL_COMMAND: a shell command; `{script}` (if present)
+   * is replaced by the quoted script path, else the path is appended. */
+  | { kind: "shell"; command: string }
+  /** `.command`-executing apps (Terminal, iTerm): `open -a <app> <script>`. */
+  | { kind: "openApp"; app: string }
+  /** Terminals driven by their own CLI: `open -na <app> --args <args> <sh>
+   * <script>` — args come first, the script program is appended. */
+  | { kind: "openAppArgs"; app: string; args: string[] };
+
+/**
+ * Built-in launch recipes for well-known macOS terminals (ADR-0016 §5). Each
+ * mechanism is the app's documented, verified way to run a command in a fresh
+ * window: Terminal and iTerm execute `.command` files handed over via open;
+ * WezTerm's `start --` runs an alternative program (wezterm.org/cli/start.html);
+ * kitty takes the program as normal positional arguments
+ * (sw.kovidgoyal.net/kitty/invocation); Alacritty and Ghostty support the
+ * common `-e` flag. The script does its own `cd`, so no per-app cwd flags.
+ * Warp is deliberately ABSENT — it cannot execute `.command` files (#1917)
+ * and has no programmatic command execution at all (URI scheme opens dirs
+ * only; still an open request in #3959/#9083). Hyper is absent for the same
+ * reason (#3677).
+ */
+const TERMINAL_APP_LAUNCHERS: Record<string, TerminalLaunch> = {
+  terminal: { kind: "openApp", app: "Terminal" },
+  apple_terminal: { kind: "openApp", app: "Terminal" },
+  iterm: { kind: "openApp", app: "iTerm" },
+  iterm2: { kind: "openApp", app: "iTerm" },
+  wezterm: { kind: "openAppArgs", app: "WezTerm", args: ["start", "--"] },
+  kitty: { kind: "openAppArgs", app: "kitty", args: [] },
+  alacritty: { kind: "openAppArgs", app: "Alacritty", args: ["-e"] },
+  ghostty: { kind: "openAppArgs", app: "Ghostty", args: ["-e"] },
+};
+
+/**
+ * Pick how to open the REPL script. The hub is a background daemon — its env
+ * carries no terminal and macOS has no default-terminal setting — so nothing
+ * is detected. Priority: the explicit command template (the universal escape
+ * hatch) → a built-in launcher by app name (aliases are case- and
+ * `.app`-suffix-insensitive) → plain Terminal.app. Warp gets a special warning
+ * because it accepts the open but cannot run the script; any other unmatched
+ * name passes through to `open -a` unchanged.
+ */
+export function resolveTerminalLaunch(env: NodeJS.ProcessEnv): {
+  launch: TerminalLaunch;
+  warning?: string;
+} {
+  const command = (env.ZCODE_ACP_HUB_TERMINAL_COMMAND ?? "").trim();
+  if (command) return { launch: { kind: "shell", command } };
+  const raw = (env.ZCODE_ACP_HUB_TERMINAL_APP ?? "").trim();
+  const name = raw.toLowerCase().replace(/\.app$/, "");
+  const launcher = TERMINAL_APP_LAUNCHERS[name];
+  if (launcher) return { launch: launcher };
+  if (name === "warp") {
+    return {
+      launch: { kind: "openApp", app: raw || "Warp" },
+      warning:
+        "Warp cannot execute .command scripts (warpdotdev/warp#1917) and has no " +
+        "programmatic command execution (warpdotdev/warp#3959, #9083) — the window " +
+        "will idle and session-create falls back to a headless bridge after the " +
+        "register timeout; set ZCODE_ACP_HUB_TERMINAL_COMMAND to drive Warp another way",
+    };
+  }
+  return { launch: { kind: "openApp", app: raw || "Terminal" } };
+}
+
+/**
+ * The .command script body. The incubation env MUST be embedded as exports:
+ * the script runs in a fresh shell spawned by the terminal app, which
+ * inherits launchd's environment — NOT the hub's — so without them the REPL
+ * would boot as a plain local session and never register back (the
+ * incubation would stall into its timeout). Everything ZCODE_ACP_* travels;
+ * values are single-quoted.
+ */
+export function terminalReplScript(cwd: string, cliJs: string, env: NodeJS.ProcessEnv): string {
+  const exports = Object.keys(env)
+    .filter((k) => k.startsWith("ZCODE_ACP_"))
+    .map((k) => `export ${k}=${shQuote(String(env[k]))}`);
+  return [
+    "#!/bin/sh",
+    `# Hub-incubated REPL session (ADR-0016): closing this window ends the bridge.`,
+    `cd ${shQuote(cwd)} || exit 1`,
+    ...exports,
+    `exec ${shQuote(process.execPath)} ${shQuote(cliJs)}`,
+    "",
+  ].join("\n");
+}
+
+/**
+ * Spawn session-create as a VISIBLE interactive REPL (ADR-0016): write a
+ * throwaway .command script (`cd <project> && exec node cli.js`) and hand it
+ * to a terminal (resolveTerminalLaunch) — the user gets a real terminal
+ * window running the local CLI instead of an invisible daemon. The REPL's
+ * bridge child inherits the remote ENV, so the incubation registers exactly
+ * like a serve bridge; closing the window ends the bridge (its lifetime
+ * follows the terminal, the ADR-0001 anchor). Returns null when a terminal
+ * can't be used — platform, gated off via ZCODE_ACP_HUB_TERMINAL, or the
+ * open failing (headless/SSH) — and the caller falls back to the detached
+ * serve spawn.
+ */
+async function spawnTerminalRepl(opts: {
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+}): Promise<ChildProcess | null> {
+  if (process.platform !== "darwin") return null;
+  const gate = (process.env[TERMINAL_GATE_ENV] ?? "").trim().toLowerCase();
+  if (["0", "false", "off"].includes(gate)) return null;
+  const cliJs = fileURLToPath(new URL("../cli.js", import.meta.url));
+  const script = path.join(mkdtempSync(path.join(tmpdir(), "zcode-acp-term-")), "repl.command");
+  writeFileSync(script, terminalReplScript(opts.cwd, cliJs, opts.env), { mode: 0o700 });
+  chmodSync(script, 0o700);
+  const { launch, warning } = resolveTerminalLaunch(process.env);
+  if (warning) warn(`hub: ${warning}`);
+  let argv: string[];
+  if (launch.kind === "shell") {
+    const rendered = launch.command.includes("{script}")
+      ? launch.command.replace("{script}", shQuote(script))
+      : `${launch.command} ${shQuote(script)}`;
+    argv = ["/bin/sh", "-c", rendered];
+  } else if (launch.kind === "openApp") {
+    argv = ["open", "-a", launch.app, script];
+  } else {
+    argv = ["open", "-na", launch.app, "--args", ...launch.args, "/bin/sh", script];
+  }
+  // Async spawn — spawnSync would freeze the hub's event loop (WS proxying,
+  // heartbeats for every live bridge) for up to the full timeout while a GUI
+  // app cold-starts.
+  const errChunks: Buffer[] = [];
+  const opened = await new Promise<{ error?: Error; timedOut?: boolean; code?: number | null }>(
+    (resolve) => {
+      const child = spawn(argv[0]!, argv.slice(1), { stdio: ["ignore", "ignore", "pipe"] });
+      child.stderr?.on("data", (c: Buffer) => errChunks.push(c));
+      const timer = setTimeout(() => {
+        child.kill();
+        resolve({ timedOut: true });
+      }, TERMINAL_OPEN_TIMEOUT_MS);
+      child.once("error", (e: Error) => {
+        clearTimeout(timer);
+        resolve({ error: e });
+      });
+      child.once("exit", (code: number | null) => {
+        clearTimeout(timer);
+        resolve({ code });
+      });
+    },
+  );
+  if (opened.error || opened.timedOut || opened.code !== 0) {
+    const detail = opened.timedOut
+      ? `timed out after ${TERMINAL_OPEN_TIMEOUT_MS}ms`
+      : (opened.error?.message ?? Buffer.concat(errChunks).toString("utf8").trim()) ||
+        `exit ${opened.code ?? "?"}`;
+    warn(`hub: no terminal window for ${opts.cwd} (${detail}) — falling back to a headless bridge`);
+    return null;
+  }
+  log(`hub: opened a Terminal REPL for ${opts.cwd}`);
+  // `open` has already exited; incubation only needs a child that reads as
+  // alive until the bridge registers. A window that dies early surfaces as
+  // the register timeout — the terminal window itself shows the reason.
+  const fake = new EventEmitter() as ChildProcess & {
+    pid: number;
+    exitCode: number | null;
+    signalCode: string | null;
+  };
+  fake.pid = -1;
+  fake.exitCode = null;
+  fake.signalCode = null;
+  return fake as unknown as ChildProcess;
+}
+
+/**
+ * Default bridge spawner for the remote session-create endpoints: a visible
+ * terminal REPL for session-create (ADR-0016, macOS + not gated off), a
+ * detached headless serve bridge otherwise (the ADR-0014 original — also the
+ * fallback whenever the terminal window can't be opened).
+ */
+async function defaultSpawnServe(opts: {
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  kind: "repl" | "serve";
+}): Promise<ChildProcess> {
+  if (opts.kind === "repl") {
+    const viaTerminal = await spawnTerminalRepl(opts);
+    if (viaTerminal) return viaTerminal;
+  }
   // dist/remote/hub-server.js → dist/cli.js (one level up).
   const cliJs = fileURLToPath(new URL("../cli.js", import.meta.url));
   const child = spawn(process.execPath, [cliJs, "serve"], {
@@ -268,6 +469,65 @@ function portOpen(port: number, timeoutMs: number): Promise<boolean> {
     socket.once("timeout", () => done(false));
     socket.once("error", () => done(false));
     socket.connect(port, "127.0.0.1");
+  });
+}
+
+/** Body cap for a bridge's GET /sessions answer (session lists are small). */
+const MAX_SESSION_LIST_BYTES = 4 * 1024 * 1024;
+/**
+ * A cold bridge must spawn its backend before the store answers, so the
+ * budget covers an incubation plus one session/list round-trip (the bridge
+ * gives its own query 15s).
+ */
+const SESSION_LIST_TIMEOUT_MS = 12_000;
+
+/**
+ * Fetch a bridge's GET /sessions payload (ADR-0015), forwarding the
+ * pagination query ("?limit=..&before=.."). Resolves with the parsed JSON;
+ * rejects on transport failure, a non-200 answer, truncation, or a non-JSON
+ * body — the caller turns every rejection into a 502.
+ */
+function fetchBridgeSessions(
+  port: number,
+  query = "",
+): Promise<{ sessions?: unknown[]; nextCursor?: unknown }> {
+  return new Promise((resolve, reject) => {
+    const req = httpGet({ host: "127.0.0.1", port, path: `/sessions${query}` }, (up) => {
+      if ((up.statusCode ?? 500) !== 200) {
+        up.resume();
+        reject(new Error(`bridge answered ${up.statusCode ?? "?"}`));
+        return;
+      }
+      const chunks: Buffer[] = [];
+      let size = 0;
+      up.on("data", (c: Buffer) => {
+        size += c.length;
+        if (size > MAX_SESSION_LIST_BYTES) {
+          up.destroy();
+          reject(new Error("bridge session list too large"));
+          return;
+        }
+        chunks.push(c);
+      });
+      up.on("end", () => {
+        try {
+          resolve(
+            JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+              sessions?: unknown[];
+              nextCursor?: unknown;
+            },
+          );
+        } catch {
+          reject(new Error("bridge returned an invalid session list"));
+        }
+      });
+      up.on("error", () => reject(new Error("bridge session list failed")));
+    });
+    req.on("error", () => reject(new Error("bridge unreachable")));
+    req.setTimeout(SESSION_LIST_TIMEOUT_MS, () => {
+      req.destroy();
+      reject(new Error("bridge session list timed out"));
+    });
   });
 }
 
@@ -379,7 +639,11 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
    * findServe check (check-then-act). Check-then-set is one synchronous
    * block, so requests can only ever observe "no entry" one at a time.
    */
-  const serveIncubations = new Map<string, Promise<{ id: string; reused: boolean }>>();
+  // Single-flight incubation per workspace (see joinIncubation below).
+  const serveIncubations = new Map<
+    string,
+    { kind: "repl" | "serve"; promise: Promise<{ id: string; reused: boolean }> }
+  >();
 
   /** The live serve instance for a workspace, if any (per-workspace dedupe). */
   const findServeInstance = (workspacePath: string): InstanceEntry | undefined => {
@@ -402,19 +666,25 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
   };
 
   /**
-   * Spawn a serve bridge and poll until it registers (or fails fast on child
-   * exit / timeout). Shared by every POST /api/instances currently incubating
-   * this workspace — all joiners see the same outcome.
+   * Spawn a bridge and poll until it registers (or fails fast on child exit /
+   * timeout). Shared by every incubating endpoint for this workspace — all
+   * joiners see the same outcome. Kind picks the spawn surface: "repl" opens
+   * a visible terminal (remote session-create, ADR-0016), "serve" the
+   * detached headless bridge (background listing, ADR-0015).
    */
-  const incubateServe = async (workspacePath: string): Promise<{ id: string; reused: boolean }> => {
+  const incubateServe = async (
+    workspacePath: string,
+    kind: "repl" | "serve",
+  ): Promise<{ id: string; reused: boolean }> => {
     // Async spawn failures (ENOENT — the dir vanished between the whitelist
     // check and the spawn) arrive as an 'error' event with exitCode still
-    // null; without this flag the poll burns the full 10s budget.
+    // null; without this flag the poll burns the full budget.
     let spawnError: Error | null = null;
     let child: ChildProcess;
     try {
-      child = spawnServe({
+      child = await spawnServe({
         cwd: workspacePath,
+        kind,
         env: {
           ...process.env,
           ZCODE_ACP_REMOTE: "1",
@@ -423,6 +693,13 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
           // Parity with the bridge-side spawnHub: the serve child may have to
           // (re)spawn the hub itself, and must bind the same configured host.
           ZCODE_ACP_HUB_HOST: host,
+          // ADR-0016: the incubated bridge registers as THIS project's serve
+          // bridge (the hub's per-workspace dedupe matches it) and pins its
+          // session roots to the project cwd, so ADR-0014's whitelist
+          // semantics survive the visible-terminal lifecycle. The detached
+          // serve path ignores both (it hardcodes origin/serveMode itself).
+          ZCODE_ACP_REMOTE_ORIGIN: "serve",
+          ZCODE_ACP_REMOTE_PIN_CWD: "1",
         },
       });
       child.once("error", (e: Error) => {
@@ -432,14 +709,19 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
       warn(`hub: serve spawn failed: ${e instanceof Error ? e.message : String(e)}`);
       throw new Error("serve bridge spawn failed");
     }
-    log(`hub: spawned serve bridge for ${workspacePath} (pid ${child.pid})`);
-    const deadline = Date.now() + SERVE_REGISTER_TIMEOUT_MS;
+    log(
+      `hub: spawned ${kind === "repl" ? "terminal REPL" : "serve bridge"} for ${workspacePath} (pid ${child.pid})`,
+    );
+    const budget = kind === "repl" ? REPL_REGISTER_TIMEOUT_MS : SERVE_REGISTER_TIMEOUT_MS;
+    const deadline = Date.now() + budget;
     for (;;) {
       await new Promise<void>((resolve) => setTimeout(resolve, SERVE_REGISTER_POLL_MS).unref?.());
       const entry = findServeInstance(workspacePath);
       if (entry) return { id: entry.id, reused: false };
       // The child dying is the honest fast-fail (missing cwd perms, port
-      // exhaustion, crash) — without this check the loop burns the full 10s.
+      // exhaustion, crash) — without this check the loop burns the full budget.
+      // (A terminal REPL reports through the window itself, so only the
+      // timeout applies there.)
       if (spawnError || child.exitCode !== null || child.signalCode !== null) {
         warn(`hub: serve bridge for ${workspacePath} exited during startup`);
         throw new Error("serve bridge exited during startup");
@@ -449,6 +731,37 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
         throw new Error("serve bridge did not register in time");
       }
     }
+  };
+
+  /**
+   * Single-flight incubation per workspace: concurrent endpoint calls join one
+   * spawn instead of racing duplicates. A "serve" caller (the listing) joins
+   * ANY in-flight incubation — the outcome it waits for is "a serve bridge is
+   * registered", whichever surface spawned it. A "repl" caller (session-
+   * create) joins only another repl: the visible window IS the feature
+   * (ADR-0016), so it never piggybacks on an invisible listing spawn.
+   */
+  const joinIncubation = (
+    workspacePath: string,
+    kind: "repl" | "serve",
+  ): Promise<{ id: string; reused: boolean }> => {
+    const inflight = serveIncubations.get(workspacePath);
+    if (inflight && (inflight.kind === kind || kind === "serve")) {
+      log(`hub: joining the incubating serve bridge for ${workspacePath}`);
+      return inflight.promise;
+    }
+    const promise = incubateServe(workspacePath, kind);
+    serveIncubations.set(workspacePath, { kind, promise });
+    // Drop the entry once settled (identity-checked — a newer incubation may
+    // already have replaced it). The catch keeps the DERIVED promise handled;
+    // the original is awaited by its creating request.
+    promise
+      .catch(() => undefined)
+      .finally(() => {
+        const current = serveIncubations.get(workspacePath);
+        if (current && current.promise === promise) serveIncubations.delete(workspacePath);
+      });
+    return promise;
   };
 
   /**
@@ -632,15 +945,105 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
       res.end(JSON.stringify(projects));
       return;
     }
-    // POST /api/instances — create (or reuse) a headless serve bridge for one
-    // known project. The hub spawns `zcode-acp serve` detached in the project
-    // cwd and waits for its heartbeat registration; the bridge lives its own
-    // idle-timed life afterwards (ADR-0014). Dedupe: one serve instance per
-    // workspace — an existing live one is reused, and concurrent POSTs join
-    // the same in-flight incubation instead of double-spawning. Accepted
-    // bound: a hub restart clears the instance table, so a POST inside the
-    // bridges' ≤10s re-registration window may incubate a duplicate —
-    // harmless (both serve, future POSTs dedupe, an idle one exits in 10min).
+    // GET /api/projects/sessions?workspacePath=… — the project's backend
+    // session store (ADR-0015), including closed ones no bridge advertises.
+    // Discovery stays running-scoped by design; this is the deliberate
+    // "resume an old session" surface. PAGINATED (long-lived projects hold
+    // dozens of sessions): ?limit= (default 20, max 200) rows newest-first,
+    // ?before=<ms> resumes an older page; the answer's nextCursor (null on
+    // the last page) feeds the next call. Same whitelist gate as
+    // POST /api/instances (the check bounds which cwds may incubate a serve
+    // bridge), then the ADR-0014 incubation ensures a serve bridge and the
+    // query proxies to its loopback /sessions. The answer wraps the bridge
+    // payload with the instance a list-then-load client attaches to
+    // (session/load reuses the same one).
+    if (url.pathname === "/api/projects/sessions" && req.method === "GET") {
+      if (!authorized(req, url, token)) {
+        res.writeHead(401, { "Content-Type": "text/plain" });
+        res.end("unauthorized");
+        return;
+      }
+      const workspacePath = (url.searchParams.get("workspacePath") ?? "").trim();
+      if (!workspacePath) {
+        res.writeHead(400, { "Content-Type": "text/plain" });
+        res.end("workspacePath required");
+        return;
+      }
+      // Pagination forwarding: validate here so a bad page request fails
+      // fast with 400 instead of surfacing as the bridge's 502.
+      const pagination = new URLSearchParams();
+      for (const name of ["limit", "before"]) {
+        const raw = url.searchParams.get(name);
+        if (raw === null) continue;
+        if (!/^\d+$/.test(raw) || (name === "limit" && parseInt(raw, 10) < 1)) {
+          res.writeHead(400, { "Content-Type": "text/plain" });
+          res.end(`invalid ${name} — positive integer expected`);
+          return;
+        }
+        pagination.set(name, raw);
+      }
+      const beforeId = url.searchParams.get("beforeId");
+      if (beforeId !== null) {
+        if (!/^[\w.:-]+$/.test(beforeId)) {
+          res.writeHead(400, { "Content-Type": "text/plain" });
+          res.end("invalid beforeId — session id expected");
+          return;
+        }
+        pagination.set("beforeId", beforeId);
+      }
+      const known = await listKnownWorkspaces(projectsDbPath);
+      if (!known.some((p) => p.workspacePath === workspacePath)) {
+        res.writeHead(403, { "Content-Type": "text/plain" });
+        res.end("unknown project");
+        return;
+      }
+      try {
+        let entry = findServeInstance(workspacePath);
+        if (!entry) {
+          // "serve": a background listing must not pop a terminal window
+          // (ADR-0015) — only session-create does (ADR-0016). joinIncubation
+          // makes concurrent listings (and a listing racing a create) share
+          // one spawn instead of doubling bridges.
+          await joinIncubation(workspacePath, "serve");
+          entry = findServeInstance(workspacePath);
+        }
+        if (!entry) {
+          throw new Error("serve bridge did not register");
+        }
+        const qs = pagination.toString();
+        const payload = await fetchBridgeSessions(entry.port, qs ? `?${qs}` : "");
+        res.writeHead(200, {
+          "Content-Type": "application/json",
+          "Cache-Control": "no-store",
+        });
+        res.end(
+          JSON.stringify({
+            workspacePath,
+            instance: { id: entry.id, origin: entry.origin },
+            ...(Array.isArray(payload.sessions)
+              ? { sessions: payload.sessions }
+              : { sessions: [] }),
+            nextCursor: payload.nextCursor ?? null,
+          }),
+        );
+      } catch (e) {
+        res.writeHead(502, { "Content-Type": "text/plain" });
+        res.end(e instanceof Error ? e.message : "session list failed");
+      }
+      return;
+    }
+    // POST /api/instances — create (or reuse) a bridge for one known project.
+    // Session-create incubates a VISIBLE interactive REPL in the user's
+    // terminal (ADR-0016, macOS; ZCODE_ACP_HUB_TERMINAL=0 / headless falls
+    // back to the detached `zcode-acp serve` of ADR-0014). The hub waits for
+    // the bridge's heartbeat registration; the bridge lives its own life
+    // afterwards (a terminal REPL until the window closes, a serve bridge on
+    // its idle timer). Dedupe: one serve-origin instance per workspace — an
+    // existing live one is reused, and concurrent POSTs join the same
+    // in-flight incubation instead of double-spawning. Accepted bound: a hub
+    // restart clears the instance table, so a POST inside the bridges' ≤10s
+    // re-registration window may incubate a duplicate — harmless (both serve,
+    // future POSTs dedupe, an idle one exits in 10min).
     if (url.pathname === "/api/instances" && req.method === "POST") {
       if (!authorized(req, url, token)) {
         res.writeHead(401, { "Content-Type": "text/plain" });
@@ -668,23 +1071,11 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
         res.end(JSON.stringify({ id: existing.id, reused: true }));
         return;
       }
-      let incubation = serveIncubations.get(workspacePath);
-      if (!incubation) {
-        incubation = incubateServe(workspacePath);
-        serveIncubations.set(workspacePath, incubation);
-        // Drop the entry once settled (identity-checked — a newer incubation
-        // may already have replaced it). The catch keeps the DERIVED promise
-        // handled; the original is awaited by its creating POST.
-        incubation
-          .catch(() => undefined)
-          .finally(() => {
-            if (serveIncubations.get(workspacePath) === incubation) {
-              serveIncubations.delete(workspacePath);
-            }
-          });
-      } else {
-        log(`hub: joining the incubating serve bridge for ${workspacePath}`);
-      }
+      // Session-create incubates a VISIBLE terminal REPL (ADR-0016) — the
+      // user gets a real local CLI window, not an invisible daemon; the
+      // detached serve spawn is the fallback (no GUI / gated off / macOS
+      // open failure).
+      const incubation = joinIncubation(workspacePath, "repl");
       try {
         const out = await incubation;
         res.writeHead(200, { "Content-Type": "application/json" });

--- a/src/remote/session-list-endpoint.ts
+++ b/src/remote/session-list-endpoint.ts
@@ -1,0 +1,173 @@
+/**
+ * Remote session history endpoint (ADR-0015), served on the bridge's loopback
+ * HTTP server and wrapped by the hub at
+ * GET /api/projects/sessions?workspacePath=…
+ *
+ * Discovery (the heartbeat payload) deliberately lists only RUNNING-scoped
+ * sessions — deriving membership from the store would flood it with every
+ * retired conversation. This endpoint is the deliberate counterpart: the
+ * project's ENTIRE backend session store, including closed conversations no
+ * bridge currently holds, so a remote client can pick one and resume it with
+ * `session/load` (pass-through resume accepts raw backend ids).
+ *
+ * Long-lived projects hold dozens of sessions, so the listing is PAGINATED:
+ * newest first (updatedAt descending, sessionId descending as the tiebreak so
+ * pages are stable), `limit` per page (default 20, max 200), and a composite
+ * cursor for "load more": `?before=<ms>&beforeId=<sessionId>` names the last
+ * row of the previous page, so one millisecond holding more rows than a page
+ * never skips or repeats them. The response carries `nextCursor`
+ * (`{before, beforeId}`, null on the last page). The backend `session/list`
+ * has no native pagination — the full store arrives once and is windowed
+ * here; entries are tiny, so that round-trip is cheap.
+ *
+ * Each entry carries `live` (this bridge currently holds the conversation
+ * with real activity) and `running` (a turn is in flight) so a client can
+ * render state from this one call. The workspace is never client-chosen:
+ * `listSessions` pins serve mode to the process cwd (ADR-0014), and the
+ * editor case passes the bridge's own project cwd.
+ */
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+import { listSessions } from "../handlers/session.js";
+import type { ZcodeAcpServer } from "../server.js";
+import { runningZcodeSids } from "./status-endpoint.js";
+
+/** Rows per page when the client sends no limit. */
+export const DEFAULT_SESSION_LIMIT = 20;
+/** Hard cap — a bigger ask is clamped, not refused. */
+export const MAX_SESSION_LIMIT = 200;
+
+/** Parsed pagination query; null = a malformed value the caller must 400. */
+export interface SessionListQuery {
+  limit: number;
+  /** updatedAt (ms) of the cursor row: only older rows — or tied, see beforeId. */
+  before?: number;
+  /** sessionId of the cursor row: excludes it and already-shown tied rows. */
+  beforeId?: string;
+}
+
+/** Opaque backend session id — the charset `beforeId` may travel as. */
+const SESSION_ID_RE = /^[\w.:-]+$/;
+
+/** Parse ?limit=&before=&beforeId=; limit clamped into [1, MAX]. */
+export function parseSessionListQuery(searchParams: URLSearchParams): SessionListQuery | null {
+  const limitRaw = searchParams.get("limit");
+  const beforeRaw = searchParams.get("before");
+  const beforeIdRaw = searchParams.get("beforeId");
+  let limit = DEFAULT_SESSION_LIMIT;
+  if (limitRaw !== null) {
+    if (!/^\d+$/.test(limitRaw)) return null;
+    const parsed = parseInt(limitRaw, 10);
+    if (parsed < 1) return null;
+    limit = Math.min(parsed, MAX_SESSION_LIMIT);
+  }
+  let before: number | undefined;
+  if (beforeRaw !== null) {
+    if (!/^\d+$/.test(beforeRaw)) return null;
+    before = parseInt(beforeRaw, 10);
+  }
+  if (beforeIdRaw !== null && !SESSION_ID_RE.test(beforeIdRaw)) return null;
+  return { limit, before, beforeId: beforeIdRaw ?? undefined };
+}
+
+/** ISO string → ms epoch; absent/unparsable sorts oldest (0). */
+function updatedAtMs(iso: string | null | undefined): number {
+  if (!iso) return 0;
+  const t = Date.parse(iso);
+  return Number.isNaN(t) ? 0 : t;
+}
+
+function sendText(res: ServerResponse, code: number, message: string): void {
+  if (res.writableEnded) return;
+  res.writeHead(code, { "Content-Type": "text/plain" });
+  res.end(message);
+}
+
+async function handleList(server: ZcodeAcpServer, req: IncomingMessage, res: ServerResponse) {
+  // Consume any request body so the client's connection drains cleanly.
+  req.resume();
+
+  const url = new URL(req.url ?? "/", "http://127.0.0.1");
+  const query = parseSessionListQuery(url.searchParams);
+  if (!query) {
+    sendText(res, 400, "invalid limit/before — positive integers expected");
+    return;
+  }
+
+  const { sessions } = await listSessions(server, { cwd: server.projectCwd() });
+  // Newest first; the id tiebreak makes the order total, and the composite
+  // cursor names the exact last row, so pages never repeat or skip rows —
+  // even when a single millisecond holds more rows than a page.
+  const sorted = [...sessions].sort(
+    (a, b) =>
+      updatedAtMs(b.updatedAt) - updatedAtMs(a.updatedAt) ||
+      (a.sessionId > b.sessionId ? -1 : a.sessionId < b.sessionId ? 1 : 0),
+  );
+  const before = query.before;
+  const filtered =
+    before === undefined
+      ? sorted
+      : sorted.filter((s) => {
+          const t = updatedAtMs(s.updatedAt);
+          if (t !== before) return t < before;
+          // Tied with the cursor row: keep only ids strictly after it in the
+          // (descending) id order. Without beforeId (hand-rolled query) tied
+          // rows are conservatively dropped — our own cursor always names it.
+          return query.beforeId !== undefined && s.sessionId < query.beforeId;
+        });
+  const page = filtered.slice(0, query.limit);
+  const lastRow = page.length > 0 ? page[page.length - 1]! : undefined;
+  const nextCursor =
+    filtered.length > query.limit && lastRow
+      ? { before: updatedAtMs(lastRow.updatedAt), beforeId: lastRow.sessionId }
+      : null;
+
+  // live/running flags are computed once for the PAGE — the membership gates
+  // are the same as discovery's heartbeat payload.
+  const running = runningZcodeSids(server);
+  const live = new Set<string>();
+  for (const [acpSid, summary] of server.sessionSummaries) {
+    if (!summary.hasActivity) continue;
+    const zcodeSid = server.resolveSid(acpSid);
+    if (zcodeSid) live.add(zcodeSid);
+  }
+  const body = JSON.stringify({
+    sessions: page.map((s) => ({
+      ...s,
+      live: live.has(s.sessionId),
+      running: running.has(s.sessionId),
+    })),
+    nextCursor,
+  });
+  res.writeHead(200, {
+    "Content-Type": "application/json",
+    "Content-Length": Buffer.byteLength(body),
+    // Listing pages poll on refresh; a stale copy would resurrect closed rows.
+    "Cache-Control": "no-store",
+  });
+  res.end(body);
+}
+
+/**
+ * Build the /sessions history request handler for the loopback endpoint.
+ * Failures (backend down, spawn refused) degrade to a status code, never
+ * into the event loop.
+ */
+export function createSessionListHandler(
+  server: ZcodeAcpServer,
+): (req: IncomingMessage, res: ServerResponse) => void {
+  return (req, res) => {
+    if (req.method !== "GET" && req.method !== "HEAD") {
+      sendText(res, 405, "method not allowed");
+      return;
+    }
+    void handleList(server, req, res).catch((e) => {
+      if (res.headersSent) {
+        res.destroy();
+        return;
+      }
+      sendText(res, 502, `session list failed: ${e instanceof Error ? e.message : String(e)}`);
+    });
+  };
+}

--- a/tests/hub.test.ts
+++ b/tests/hub.test.ts
@@ -32,7 +32,13 @@ vi.mock("../src/tasks-index.js", () => ({
   listKnownWorkspaces: listKnownWorkspacesMock,
 }));
 
-import { resetQuotaCacheForTest, startHub, type HubHandle } from "../src/remote/hub-server.js";
+import {
+  resetQuotaCacheForTest,
+  resolveTerminalLaunch,
+  startHub,
+  terminalReplScript,
+  type HubHandle,
+} from "../src/remote/hub-server.js";
 import { AGENT_INFO } from "../src/utils.js";
 
 const TOKEN = "test-hub-token";
@@ -875,7 +881,7 @@ describe("hub remote session-create (ADR-0014)", () => {
    * once(); the mutable exitCode/signalCode fields flip the death checks.
    */
   let fakeChild: EventEmitter & { pid: number; exitCode: number | null; signalCode: string | null };
-  let spawnCalls: Array<{ cwd: string; env: NodeJS.ProcessEnv }>;
+  let spawnCalls: Array<{ cwd: string; env: NodeJS.ProcessEnv; kind: "repl" | "serve" }>;
   let spawnCount: number;
 
   beforeEach(() => {
@@ -893,7 +899,7 @@ describe("hub remote session-create (ADR-0014)", () => {
   });
 
   function spawnServeSpy() {
-    return (opts: { cwd: string; env: NodeJS.ProcessEnv }) => {
+    return (opts: { cwd: string; env: NodeJS.ProcessEnv; kind: "repl" | "serve" }) => {
       spawnCount++;
       spawnCalls.push(opts);
       return fakeChild as unknown as import("node:child_process").ChildProcess;
@@ -930,9 +936,7 @@ describe("hub remote session-create (ADR-0014)", () => {
     const hub = await startTestHub({ spawnServe: spawnServeSpy() });
     const url = `http://127.0.0.1:${hub.port}/api/instances`;
     expect((await fetch(url, { method: "POST" })).status).toBe(401);
-    expect(
-      (await fetch(url, { method: "POST", headers: auth, body: "{}" })).status,
-    ).toBe(400);
+    expect((await fetch(url, { method: "POST", headers: auth, body: "{}" })).status).toBe(400);
     const res = await fetch(url, {
       method: "POST",
       headers: { ...auth, "Content-Type": "application/json" },
@@ -954,8 +958,15 @@ describe("hub remote session-create (ADR-0014)", () => {
     await new Promise((r) => setTimeout(r, 400));
     expect(spawnCount).toBe(1);
     expect(spawnCalls[0]!.cwd).toBe(PROJECT);
+    // Session-create incubates a VISIBLE terminal REPL (ADR-0016); the stub
+    // stands in for whichever surface the platform picked.
+    expect(spawnCalls[0]!.kind).toBe("repl");
     expect(spawnCalls[0]!.env.ZCODE_ACP_REMOTE).toBe("1");
     expect(spawnCalls[0]!.env.ZCODE_ACP_REMOTE_TOKEN).toBe(TOKEN);
+    // ADR-0016 ENV: register as the project's serve bridge + pin session
+    // roots to the project cwd (ADR-0014 whitelist semantics).
+    expect(spawnCalls[0]!.env.ZCODE_ACP_REMOTE_ORIGIN).toBe("serve");
+    expect(spawnCalls[0]!.env.ZCODE_ACP_REMOTE_PIN_CWD).toBe("1");
     await registerServeBridge(hub, PROJECT);
     const res = await pending;
     expect(res.status).toBe(200);
@@ -1061,5 +1072,343 @@ describe("hub remote session-create (ADR-0014)", () => {
     const byId = Object.fromEntries(list.map((e) => [e.id, e.origin]));
     expect(byId[`serve-${PROJECT}`]).toBe("serve");
     expect(byId["editor-1"]).toBe("editor");
+  });
+});
+
+describe("hub project session history (ADR-0015)", () => {
+  const PROJECT = "/Users/dev/Develop/demo";
+  const auth = { Authorization: `Bearer ${TOKEN}` };
+  const STORE = [
+    {
+      sessionId: "sess_closed",
+      title: "Old work",
+      updatedAt: "2026-08-01T10:00:00.000Z",
+      live: false,
+      running: false,
+    },
+    {
+      sessionId: "sess_live",
+      title: "Current",
+      updatedAt: "2026-09-01T10:00:00.000Z",
+      live: true,
+      running: false,
+    },
+  ];
+
+  let fakeChild: EventEmitter & { pid: number; exitCode: number | null; signalCode: string | null };
+  let spawnCount: number;
+
+  beforeEach(() => {
+    listKnownWorkspacesMock.mockReset();
+    listKnownWorkspacesMock.mockResolvedValue([
+      { workspacePath: PROJECT, sessions: 3, lastActive: 1234 },
+    ]);
+    fakeChild = new EventEmitter() as typeof fakeChild;
+    fakeChild.pid = 4242;
+    fakeChild.exitCode = null;
+    fakeChild.signalCode = null;
+    spawnCount = 0;
+  });
+
+  /** Fake bridge loopback HTTP server serving GET /sessions (records the URL). */
+  function startSessionsBridge(
+    status = 200,
+  ): Promise<{ port: number; seenUrl: () => string | null }> {
+    return new Promise((resolve) => {
+      let seen: string | null = null;
+      const server = createServer((req, res) => {
+        seen = req.url ?? "";
+        res.writeHead(status, { "Content-Type": "application/json" });
+        // Real bridge semantics: a continued page carries the next cursor,
+        // an under-limit first page has none.
+        const cursor = (req.url ?? "").includes("before=") ? 1234 : null;
+        res.end(JSON.stringify({ sessions: STORE, nextCursor: cursor }));
+      });
+      server.listen(0, "127.0.0.1", () => {
+        const addr = server.address();
+        resolve({
+          port: typeof addr === "object" && addr ? addr.port : 0,
+          seenUrl: () => seen,
+        });
+      });
+      track(server, (s) => new Promise<void>((r) => s.close(() => r())));
+    });
+  }
+
+  async function registerServeBridge(hub: HubHandle, port: number): Promise<void> {
+    const res = await fetch(`http://127.0.0.1:${hub.port}/api/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(
+        registerBody({
+          id: `serve-${PROJECT}`,
+          workspace: PROJECT,
+          origin: "serve",
+          port,
+          pid: 4242,
+        }),
+      ),
+    });
+    expect(res.ok).toBe(true);
+  }
+
+  it("requires auth, a workspacePath, and a whitelisted project", async () => {
+    const hub = await startTestHub();
+    const url = `http://127.0.0.1:${hub.port}/api/projects/sessions`;
+    expect((await fetch(url)).status).toBe(401);
+    expect((await fetch(url, { headers: auth })).status).toBe(400);
+    const res = await fetch(`${url}?workspacePath=${encodeURIComponent("/etc")}`, {
+      headers: auth,
+    });
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe("unknown project");
+  });
+
+  it("proxies the live serve bridge's list and wraps it with the instance", async () => {
+    const bridge = await startSessionsBridge();
+    const hub = await startTestHub();
+    await registerServeBridge(hub, bridge.port);
+
+    const res = await fetch(
+      `http://127.0.0.1:${hub.port}/api/projects/sessions?workspacePath=${encodeURIComponent(PROJECT)}`,
+      { headers: auth },
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      workspacePath: PROJECT,
+      instance: { id: `serve-${PROJECT}`, origin: "serve" },
+      sessions: STORE,
+      nextCursor: null,
+    });
+    // No pagination params — the bridge gets a bare /sessions.
+    expect(bridge.seenUrl()).toBe("/sessions");
+  });
+
+  it("forwards pagination params to the bridge and passes nextCursor through", async () => {
+    const bridge = await startSessionsBridge();
+    const hub = await startTestHub();
+    await registerServeBridge(hub, bridge.port);
+
+    const res = await fetch(
+      `http://127.0.0.1:${hub.port}/api/projects/sessions?workspacePath=${encodeURIComponent(PROJECT)}&limit=5&before=1000&beforeId=sess_004`,
+      { headers: auth },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { nextCursor: unknown };
+    expect(bridge.seenUrl()).toBe("/sessions?limit=5&before=1000&beforeId=sess_004");
+    expect(body.nextCursor).toBe(1234);
+  });
+
+  it("answers 400 for malformed pagination params without spawning", async () => {
+    const bridge = await startSessionsBridge();
+    const hub = await startTestHub();
+    await registerServeBridge(hub, bridge.port);
+    const url = `http://127.0.0.1:${hub.port}/api/projects/sessions`;
+
+    expect(
+      (
+        await fetch(`${url}?workspacePath=${encodeURIComponent(PROJECT)}&limit=0`, {
+          headers: auth,
+        })
+      ).status,
+    ).toBe(400);
+    expect(
+      (
+        await fetch(`${url}?workspacePath=${encodeURIComponent(PROJECT)}&limit=00`, {
+          headers: auth,
+        })
+      ).status,
+    ).toBe(400);
+    expect(
+      (
+        await fetch(`${url}?workspacePath=${encodeURIComponent(PROJECT)}&before=abc`, {
+          headers: auth,
+        })
+      ).status,
+    ).toBe(400);
+    expect(
+      (
+        await fetch(`${url}?workspacePath=${encodeURIComponent(PROJECT)}&beforeId=bad%20id`, {
+          headers: auth,
+        })
+      ).status,
+    ).toBe(400);
+    expect(bridge.seenUrl()).toBeNull();
+  });
+
+  it("incubates a serve bridge when none is live, then reuses it", async () => {
+    const bridge = await startSessionsBridge();
+    let seenKind: "repl" | "serve" | null = null;
+    const hub = await startTestHub({
+      spawnServe: (opts: { cwd: string; env: NodeJS.ProcessEnv; kind: "repl" | "serve" }) => {
+        spawnCount++;
+        seenKind = opts.kind;
+        // The spawned bridge registers itself moments after boot.
+        void fetch(`http://127.0.0.1:${hub.port}/api/register`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(
+            registerBody({
+              id: `serve-${opts.cwd}`,
+              workspace: opts.cwd,
+              origin: "serve",
+              port: bridge.port,
+              pid: 4242,
+            }),
+          ),
+        });
+        return fakeChild as unknown as import("node:child_process").ChildProcess;
+      },
+    });
+    const url = `http://127.0.0.1:${hub.port}/api/projects/sessions?workspacePath=${encodeURIComponent(PROJECT)}`;
+
+    const res = await fetch(url, { headers: auth });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { instance: { id: string }; sessions: unknown[] };
+    expect(body.instance).toEqual({ id: `serve-${PROJECT}`, origin: "serve" });
+    expect(body.sessions).toEqual(STORE);
+    expect(spawnCount).toBe(1);
+    // A background listing must not pop a terminal window — detached serve only.
+    expect(seenKind).toBe("serve");
+
+    // A second listing joins the now-registered bridge — no second spawn.
+    expect((await fetch(url, { headers: auth })).status).toBe(200);
+    expect(spawnCount).toBe(1);
+  });
+
+  it("joins one incubation when two listings race (no double spawn)", async () => {
+    const bridge = await startSessionsBridge();
+    const hub = await startTestHub({
+      spawnServe: (opts: { cwd: string; env: NodeJS.ProcessEnv; kind: "repl" | "serve" }) => {
+        spawnCount++;
+        // Register late enough that BOTH listings find no live instance and
+        // must join the in-flight incubation instead of spawning their own.
+        const timer = setTimeout(() => {
+          void fetch(`http://127.0.0.1:${hub.port}/api/register`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(
+              registerBody({
+                id: `serve-${opts.cwd}`,
+                workspace: opts.cwd,
+                origin: "serve",
+                port: bridge.port,
+                pid: 4242,
+              }),
+            ),
+          });
+        }, 700);
+        timer.unref?.();
+        return fakeChild as unknown as import("node:child_process").ChildProcess;
+      },
+    });
+    const url = `http://127.0.0.1:${hub.port}/api/projects/sessions?workspacePath=${encodeURIComponent(PROJECT)}`;
+
+    const [a, b] = await Promise.all([
+      fetch(url, { headers: auth }),
+      fetch(url, { headers: auth }),
+    ]);
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(200);
+    expect(spawnCount).toBe(1);
+  });
+
+  it("answers 502 when the bridge serves a broken list", async () => {
+    const bridge = await startSessionsBridge(500);
+    const hub = await startTestHub();
+    await registerServeBridge(hub, bridge.port);
+
+    const res = await fetch(
+      `http://127.0.0.1:${hub.port}/api/projects/sessions?workspacePath=${encodeURIComponent(PROJECT)}`,
+      { headers: auth },
+    );
+    expect(res.status).toBe(502);
+    expect(await res.text()).toContain("bridge answered 500");
+  });
+});
+
+describe("terminal launch resolution (ADR-0016)", () => {
+  it("prefers the explicit command template over everything", () => {
+    const out = resolveTerminalLaunch({
+      ZCODE_ACP_HUB_TERMINAL_COMMAND: "my-term --run {script}",
+      ZCODE_ACP_HUB_TERMINAL_APP: "iTerm",
+    });
+    expect(out.launch).toEqual({ kind: "shell", command: "my-term --run {script}" });
+    expect(out.warning).toBeUndefined();
+  });
+
+  it("maps well-known apps to their verified launch mechanism", () => {
+    expect(resolveTerminalLaunch({ ZCODE_ACP_HUB_TERMINAL_APP: "WezTerm" }).launch).toEqual({
+      kind: "openAppArgs",
+      app: "WezTerm",
+      args: ["start", "--"],
+    });
+    expect(resolveTerminalLaunch({ ZCODE_ACP_HUB_TERMINAL_APP: "kitty" }).launch).toEqual({
+      kind: "openAppArgs",
+      app: "kitty",
+      args: [],
+    });
+    expect(resolveTerminalLaunch({ ZCODE_ACP_HUB_TERMINAL_APP: "ghostty" }).launch).toEqual({
+      kind: "openAppArgs",
+      app: "Ghostty",
+      args: ["-e"],
+    });
+    expect(resolveTerminalLaunch({ ZCODE_ACP_HUB_TERMINAL_APP: "Alacritty" }).launch).toEqual({
+      kind: "openAppArgs",
+      app: "Alacritty",
+      args: ["-e"],
+    });
+    // .command executors; aliases are case- and .app-suffix-insensitive.
+    expect(resolveTerminalLaunch({ ZCODE_ACP_HUB_TERMINAL_APP: "iTerm.app" }).launch).toEqual({
+      kind: "openApp",
+      app: "iTerm",
+    });
+    expect(resolveTerminalLaunch({ ZCODE_ACP_HUB_TERMINAL_APP: "iterm2" }).launch).toEqual({
+      kind: "openApp",
+      app: "iTerm",
+    });
+    expect(resolveTerminalLaunch({ ZCODE_ACP_HUB_TERMINAL_APP: "Apple_Terminal" }).launch).toEqual({
+      kind: "openApp",
+      app: "Terminal",
+    });
+  });
+
+  it("warns on Warp — it cannot run scripts or commands programmatically", () => {
+    const out = resolveTerminalLaunch({ ZCODE_ACP_HUB_TERMINAL_APP: "Warp" });
+    expect(out.launch).toEqual({ kind: "openApp", app: "Warp" });
+    expect(out.warning).toContain("warpdotdev/warp#1917");
+    expect(out.warning).toContain("ZCODE_ACP_HUB_TERMINAL_COMMAND");
+  });
+
+  it("passes unknown apps through to open -a and defaults to Terminal.app", () => {
+    expect(resolveTerminalLaunch({ ZCODE_ACP_HUB_TERMINAL_APP: "MyTerm" }).launch).toEqual({
+      kind: "openApp",
+      app: "MyTerm",
+    });
+    expect(resolveTerminalLaunch({}).launch).toEqual({ kind: "openApp", app: "Terminal" });
+    // The hub is a background process — its own env has no terminal, and
+    // TERM_PROGRAM (at best an accident of how the hub was launched) is
+    // never consulted.
+    expect(resolveTerminalLaunch({ TERM_PROGRAM: "iTerm.app" }).launch).toEqual({
+      kind: "openApp",
+      app: "Terminal",
+    });
+  });
+});
+
+describe("terminal REPL script (ADR-0016)", () => {
+  it("embeds the hub's ZCODE_ACP_* env so the fresh terminal shell registers", () => {
+    const body = terminalReplScript("/Users/me/proj", "/opt/cli.js", {
+      PATH: "/usr/bin",
+      ZCODE_ACP_REMOTE: "1",
+      ZCODE_ACP_REMOTE_TOKEN: "tok it's",
+      ZCODE_ACP_REMOTE_ORIGIN: "serve",
+    });
+    expect(body).toContain("cd '/Users/me/proj' || exit 1");
+    expect(body).toContain("export ZCODE_ACP_REMOTE='1'");
+    expect(body).toContain("export ZCODE_ACP_REMOTE_TOKEN='tok it'\\''s'");
+    expect(body).toContain("export ZCODE_ACP_REMOTE_ORIGIN='serve'");
+    expect(body).toContain("exec '");
+    expect(body).not.toContain("PATH=");
   });
 });

--- a/tests/remote-config.test.ts
+++ b/tests/remote-config.test.ts
@@ -49,6 +49,7 @@ describe("parseRemoteConfig", () => {
       hubHost: DEFAULT_HUB_HOST,
       bridgePort: DEFAULT_BRIDGE_PORT,
       origin: "editor",
+      pinCwd: false,
     });
   });
 
@@ -75,7 +76,24 @@ describe("parseRemoteConfig", () => {
       hubHost: "0.0.0.0",
       bridgePort: 9001,
       origin: "editor",
+      pinCwd: false,
     });
+  });
+
+  it("reads the hub-incubation overrides (origin, cwd pin) — ADR-0016", () => {
+    // A hub-incubated terminal REPL registers as the project's serve bridge
+    // and pins its session roots to the process cwd.
+    const config = parseRemoteConfig({
+      ...BASE_ENV,
+      ZCODE_ACP_REMOTE_ORIGIN: "serve",
+      ZCODE_ACP_REMOTE_PIN_CWD: "1",
+    });
+    expect(config?.origin).toBe("serve");
+    expect(config?.pinCwd).toBe(true);
+    // Any other spelling reads as editor / unpinned (parseOrigin's rule).
+    const loose = parseRemoteConfig({ ...BASE_ENV, ZCODE_ACP_REMOTE_ORIGIN: "editor" });
+    expect(loose?.origin).toBe("editor");
+    expect(loose?.pinCwd).toBe(false);
   });
 });
 

--- a/tests/remote-session-list.test.ts
+++ b/tests/remote-session-list.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Session history endpoint (ADR-0015): the bridge-side GET /sessions handler
+ * through a real loopback HTTP server with an in-memory ZcodeAcpServer and a
+ * fake backend. Proves the FULL store listing (closed conversations included —
+ * the counterpart to the running-scoped discovery payload), the per-entry
+ * live/running flags a remote resume picker renders, and the pagination that
+ * keeps long-lived projects browsable (newest first, limit + before cursor).
+ */
+
+import { createServer, type Server } from "node:http";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { ZcodeBackend } from "../src/backend/client.js";
+import {
+  createSessionListHandler,
+  DEFAULT_SESSION_LIMIT,
+  MAX_SESSION_LIMIT,
+} from "../src/remote/session-list-endpoint.js";
+import { ZcodeAcpServer } from "../src/server.js";
+
+const cleanups: Array<() => Promise<void> | void> = [];
+
+afterEach(async () => {
+  while (cleanups.length) {
+    const stop = cleanups.pop()!;
+    await stop();
+  }
+});
+
+/** Boot the list handler on an ephemeral port; returns its base URL. */
+async function bootList(server: ZcodeAcpServer): Promise<string> {
+  const handler = createSessionListHandler(server);
+  const httpServer: Server = createServer((req, res) => {
+    if (new URL(req.url ?? "/", "http://127.0.0.1").pathname === "/sessions") handler(req, res);
+    else {
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end("not found");
+    }
+  });
+  await new Promise<void>((resolve) => httpServer.listen(0, "127.0.0.1", resolve));
+  cleanups.push(() => new Promise<void>((resolve) => httpServer.close(() => resolve())));
+  const addr = httpServer.address();
+  return `http://127.0.0.1:${typeof addr === "object" && addr ? addr.port : 0}`;
+}
+
+/** Fake backend answering only session/list with the given sessions array. */
+function listBackend(
+  sessions: unknown[],
+  answer?: () => { result?: unknown; error?: { message: string } },
+): ZcodeBackend {
+  return {
+    isDead: false,
+    request: async (_id: number, method: string) => {
+      if (method === "session/list") {
+        return answer ? answer() : { result: { sessions } };
+      }
+      return { error: { message: "unhandled" } };
+    },
+  } as unknown as ZcodeBackend;
+}
+
+/** ISO timestamps listSessions would produce from the given ms epochs. */
+function fixture(n: number): Array<{ sessionId: string; title: string; updatedAt: number }> {
+  return Array.from({ length: n }, (_, i) => ({
+    sessionId: `sess_${String(i).padStart(3, "0")}`,
+    title: `work ${i}`,
+    updatedAt: 1_000 + i,
+  }));
+}
+
+describe("session history endpoint", () => {
+  it("lists the full store — closed sessions included — with live/running flags", async () => {
+    const server = new ZcodeAcpServer();
+    server.backend = listBackend([
+      { sessionId: "sess_closed", title: "Old work", updatedAt: 800 },
+      { sessionId: "sess_live", title: "Current", updatedAt: 900 },
+    ]);
+    server.registerSession("s-live", "sess_live");
+    server.markSessionActive("s-live");
+
+    const res = await fetch(`${await bootList(server)}/sessions`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      sessions: Array<{
+        sessionId: string;
+        title?: string;
+        updatedAt?: string;
+        live: boolean;
+        running: boolean;
+      }>;
+      nextCursor: { before: number; beforeId: string } | null;
+    };
+    const byId = Object.fromEntries(body.sessions.map((s) => [s.sessionId, s]));
+    expect(Object.keys(byId).sort()).toEqual(["sess_closed", "sess_live"]);
+    // Closed conversation: full entry, no live alias on this bridge.
+    expect(byId.sess_closed).toMatchObject({ title: "Old work", live: false, running: false });
+    expect(typeof byId.sess_closed!.updatedAt).toBe("string");
+    expect(byId.sess_live).toMatchObject({ title: "Current", live: true, running: false });
+    // Fewer rows than the page size — no continuation.
+    expect(body.nextCursor).toBeNull();
+  });
+
+  it("sorts newest-first (id desc tiebreak) and paginates with the composite cursor", async () => {
+    const server = new ZcodeAcpServer();
+    // Deliberately shuffled; same updatedAt for sess_004/sess_005 exercises
+    // the tiebreak.
+    server.backend = listBackend([
+      { sessionId: "sess_003", title: "w3", updatedAt: 1_003 },
+      { sessionId: "sess_005", title: "w5", updatedAt: 1_005 },
+      { sessionId: "sess_001", title: "w1", updatedAt: 1_001 },
+      { sessionId: "sess_004", title: "w4", updatedAt: 1_005 },
+      { sessionId: "sess_002", title: "w2", updatedAt: 1_002 },
+    ]);
+    const base = await bootList(server);
+    type Cursor = { before: number; beforeId: string } | null;
+    const ids = (b: unknown) => b as { sessions: Array<{ sessionId: string }>; nextCursor: Cursor };
+    const page = async (cursor: Cursor): Promise<ReturnType<typeof ids>> =>
+      ids(
+        await (
+          await fetch(
+            cursor
+              ? `${base}/sessions?limit=2&before=${cursor.before}&beforeId=${encodeURIComponent(cursor.beforeId)}`
+              : `${base}/sessions?limit=2`,
+          )
+        ).json(),
+      );
+
+    const page1 = await page(null);
+    expect(page1.sessions.map((s) => s.sessionId)).toEqual(["sess_005", "sess_004"]);
+    // 5 rows > limit 2 → the cursor names the exact last row (tied ms).
+    expect(page1.nextCursor).toEqual({ before: 1_005, beforeId: "sess_004" });
+
+    const page2 = await page(page1.nextCursor);
+    expect(page2.sessions.map((s) => s.sessionId)).toEqual(["sess_003", "sess_002"]);
+    expect(page2.nextCursor).toEqual({ before: 1_002, beforeId: "sess_002" });
+
+    const page3 = await page(page2.nextCursor);
+    expect(page3.sessions.map((s) => s.sessionId)).toEqual(["sess_001"]);
+    expect(page3.nextCursor).toBeNull();
+  });
+
+  it("reaches every row when one millisecond spans several pages", async () => {
+    const server = new ZcodeAcpServer();
+    server.backend = listBackend(
+      ["e", "d", "c", "b", "a"].map((suffix) => ({
+        sessionId: `sess_${suffix}`,
+        title: suffix,
+        updatedAt: 1_000,
+      })),
+    );
+    const base = await bootList(server);
+    const seen: string[] = [];
+    let cursor: { before: number; beforeId: string } | null = null;
+    for (;;) {
+      const url = cursor
+        ? `${base}/sessions?limit=2&before=${cursor.before}&beforeId=${encodeURIComponent(cursor.beforeId)}`
+        : `${base}/sessions?limit=2`;
+      const body = (await (await fetch(url)).json()) as {
+        sessions: Array<{ sessionId: string }>;
+        nextCursor: { before: number; beforeId: string } | null;
+      };
+      seen.push(...body.sessions.map((s) => s.sessionId));
+      if (!body.nextCursor) break;
+      cursor = body.nextCursor;
+    }
+    // All five tied rows, descending id order, none skipped or repeated —
+    // a ms-only cursor would strand rows past the first page boundary.
+    expect(seen).toEqual(["sess_e", "sess_d", "sess_c", "sess_b", "sess_a"]);
+  });
+
+  it("defaults to DEFAULT_SESSION_LIMIT rows and clamps the asked limit", async () => {
+    const server = new ZcodeAcpServer();
+    server.backend = listBackend(fixture(MAX_SESSION_LIMIT + 50));
+    const base = await bootList(server);
+
+    const defaulted = (await (await fetch(`${base}/sessions`)).json()) as {
+      sessions: unknown[];
+    };
+    expect(defaulted.sessions).toHaveLength(DEFAULT_SESSION_LIMIT);
+
+    const clamped = (await (await fetch(`${base}/sessions?limit=99999`)).json()) as {
+      sessions: unknown[];
+    };
+    expect(clamped.sessions).toHaveLength(MAX_SESSION_LIMIT);
+  });
+
+  it("answers 400 for malformed pagination params", async () => {
+    const server = new ZcodeAcpServer();
+    server.backend = listBackend([]);
+    const base = await bootList(server);
+
+    expect((await fetch(`${base}/sessions?limit=0`)).status).toBe(400);
+    expect((await fetch(`${base}/sessions?limit=00`)).status).toBe(400);
+    expect((await fetch(`${base}/sessions?limit=abc`)).status).toBe(400);
+    expect((await fetch(`${base}/sessions?before=yesterday`)).status).toBe(400);
+    expect((await fetch(`${base}/sessions?limit=-3`)).status).toBe(400);
+    expect((await fetch(`${base}/sessions?beforeId=bad%20id`)).status).toBe(400);
+  });
+
+  it("marks a conversation with an in-flight turn as running", async () => {
+    const server = new ZcodeAcpServer();
+    server.backend = listBackend([{ sessionId: "sess_live", title: "busy", updatedAt: 900 }]);
+    server.registerSession("s-live", "sess_live");
+    server.markSessionActive("s-live");
+    server.pendingTurns.set(7, { zcodeSid: "sess_live", cancelled: false });
+
+    const res = await fetch(`${await bootList(server)}/sessions`);
+    const body = (await res.json()) as { sessions: Array<{ sessionId: string; running: boolean }> };
+    expect(body.sessions[0]).toMatchObject({ sessionId: "sess_live", running: true });
+  });
+
+  it("treats a backend-id-only attachment (pass-through resume) as live", async () => {
+    const server = new ZcodeAcpServer();
+    server.backend = listBackend([{ sessionId: "sess_direct", title: "remote", updatedAt: 900 }]);
+    server.registerSession("sess_direct", "sess_direct");
+    server.markSessionActive("sess_direct");
+
+    const res = await fetch(`${await bootList(server)}/sessions`);
+    const body = (await res.json()) as { sessions: Array<{ sessionId: string; live: boolean }> };
+    expect(body.sessions[0]).toMatchObject({ sessionId: "sess_direct", live: true });
+  });
+
+  it("answers 405 for non-GET and 502 when the backend list fails", async () => {
+    const server = new ZcodeAcpServer();
+    server.backend = listBackend([], () => ({ error: { message: "backend down" } }));
+    const base = await bootList(server);
+
+    expect((await fetch(`${base}/sessions`, { method: "POST" })).status).toBe(405);
+    const res = await fetch(`${base}/sessions`);
+    expect(res.status).toBe(502);
+    expect(await res.text()).toContain("backend down");
+  });
+});


### PR DESCRIPTION
## Summary

Three features for the remote-access chain (hub + bridges), plus review-driven hardening:

- **ADR-0015 — per-project session history**: bridge loopback `GET /sessions` lists the FULL backend session store for the project (closed conversations included), newest first with a composite cursor (`?before=<ms>&beforeId=<id>` → `nextCursor: {before, beforeId} | null`) so timestamps tied across a page boundary are never skipped. Hub `GET /api/projects/sessions` wraps it: token auth → known-project whitelist → single-flight serve-bridge incubation (`joinIncubation`) → proxy.
- **ADR-0016 — visible terminal REPL on remote session-create**: `POST /api/instances` opens a real terminal window running the local CLI REPL instead of an invisible daemon. The `.command` script embeds the hub's `ZCODE_ACP_*` env (the terminal's fresh shell inherits launchd env, so the REPL could otherwise never register back). Built-in launch recipes for Terminal, iTerm, WezTerm, kitty, Alacritty, Ghostty (`ZCODE_ACP_HUB_TERMINAL_APP` / `_COMMAND` overrides); Warp/Hyper unsupported by design (no programmatic command execution). Any failure degrades to the detached headless serve spawn.
- **Serve semantics**: `ZCODE_ACP_REMOTE_ORIGIN` / `ZCODE_ACP_REMOTE_PIN_CWD` pin session roots to the process cwd so the whitelist survives the visible-terminal lifecycle.

## Review fixes (pre-merge)

- Pagination cursor upgraded from ms-only to composite (tied rows were unreachable past a page boundary) — regression test walks 5 rows sharing one ms across 3 pages.
- Concurrent listings now join one incubation instead of spawning duplicate bridges — regression test with two racing GETs.
- `limit=00` (and any non-positive) rejected with 400 on both hub and bridge.
- Terminal `open` is now async — `spawnSync` could freeze the hub's event loop (WS proxying, heartbeats) for up to 3s.

## Test plan

- `pnpm typecheck`, `pnpm lint`, prettier clean.
- 73 tests across `tests/hub.test.ts`, `tests/remote-session-list.test.ts`, `tests/remote-config.test.ts`; full suite green except the 3 pre-existing environmental `tests/sandbox.test.ts` failures (fail on a clean tree too).