### PR TITLE
fix(hub): self-relaunch outside the sandbox via launchd when born wrapped

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,6 +216,19 @@ ZCode protocol types into ACP notifications directly — always translate.
   armed then EACCES/ENOTDIR/vanished also reads as armed — falling back to
   the template would silently disarm). `/dev/null` must stay write-allowed
   or every `git commit` breaks.
+- **A hub born inside the Seatbelt wrap silently breaks session-create**:
+  macOS TCC attributes the hub's `open -a Terminal` to the requester identity
+  "Sandbox" and Terminal refuses the document — while `open` itself exits 0,
+  so `spawnTerminalRepl` reads success, the incubation burns its 20s budget,
+  and every remote create 502s. Seatbelt cannot be escaped from within, so
+  the fix is launchd (it lives outside): every sandboxed backend spawn is
+  birth-marked `ZCODE_ACP_SANDBOX_ACTIVE` (server.ts ensureBackend — NOT the
+  same signal as `ZCODE_ACP_SANDBOX`, which a user may legitimately set
+  globally), and the hub boot-checks the marker and relaunches itself via
+  `launchctl bootstrap gui/$UID` + kickstart before binding
+  (src/remote/hub-sandbox.ts; plist in a temp mkdtemp, launchd reads the path
+  itself). Don't reconnect this through `open` retries or TCC prompts — the
+  attribution is the problem, not a missing permission.
 - **ACP wire method names are snake_case** (`session/request_permission`,
   not `session/requestPermission`) — the camelCase spelling is silently
   method-not-found (-32601) on real clients, and an `as never` param cast

--- a/docs/REMOTE.md
+++ b/docs/REMOTE.md
@@ -39,7 +39,11 @@ manually). It does three things only: token auth, instance discovery, and
 byte-level proxying (ACP WebSocket plus read-only session files) — no session
 state, no path semantics. It exits after ~10 idle minutes and is re-spawned
 on demand. Each bridge registers every 10s as a heartbeat and drops out of
-discovery ~30s after it stops.
+discovery ~30s after it stops. **Sandbox inheritance is self-healed:** a hub
+born inside the Seatbelt wrap (a sandboxed backend spawned it — marked via
+`ZCODE_ACP_SANDBOX_ACTIVE`) relaunches itself through launchd, outside the
+sandbox, before binding; inside the sandbox macOS would refuse its opening of
+the visible session terminal (TCC), breaking remote session-create.
 
 **Discovery API** (for client authors; fields are additive-only):
 

--- a/src/bin/hub.ts
+++ b/src/bin/hub.ts
@@ -12,6 +12,13 @@
  * Refuses to start without ZCODE_ACP_REMOTE_TOKEN — the hub is the only public
  * entry point and never runs unauthenticated. Exits 0 on EADDRINUSE: another
  * hub already owns the port, which is the desired machine-singleton behaviour.
+ *
+ * If the hub finds itself INSIDE our Seatbelt wrap (ZCODE_ACP_SANDBOX_ACTIVE,
+ * birth-marked onto every sandboxed backend spawn and inherited down the
+ * chain), it relaunches itself via launchd — which lives OUTSIDE the sandbox —
+ * before binding: a sandboxed hub cannot open the visible session terminal
+ * (macOS TCC refuses the request attributed to "Sandbox"), and Seatbelt can
+ * never be escaped from within. See src/remote/hub-sandbox.ts.
  */
 
 import { spawn } from "node:child_process";
@@ -19,6 +26,7 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 
 import { parseHubConfig } from "../remote/config.js";
+import { sandboxBorn, selfRelaunchOutsideSandbox } from "../remote/hub-sandbox.js";
 import { startHub } from "../remote/hub-server.js";
 import { log, warn } from "../utils.js";
 
@@ -51,6 +59,20 @@ function respawnSelf(): void {
 export async function main(): Promise<void> {
   const config = parseHubConfig();
   if (!config) process.exit(1);
+  // Born inside our Seatbelt wrap (a sandboxed backend spawned this hub and
+  // the marker was inherited): relaunch via launchd, which lives OUTSIDE the
+  // sandbox. The port is not bound yet, so the relaunched instance binds
+  // cleanly. If the relaunch fails, keep running degraded — everything but
+  // the visible terminal still works — and say so loudly.
+  if (sandboxBorn()) {
+    const hubJs = fileURLToPath(new URL("../bin/hub.js", import.meta.url));
+    if (selfRelaunchOutsideSandbox({ nodePath: process.execPath, hubJs })) process.exit(0);
+    warn(
+      "hub: running INSIDE a Seatbelt sandbox — macOS will refuse this hub's " +
+        "open of the visible session terminal (TCC), so remote session-create " +
+        "falls back to a headless bridge",
+    );
+  }
   const hub = await startHub({
     port: config.hubPort,
     host: config.hubHost,

--- a/src/remote/hub-sandbox.ts
+++ b/src/remote/hub-sandbox.ts
@@ -1,0 +1,170 @@
+/**
+ * Hub sandbox self-relaunch (macOS / launchd).
+ *
+ * A hub born inside our Seatbelt wrap cannot do its job: `open -a Terminal`
+ * for the visible REPL (ADR-0016) gets TCC-attributed to the requester
+ * identity "Sandbox" and Terminal silently refuses the document — while
+ * `open` itself exits 0, so the incubation just burns its budget and every
+ * remote session-create fails. Seatbelt cannot be escaped from within (it
+ * is inherited unconditionally across fork/exec), so the only way out is a
+ * process that already lives OUTSIDE the sandbox: launchd. The wrapped hub
+ * writes a throwaway LaunchAgent plist (launchd reads the path itself, the
+ * sandbox does not constrain it) and bootstraps itself into the user's gui
+ * domain; the relaunched hub is a clean user process.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+
+import { log, warn } from "../utils.js";
+
+/**
+ * Set on every sandboxed backend spawn (see server.ts ensureBackend) and
+ * inherited down any spawn chain. Its presence in the hub's env means THIS
+ * process was born inside the wrap — unlike ZCODE_ACP_SANDBOX, which a user
+ * may legitimately set globally and which must NOT trigger a relaunch.
+ */
+export const SANDBOX_ACTIVE_ENV = "ZCODE_ACP_SANDBOX_ACTIVE";
+
+/** launchd label for the self-relaunched hub (machine singleton, like the port). */
+export const HUB_LAUNCH_LABEL = "com.zcode.acp.hub";
+
+/** Whether this process was born inside our Seatbelt wrap. */
+export function sandboxBorn(env: NodeJS.ProcessEnv = process.env): boolean {
+  return process.platform === "darwin" && (env[SANDBOX_ACTIVE_ENV] ?? "").trim() !== "";
+}
+
+/** Minimal XML escaping for plist string values (env values are arbitrary). */
+function xmlEscape(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * The LaunchAgent plist body: run the hub entry under this node, with THIS
+ * process's env minus the birth marker (so the relaunched hub does not
+ * re-trigger). RunAtLoad/KeepAlive stay false — the hub is started exactly
+ * once, now, via kickstart; if it dies the bridges re-spawn it (the existing
+ * machine-singleton behaviour).
+ */
+export function buildHubRelaunchPlist(opts: {
+  nodePath: string;
+  hubJs: string;
+  env: NodeJS.ProcessEnv;
+  logPath: string;
+}): string {
+  const envEntries = Object.entries(opts.env).filter(([k]) => k !== SANDBOX_ACTIVE_ENV);
+  const pair = ([k, v]: [string, string | undefined]) =>
+    `        <key>${xmlEscape(k)}</key>\n        <string>${xmlEscape(String(v))}</string>`;
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${HUB_LAUNCH_LABEL}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>${xmlEscape(opts.nodePath)}</string>
+        <string>${xmlEscape(opts.hubJs)}</string>
+        <string>hub</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+${envEntries.map(pair).join("\n")}
+    </dict>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>KeepAlive</key>
+    <false/>
+    <key>StandardOutPath</key>
+    <string>${xmlEscape(opts.logPath)}</string>
+    <key>StandardErrorPath</key>
+    <string>${xmlEscape(opts.logPath)}</string>
+</dict>
+</plist>
+`;
+}
+
+/**
+ * Relaunch this hub outside the sandbox: write the plist into a fresh
+ * mkdtemp (a default-allowed temp tree under the Seatbelt profile, and
+ * launchd — outside the sandbox — reads the path itself), load it into the
+ * user's gui domain and start the job. Returns true when the relaunch was
+ * handed to launchd; false means the caller should keep running (degraded)
+ * and warn. Best-effort diagnostics of the relaunched hub land in the log
+ * file next to the plist.
+ *
+ * A label that was already bootstrapped freezes the FIRST plist's definition
+ * — `kickstart` restarts whatever is loaded and would silently revive stale
+ * env (a rotated token, an old port). The definition must therefore be
+ * swapped: bootout the old label, then bootstrap the fresh plist (bootout is
+ * asynchronous, so bootstrap retries a few times). A blind kickstart of an
+ * unreplaced definition is never attempted.
+ */
+export function selfRelaunchOutsideSandbox(opts: {
+  nodePath: string;
+  hubJs: string;
+  logPath?: string;
+}): boolean {
+  const dir = mkdtempSync(path.join(tmpdir(), "zcode-hub-relaunch-"));
+  const logPath = opts.logPath ?? path.join(dir, "hub.log");
+  const plistPath = path.join(dir, "hub.plist");
+  writeFileSync(plistPath, buildHubRelaunchPlist({ ...opts, env: process.env, logPath }));
+  const domain = `gui/${process.getuid?.() ?? 0}`;
+  const target = `${domain}/${HUB_LAUNCH_LABEL}`;
+  // Best-effort cleanup of the PREVIOUS attempt's dir (plist + log); the
+  // current dir stays — the relaunched job writes its log there.
+  const sentinel = path.join(tmpdir(), "zcode-hub-relaunch-last");
+  try {
+    const previous = readFileSync(sentinel, "utf8").trim();
+    if (previous) rmSync(previous, { recursive: true, force: true });
+  } catch {
+    // no previous attempt (or unreadable) — nothing to clean
+  }
+  try {
+    writeFileSync(sentinel, dir);
+  } catch {
+    // best-effort — worst case a few temp dirs accumulate
+  }
+  let loaded = false;
+  let lastError = "";
+  for (let attempt = 0; attempt < 3 && !loaded; attempt++) {
+    try {
+      execFileSync("launchctl", ["bootstrap", domain, plistPath], { stdio: "ignore" });
+      loaded = true;
+    } catch (e) {
+      lastError = e instanceof Error ? e.message : String(e);
+      // Likely already bootstrapped: drop the old definition and retry with
+      // the fresh plist (bootout completes asynchronously — hence the wait).
+      try {
+        execFileSync("launchctl", ["bootout", target], { stdio: "ignore" });
+      } catch {
+        // nothing was loaded under the label — nothing to boot out
+      }
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 300);
+    }
+  }
+  if (!loaded) {
+    warn(
+      `hub: launchd bootstrap failed (${lastError}) — running sandboxed; ` +
+        "restart the hub from a normal terminal instead",
+    );
+    return false;
+  }
+  try {
+    execFileSync("launchctl", ["kickstart", target], { stdio: "ignore" });
+  } catch (e) {
+    warn(
+      `hub: launchd kickstart failed (${e instanceof Error ? e.message : String(e)}) — ` +
+        "running sandboxed; restart the hub from a normal terminal instead",
+    );
+    return false;
+  }
+  log(`hub: relaunched outside the sandbox via launchd (${target}, plist: ${plistPath})`);
+  return true;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -284,6 +284,14 @@ export class ZcodeAcpServer {
         workspaces,
         extraAllow: [...extraAllow, ...this.sandboxOnceAllows],
       });
+      // Birth-mark the wrapped process: the marker is inherited down any
+      // spawn chain (a hub (re)spawned below a sandboxed backend carries
+      // it), and the hub's boot check uses it to self-relaunch outside the
+      // sandbox via launchd — a hub born inside Seatbelt cannot open the
+      // visible terminal (macOS TCC attributes its `open -a Terminal` to
+      // "Sandbox" and Terminal silently refuses), and Seatbelt itself can
+      // never be escaped from within.
+      env.ZCODE_ACP_SANDBOX_ACTIVE = "1";
     }
     this.backend = new ZcodeBackend(argv, env);
     return this.backend;

--- a/tests/hub-entry.test.ts
+++ b/tests/hub-entry.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const startHubMock = vi.hoisted(() => vi.fn());
+const parseHubConfigMock = vi.hoisted(() => vi.fn());
+const sandboxBornMock = vi.hoisted(() => vi.fn());
+const selfRelaunchMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../src/remote/hub-server.js", () => ({ startHub: startHubMock }));
+vi.mock("../src/remote/config.js", () => ({
+  parseHubConfig: parseHubConfigMock,
+}));
+vi.mock("../src/remote/hub-sandbox.js", () => ({
+  sandboxBorn: sandboxBornMock,
+  selfRelaunchOutsideSandbox: selfRelaunchMock,
+}));
+
+import { main } from "../src/bin/hub.js";
+
+/**
+ * Wiring contract for the hub entry (the ordering IS the fix): the sandbox
+ * self-relaunch must happen BEFORE startHub binds the port — otherwise the
+ * sandboxed hub owns the port, the clean launchd instance EADDRINUSE-exits,
+ * and the broken hub keeps serving.
+ */
+describe("hub entry wiring (sandbox self-relaunch)", () => {
+  beforeEach(() => {
+    startHubMock.mockReset().mockResolvedValue({ port: 18377, close: async () => {} });
+    parseHubConfigMock
+      .mockReset()
+      .mockReturnValue({ hubPort: 18377, hubHost: "127.0.0.1", token: "t" });
+    sandboxBornMock.mockReset().mockReturnValue(false);
+    selfRelaunchMock.mockReset().mockReturnValue(false);
+  });
+
+  it("when born sandboxed and the relaunch succeeds: exits without binding", async () => {
+    sandboxBornMock.mockReturnValue(true);
+    selfRelaunchMock.mockReturnValue(true);
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("exit:0");
+    }) as never);
+    try {
+      await expect(main()).rejects.toThrow("exit:0");
+      expect(startHubMock).not.toHaveBeenCalled();
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  it("when not born sandboxed: binds normally and never attempts a relaunch", async () => {
+    await main();
+    expect(sandboxBornMock).toHaveBeenCalled();
+    expect(selfRelaunchMock).not.toHaveBeenCalled();
+    expect(startHubMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("when born sandboxed but the relaunch fails: continues degraded and binds", async () => {
+    sandboxBornMock.mockReturnValue(true);
+    selfRelaunchMock.mockReturnValue(false);
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("exit");
+    }) as never);
+    try {
+      await main();
+      expect(startHubMock).toHaveBeenCalledTimes(1);
+      expect(exitSpy).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+});

--- a/tests/hub-sandbox.test.ts
+++ b/tests/hub-sandbox.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const execFileSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({
+  execFileSync: execFileSyncMock,
+}));
+
+import {
+  buildHubRelaunchPlist,
+  HUB_LAUNCH_LABEL,
+  SANDBOX_ACTIVE_ENV,
+  sandboxBorn,
+  selfRelaunchOutsideSandbox,
+} from "../src/remote/hub-sandbox.js";
+
+describe("hub sandbox self-relaunch", () => {
+  beforeEach(() => {
+    execFileSyncMock.mockReset();
+  });
+
+  it("detects the birth marker (darwin only)", () => {
+    const platform = Object.getOwnPropertyDescriptor(process, "platform")!;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    try {
+      expect(sandboxBorn({ [SANDBOX_ACTIVE_ENV]: "1" })).toBe(true);
+      expect(sandboxBorn({})).toBe(false);
+      // The marker alone means nothing where Seatbelt does not exist.
+      Object.defineProperty(process, "platform", { value: "linux" });
+      expect(sandboxBorn({ [SANDBOX_ACTIVE_ENV]: "1" })).toBe(false);
+    } finally {
+      Object.defineProperty(process, "platform", platform);
+    }
+  });
+
+  it("builds a plist with the hub argv, the env (marker stripped), and XML escaping", () => {
+    const plist = buildHubRelaunchPlist({
+      nodePath: "/usr/bin/node",
+      hubJs: "/opt/acp/dist/bin/hub.js",
+      env: {
+        ZCODE_ACP_REMOTE_TOKEN: "to&k<'s>",
+        [SANDBOX_ACTIVE_ENV]: "1",
+        ZCODE_ACP_HUB_PORT: "18377",
+      },
+      logPath: "/tmp/hub.log",
+    });
+    expect(plist).toContain(`<string>${HUB_LAUNCH_LABEL}</string>`);
+    expect(plist).toContain("<string>/usr/bin/node</string>");
+    expect(plist).toContain("<string>/opt/acp/dist/bin/hub.js</string>");
+    expect(plist).toContain("<string>hub</string>");
+    expect(plist).toContain("<string>to&amp;k&lt;'s&gt;</string>");
+    // The birth marker never travels with the relaunch (no re-trigger loop).
+    expect(plist).not.toContain(SANDBOX_ACTIVE_ENV);
+    expect(plist).toContain("<string>18377</string>");
+    // stdout + stderr both go to the log.
+    expect((plist.match(/\/tmp\/hub\.log/g) ?? []).length).toBe(2);
+    expect(plist).toContain("<false/>");
+  });
+
+  it("self-relaunches: bootstrap then kickstart, plist in a fresh temp dir", () => {
+    execFileSyncMock.mockReturnValue(Buffer.alloc(0));
+    const ok = selfRelaunchOutsideSandbox({
+      nodePath: "/usr/bin/node",
+      hubJs: "/opt/acp/dist/bin/hub.js",
+    });
+    expect(ok).toBe(true);
+    expect(execFileSyncMock).toHaveBeenCalledTimes(2);
+    const [bootstrapCmd, bootstrapArgs] = execFileSyncMock.mock.calls[0]!;
+    expect(bootstrapCmd).toBe("launchctl");
+    expect(bootstrapArgs[0]).toBe("bootstrap");
+    expect(bootstrapArgs[1]).toMatch(/^gui\/\d+$/);
+    expect(String(bootstrapArgs[2])).toMatch(/zcode-hub-relaunch-.*hub\.plist$/);
+    // Plain kickstart — the job was JUST loaded from the fresh plist; a -k
+    // restart would be meaningless here.
+    const [, kickArgs] = execFileSyncMock.mock.calls[1]!;
+    expect(kickArgs[0]).toBe("kickstart");
+    expect(kickArgs[1]).toBe(`gui/${process.getuid()}/${HUB_LAUNCH_LABEL}`);
+  });
+
+  it("swaps a stale definition: bootout the old label, bootstrap the fresh plist", () => {
+    // First bootstrap fails (label already loaded from an earlier relaunch);
+    // bootout clears it, the retried bootstrap loads the FRESH definition.
+    let bootstraps = 0;
+    execFileSyncMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "bootstrap") {
+        bootstraps++;
+        if (bootstraps === 1) throw new Error("already bootstrapped");
+      }
+      return Buffer.alloc(0);
+    });
+    expect(
+      selfRelaunchOutsideSandbox({ nodePath: "/usr/bin/node", hubJs: "/opt/acp/dist/bin/hub.js" }),
+    ).toBe(true);
+    expect(execFileSyncMock.mock.calls.map((c) => c[1][0])).toEqual([
+      "bootstrap",
+      "bootout",
+      "bootstrap",
+      "kickstart",
+    ]);
+  });
+
+  it("never kickstarts an unreplaced definition, and fails after the retries", () => {
+    execFileSyncMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "bootstrap") throw new Error("no gui domain for this user");
+      return Buffer.alloc(0);
+    });
+    expect(
+      selfRelaunchOutsideSandbox({ nodePath: "/usr/bin/node", hubJs: "/opt/acp/dist/bin/hub.js" }),
+    ).toBe(false);
+    // 3 bootstrap attempts (with bootout between), never a blind kickstart —
+    // that would revive the stale job definition.
+    expect(execFileSyncMock.mock.calls.filter((c) => c[1][0] === "bootstrap")).toHaveLength(3);
+    expect(execFileSyncMock.mock.calls.filter((c) => c[1][0] === "kickstart")).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## The bug

A hub born inside our Seatbelt wrap (spawned down-chain from a sandboxed backend) cannot open the visible session terminal: macOS TCC attributes its `open -a Terminal` to the requester identity **"Sandbox"** and Terminal silently refuses the document — while `open` itself **exits 0**, so `spawnTerminalRepl` reads success, the incubation burns its 20s budget, and every remote session-create 502s (the old-App "一直报错" report). Seatbelt cannot be escaped from within; no TCC prompt or open-retry fixes an attribution problem.

## The fix

Route the escape through launchd, which lives outside the sandbox:

1. **Birth marker** — `server.ts ensureBackend()` sets `ZCODE_ACP_SANDBOX_ACTIVE=1` on every sandbox-wrapped backend spawn; it is inherited down any spawn chain, so a hub spawned below a wrapped process carries it. (`ZCODE_ACP_SANDBOX` alone is NOT the signal — a user may legitimately set it globally.)
2. **Hub boot self-check** — `bin/hub.ts` main() checks the marker after config parse and BEFORE binding the port, then relaunches itself: write a LaunchAgent plist into a temp mkdtemp (launchd reads the path itself, the sandbox does not constrain it), `launchctl bootstrap gui/$UID` + `kickstart`. The marker is stripped from the relaunched env (no re-trigger); the relaunched hub binds the now-free port cleanly.
3. **Stale-definition safety** — a label that was already bootstrapped freezes the FIRST plist's definition; `kickstart -k` would silently revive a rotated token/port. The implementation swaps the definition instead: `bootout` the old label, retry the bootstrap (3 attempts), and never kickstarts an unreplaced definition.
4. **Degraded fallback** — if the relaunch fails (no gui domain, launchctl missing), the hub keeps running with an actionable warn; everything but the visible terminal still works.

Review-driven hardening: bootout+retry bootstrap instead of `kickstart -k` (stale-env revival), per-attempt temp dir cleanup via a sentinel file, and a wiring test that pins the ordering (relaunch must precede `startHub`).

## Test plan

- `pnpm typecheck` / `pnpm lint` / prettier clean.
- New `tests/hub-sandbox.test.ts` (marker detection, plist content incl. XML escaping + marker stripping, launchctl call sequences incl. bootout-swap and no-blind-kickstart) and `tests/hub-entry.test.ts` (wiring ordering: relaunch-before-bind, degraded continue).
- Full suite: 974 passed; only the 3 pre-existing environmental `tests/sandbox.test.ts` failures (fail on a clean tree too).