### PR TITLE
feat(remote): terminal-REPL session-resume and executing-session listing exclusion (ADR-0017)

### DIFF
--- a/docs/REMOTE-CLIENTS.md
+++ b/docs/REMOTE-CLIENTS.md
@@ -46,18 +46,18 @@ ACP editor ────── stdio ──────────┘
 
 ## Discovery API
 
-| Endpoint                                               | Auth     | Purpose                                                                                                         |
-| ------------------------------------------------------ | -------- | --------------------------------------------------------------------------------------------------------------- |
-| `GET /api/health`                                      | none     | Liveness probe; `200` body `ok`.                                                                                |
-| `GET /api/instances`                                   | required | Registered bridge instances. Add `?probe=1` to verify first.                                                    |
-| `GET /api/instances/{id}/status`                       | required | Real-time per-session running status of one bridge.                                                             |
-| `POST /api/instances/{id}/sessions/{sessionId}/close`  | required | Retire a session from remote discovery — see [Closing a session](#closing-a-session).                           |
-| `POST /api/instances/{id}/sessions/{sessionId}/rename` | required | Rename a session — see [Renaming a session](#renaming-a-session).                                               |
-| `GET /api/quota`                                       | required | Account-level usage stats — same payload as `account/usage_stats`, no ACP connection needed.                    |
-| `POST /api/upgrade`                                    | required | Trigger the hub's own staleness check — see [Hub self-upgrade](#hub-self-upgrade).                              |
-| `GET /api/projects`                                    | required | Known-project list (remote session-create whitelist) — see below.                                               |
-| `GET /api/projects/sessions?workspacePath=`            | required | A project's full session store incl. closed ones — see [Resuming a closed session](#resuming-a-closed-session). |
-| `POST /api/instances {workspacePath}`                  | required | Create (or reuse) a headless serve bridge for one known project — see below.                                    |
+| Endpoint                                               | Auth     | Purpose                                                                                                                                                     |
+| ------------------------------------------------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET /api/health`                                      | none     | Liveness probe; `200` body `ok`.                                                                                                                            |
+| `GET /api/instances`                                   | required | Registered bridge instances. Add `?probe=1` to verify first.                                                                                                |
+| `GET /api/instances/{id}/status`                       | required | Real-time per-session running status of one bridge.                                                                                                         |
+| `POST /api/instances/{id}/sessions/{sessionId}/close`  | required | Retire a session from remote discovery — see [Closing a session](#closing-a-session).                                                                       |
+| `POST /api/instances/{id}/sessions/{sessionId}/rename` | required | Rename a session — see [Renaming a session](#renaming-a-session).                                                                                           |
+| `GET /api/quota`                                       | required | Account-level usage stats — same payload as `account/usage_stats`, no ACP connection needed.                                                                |
+| `POST /api/upgrade`                                    | required | Trigger the hub's own staleness check — see [Hub self-upgrade](#hub-self-upgrade).                                                                          |
+| `GET /api/projects`                                    | required | Known-project list (remote session-create whitelist) — see below.                                                                                           |
+| `GET /api/projects/sessions?workspacePath=`            | required | A project's full session store incl. closed ones — see [Resuming a closed session](#resuming-a-closed-session).                                             |
+| `POST /api/instances {workspacePath[, sessionId]}`     | required | Create a bridge for one known project — a visible terminal REPL (session-create) or one that boots into a closed session (resume, `sessionId`) — see below. |
 
 HTTP auth: `Authorization: Bearer <token>` or `?token=<token>`.
 
@@ -209,12 +209,23 @@ GET {hub}/api/projects/sessions?workspacePath=/Users/me/proj
   → 400 "workspacePath required" / "invalid limit/before …"
   → 403 "unknown project"          (path not on the known-project list)
   → 502 (spawn failed / bridge unreachable / broken list)
+
+POST {hub}/api/instances  body {"workspacePath":"/Users/me/proj",
+                                "sessionId":"sess_9f2…"}
+  → 200 {"id":"47080","reused":false}   (a NEW instance: the terminal window's bridge)
+  → 400 "invalid sessionId — session id expected"
+  → 502 (spawn failed / never registered; ~20s — a terminal window opens)
 ```
 
 - The listing is the project's backend session store — closed conversations
-  included. `live` marks conversations currently advertised by a bridge (the
-  same membership as discovery); `running` marks an in-flight turn. Titles
-  are the store's authoritative ones.
+  included, and conversations currently executing on this project's bridge
+  (live, or with a turn in flight) EXCLUDED: those belong to discovery, and
+  resuming one would load it onto a second bridge. The `live`/`running`
+  fields stay in the row shape for compatibility but are always `false`.
+  Titles are the store's authoritative ones. A conversation held by a
+  DIFFERENT bridge (e.g. an open editor window) cannot be detected here —
+  the two id spaces are unreconciled by design; check discovery first if in
+  doubt.
 - **Pagination** (projects can hold dozens of sessions): rows come
   newest-first (`updatedAt` descending). `?limit=<n>` sets the page size
   (default 20, max 200); the previous response's `nextCursor` splits into
@@ -226,11 +237,23 @@ GET {hub}/api/projects/sessions?workspacePath=/Users/me/proj
 - The first listing of a cold project incubates its serve bridge (the same
   machinery as remote session-create; budget ~12s) — later listings and the
   follow-up load reuse it.
-- Resume with the existing flow: `POST /api/instances` (answers
-  `reused:true` with the listing's instance), attach
-  `WS /acp?instance=<id>`, then
+- **Resume in the App (no local surface)**: `POST /api/instances` with just
+  the `workspacePath` (answers `reused:true` with the listing's instance),
+  attach `WS /acp?instance=<id>`, then
   `session/load {"sessionId":"<the listed id>"}` — history replays and the
-  conversation continues with `session/prompt`.
+  conversation continues with `session/prompt`, entirely in the client.
+- **Resume on the desktop (ADR-0017)**: `POST /api/instances` with the
+  `sessionId` too — the hub incubates a VISIBLE terminal REPL that boots
+  straight into that conversation (history replays in the window; the same
+  terminal/`ZCODE_ACP_HUB_TERMINAL` selection and headless fallback as
+  session-create). This happens EVEN when a serve bridge is already live
+  (the listing incubated one) — the answer is always the NEW instance, the
+  bridge the window runs on; attach to it and `session/load` the same id to
+  follow along in the client (both surfaces then share one bridge, one
+  backend process). A bogus id still opens the window: the REPL shows the
+  load failure and falls back to a fresh session. Resuming the same session
+  twice pops two windows; only identical concurrent requests share one
+  incubation.
 - `sessionId` here is the backend store id (`sess_…`), which `session/load`
   accepts as-is (pass-through resume). The same conversation may also appear
   in discovery under a different (ACP) id — treat discovery as the

--- a/src/remote/endpoint.ts
+++ b/src/remote/endpoint.ts
@@ -274,6 +274,11 @@ export async function startRemoteEndpoint(
     // "editor" (stdio bridge) or "serve" (headless, hub-spawned, ADR-0014):
     // lets the hub dedupe headless instances per workspace and label them.
     origin: config.origin,
+    // Hub-incubation correlation (ADR-0016/0017): the hub generates a nonce
+    // per spawn and matches its registration poll against it — several
+    // incubations can race for one workspace, and without this one's poll
+    // could claim another's bridge. Bridges started by hand carry none.
+    ...(process.env.ZCODE_ACP_SPAWN_NONCE ? { nonce: process.env.ZCODE_ACP_SPAWN_NONCE } : {}),
     // Lets the hub detect that it is older than this bridge and restart
     // itself (we then re-spawn it from this dist — see registerOnce).
     version: AGENT_INFO.version,

--- a/src/remote/hub-server.ts
+++ b/src/remote/hub-server.ts
@@ -24,7 +24,7 @@
  */
 
 import { spawn, type ChildProcess } from "node:child_process";
-import { createHash, timingSafeEqual } from "node:crypto";
+import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
 import { chmodSync, mkdtempSync, realpathSync, writeFileSync } from "node:fs";
 import type { Dirent } from "node:fs";
 import { readdir, readFile, stat } from "node:fs/promises";
@@ -79,15 +79,17 @@ export interface HubOptions {
    */
   projectsDbPath?: string;
   /**
-   * Override how the remote session-create endpoints spawn a bridge (tests
-   * inject a fake). Default: this node + this package's dist/cli.js — an
-   * interactive REPL in a visible terminal for session-create ("repl"),
-   * a detached headless serve bridge for background queries ("serve").
+   * Override how the remote session-create / session-resume endpoints spawn
+   * a bridge (tests inject a fake). Default: this node + this package's
+   * dist/cli.js — an interactive REPL in a visible terminal for
+   * session-create and session-resume ("repl"; resume carries the requested
+   * session in ZCODE_ACP_RESUME_SESSION), a detached headless serve bridge
+   * for background queries ("serve").
    */
   spawnServe?: (opts: {
     cwd: string;
     env: NodeJS.ProcessEnv;
-    /** "repl" = visible terminal (session-create); "serve" = detached headless. */
+    /** "repl" = visible terminal (session-create/-resume); "serve" = detached headless. */
     kind: "repl" | "serve";
   }) => ChildProcess | Promise<ChildProcess>;
 }
@@ -115,6 +117,13 @@ interface InstanceEntry {
   lastSeen: number;
   /** "editor" (stdio bridge) or "serve" (headless, hub-spawned, ADR-0014). */
   origin: "editor" | "serve";
+  /**
+   * Hub-incubation correlation (ADR-0016/0017): the nonce this bridge's
+   * incubation spawned it with, echoed from ZCODE_ACP_SPAWN_NONCE. Absent on
+   * bridges started by hand or by older hubs — the incubation poll falls back
+   * to any nonce-less registration for them.
+   */
+  nonce?: string;
 }
 
 const HEARTBEAT_TIMEOUT_MS = 30_000;
@@ -165,6 +174,15 @@ async function readJson(req: IncomingMessage): Promise<Record<string, unknown> |
       : null;
   } catch {
     return null;
+  }
+}
+
+/** realpath spelling of p; a vanished path falls back to raw equality. */
+function canonicalPath(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return p;
   }
 }
 
@@ -633,74 +651,94 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
   const timers: Array<ReturnType<typeof setInterval>> = [];
 
   /**
-   * One in-flight serve spawn per workspace (remote session-create,
+   * Single-flight incubation per workspace (remote session-create,
    * ADR-0014): concurrent POSTs for the same project join the SAME
    * incubation instead of racing a second detached process past the
    * findServe check (check-then-act). Check-then-set is one synchronous
    * block, so requests can only ever observe "no entry" one at a time.
+   * A resume incubation keys by session instead (ADR-0017) — concurrent
+   * resumes of different sessions each get their own window.
    */
-  // Single-flight incubation per workspace (see joinIncubation below).
+  // Single-flight incubation (see joinIncubation below).
   const serveIncubations = new Map<
     string,
-    { kind: "repl" | "serve"; promise: Promise<{ id: string; reused: boolean }> }
+    { kind: "repl" | "serve" | "resume"; promise: Promise<{ id: string; reused: boolean }> }
   >();
 
-  /** The live serve instance for a workspace, if any (per-workspace dedupe). */
-  const findServeInstance = (workspacePath: string): InstanceEntry | undefined => {
+  /** Live serve instances for a workspace, oldest registration first. */
+  const findServeInstances = (workspacePath: string): InstanceEntry[] => {
     // The dedupe key must be canonical: a whitelist row (or registration) can
     // carry a symlinked or otherwise non-canonical spelling while the serve
     // child registers with its RESOLVED process cwd — raw string equality
     // would never match, 502-ing every create and spawning a duplicate per
     // retry. realpath both sides; a vanished path falls back to raw equality.
-    const key = (p: string): string => {
-      try {
-        return realpathSync(p);
-      } catch {
-        return p;
-      }
-    };
-    const wanted = key(workspacePath);
-    return Array.from(instances.values()).find(
-      (e) => e.origin === "serve" && key(e.workspace) === wanted,
+    const wanted = canonicalPath(workspacePath);
+    return Array.from(instances.values()).filter(
+      (e) => e.origin === "serve" && canonicalPath(e.workspace) === wanted,
     );
   };
+
+  /** The live serve instance for a workspace, if any (per-workspace dedupe). */
+  const findServeInstance = (workspacePath: string): InstanceEntry | undefined =>
+    findServeInstances(workspacePath)[0];
 
   /**
    * Spawn a bridge and poll until it registers (or fails fast on child exit /
    * timeout). Shared by every incubating endpoint for this workspace — all
-   * joiners see the same outcome. Kind picks the spawn surface: "repl" opens
-   * a visible terminal (remote session-create, ADR-0016), "serve" the
-   * detached headless bridge (background listing, ADR-0015).
+   * joiners see the same outcome. Kind picks the spawn surface and the
+   * payload: "repl" opens a visible terminal (remote session-create,
+   * ADR-0016), "resume" a visible terminal that boots straight into the
+   * requested session (ADR-0017), "serve" the detached headless bridge
+   * (background listing, ADR-0015).
    */
   const incubateServe = async (
     workspacePath: string,
-    kind: "repl" | "serve",
+    kind: "repl" | "serve" | "resume",
+    sessionId?: string,
   ): Promise<{ id: string; reused: boolean }> => {
     // Async spawn failures (ENOENT — the dir vanished between the whitelist
     // check and the spawn) arrive as an 'error' event with exitCode still
     // null; without this flag the poll burns the full budget.
     let spawnError: Error | null = null;
     let child: ChildProcess;
+    // Incubation correlation (ADR-0016/0017): the spawned bridge echoes this
+    // back on every registration, so the poll pairs THIS spawn with ITS
+    // registration even when several incubations race for one workspace.
+    // terminalReplScript exports the var into the terminal's fresh shell; the
+    // detached serve spawn inherits it directly.
+    const nonce = randomUUID();
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      ZCODE_ACP_REMOTE: "1",
+      ZCODE_ACP_REMOTE_TOKEN: token,
+      ZCODE_ACP_HUB_PORT: String(port),
+      ZCODE_ACP_SPAWN_NONCE: nonce,
+      // Parity with the bridge-side spawnHub: the serve child may have to
+      // (re)spawn the hub itself, and must bind the same configured host.
+      ZCODE_ACP_HUB_HOST: host,
+      // ADR-0016: the incubated bridge registers as THIS project's serve
+      // bridge (the hub's per-workspace dedupe matches it) and pins its
+      // session roots to the project cwd, so ADR-0014's whitelist
+      // semantics survive the visible-terminal lifecycle. The detached
+      // serve path ignores both (it hardcodes origin/serveMode itself).
+      ZCODE_ACP_REMOTE_ORIGIN: "serve",
+      ZCODE_ACP_REMOTE_PIN_CWD: "1",
+    };
+    if (kind === "resume") {
+      // ADR-0017: the requested session rides the env — terminalReplScript
+      // exports every ZCODE_ACP_* var into the terminal's fresh shell, so the
+      // REPL boots into it. The detached serve fallback ignores it; the
+      // client attaches to the serve bridge and session/loads there instead.
+      env.ZCODE_ACP_RESUME_SESSION = sessionId;
+    }
     try {
+      // Resume shares session-create's visible-terminal surface (and its
+      // detached-serve fallback for headless machines); only a background
+      // listing spawns the headless form — it must never pop a window.
       child = await spawnServe({
         cwd: workspacePath,
-        kind,
-        env: {
-          ...process.env,
-          ZCODE_ACP_REMOTE: "1",
-          ZCODE_ACP_REMOTE_TOKEN: token,
-          ZCODE_ACP_HUB_PORT: String(port),
-          // Parity with the bridge-side spawnHub: the serve child may have to
-          // (re)spawn the hub itself, and must bind the same configured host.
-          ZCODE_ACP_HUB_HOST: host,
-          // ADR-0016: the incubated bridge registers as THIS project's serve
-          // bridge (the hub's per-workspace dedupe matches it) and pins its
-          // session roots to the project cwd, so ADR-0014's whitelist
-          // semantics survive the visible-terminal lifecycle. The detached
-          // serve path ignores both (it hardcodes origin/serveMode itself).
-          ZCODE_ACP_REMOTE_ORIGIN: "serve",
-          ZCODE_ACP_REMOTE_PIN_CWD: "1",
-        },
+        kind: kind === "serve" ? "serve" : "repl",
+        env,
       });
       child.once("error", (e: Error) => {
         spawnError = e;
@@ -710,13 +748,25 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
       throw new Error("serve bridge spawn failed");
     }
     log(
-      `hub: spawned ${kind === "repl" ? "terminal REPL" : "serve bridge"} for ${workspacePath} (pid ${child.pid})`,
+      `hub: spawned ${
+        kind === "resume" ? "resume REPL" : kind === "repl" ? "terminal REPL" : "serve bridge"
+      } for ${workspacePath} (pid ${child.pid})`,
     );
-    const budget = kind === "repl" ? REPL_REGISTER_TIMEOUT_MS : SERVE_REGISTER_TIMEOUT_MS;
+    const budget = kind === "serve" ? SERVE_REGISTER_TIMEOUT_MS : REPL_REGISTER_TIMEOUT_MS;
     const deadline = Date.now() + budget;
+    // A resume incubates NEXT TO the serve bridge the listing already
+    // incubated, and several incubations can race for one workspace: the poll
+    // matches only a registration that is neither a pre-existing instance nor
+    // another incubation's bridge. A nonce-less registration means a bridge
+    // older than the nonce protocol — accept it, or a legacy spawn could
+    // never satisfy its own incubation.
+    const preexisting = new Set<string>(
+      kind === "resume" ? findServeInstances(workspacePath).map((e) => e.id) : [],
+    );
     for (;;) {
       await new Promise<void>((resolve) => setTimeout(resolve, SERVE_REGISTER_POLL_MS).unref?.());
-      const entry = findServeInstance(workspacePath);
+      const candidates = findServeInstances(workspacePath).filter((e) => !preexisting.has(e.id));
+      const entry = candidates.find((e) => e.nonce === nonce) ?? candidates.find((e) => !e.nonce);
       if (entry) return { id: entry.id, reused: false };
       // The child dying is the honest fast-fail (missing cwd perms, port
       // exhaustion, crash) — without this check the loop burns the full budget.
@@ -736,30 +786,36 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
   /**
    * Single-flight incubation per workspace: concurrent endpoint calls join one
    * spawn instead of racing duplicates. A "serve" caller (the listing) joins
-   * ANY in-flight incubation — the outcome it waits for is "a serve bridge is
-   * registered", whichever surface spawned it. A "repl" caller (session-
-   * create) joins only another repl: the visible window IS the feature
-   * (ADR-0016), so it never piggybacks on an invisible listing spawn.
+   * ANY in-flight incubation keyed to its workspace — the outcome it waits for
+   * is "a serve bridge is registered", whichever surface spawned it. A "repl"
+   * caller (session-create) joins only another repl: the visible window IS the
+   * feature (ADR-0016), so it never piggybacks on an invisible listing spawn.
+   * A "resume" caller joins only the exact same session (ADR-0017) — its map
+   * key carries the session id, so resumes of different sessions each get
+   * their own window.
    */
   const joinIncubation = (
     workspacePath: string,
-    kind: "repl" | "serve",
+    kind: "repl" | "serve" | "resume",
+    sessionId?: string,
   ): Promise<{ id: string; reused: boolean }> => {
-    const inflight = serveIncubations.get(workspacePath);
+    const mapKey =
+      kind === "resume" ? `${workspacePath}\u0000resume\u0000${sessionId ?? ""}` : workspacePath;
+    const inflight = serveIncubations.get(mapKey);
     if (inflight && (inflight.kind === kind || kind === "serve")) {
       log(`hub: joining the incubating serve bridge for ${workspacePath}`);
       return inflight.promise;
     }
-    const promise = incubateServe(workspacePath, kind);
-    serveIncubations.set(workspacePath, { kind, promise });
+    const promise = incubateServe(workspacePath, kind, sessionId);
+    serveIncubations.set(mapKey, { kind, promise });
     // Drop the entry once settled (identity-checked — a newer incubation may
     // already have replaced it). The catch keeps the DERIVED promise handled;
     // the original is awaited by its creating request.
     promise
       .catch(() => undefined)
       .finally(() => {
-        const current = serveIncubations.get(workspacePath);
-        if (current && current.promise === promise) serveIncubations.delete(workspacePath);
+        const current = serveIncubations.get(mapKey);
+        if (current && current.promise === promise) serveIncubations.delete(mapKey);
       });
     return promise;
   };
@@ -1032,18 +1088,24 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
       }
       return;
     }
-    // POST /api/instances — create (or reuse) a bridge for one known project.
+    // POST /api/instances — create (or reuse) a bridge for one known project,
+    // or RESUME one of its closed sessions (optional sessionId, ADR-0017).
     // Session-create incubates a VISIBLE interactive REPL in the user's
     // terminal (ADR-0016, macOS; ZCODE_ACP_HUB_TERMINAL=0 / headless falls
-    // back to the detached `zcode-acp serve` of ADR-0014). The hub waits for
-    // the bridge's heartbeat registration; the bridge lives its own life
-    // afterwards (a terminal REPL until the window closes, a serve bridge on
-    // its idle timer). Dedupe: one serve-origin instance per workspace — an
-    // existing live one is reused, and concurrent POSTs join the same
-    // in-flight incubation instead of double-spawning. Accepted bound: a hub
-    // restart clears the instance table, so a POST inside the bridges' ≤10s
-    // re-registration window may incubate a duplicate — harmless (both serve,
-    // future POSTs dedupe, an idle one exits in 10min).
+    // back to the detached `zcode-acp serve` of ADR-0014). With a sessionId —
+    // the backend store id from the ADR-0015 listing — the hub incubates a
+    // visible REPL that boots straight into that session, EVEN when a serve
+    // bridge is already live (the listing incubated one; a resume must still
+    // surface on the desktop). The hub waits for the bridge's heartbeat
+    // registration; the bridge lives its own life afterwards (a terminal REPL
+    // until the window closes, a serve bridge on its idle timer). Dedupe: one
+    // serve-origin instance per workspace for plain creates — an existing
+    // live one is reused, and concurrent POSTs join the same in-flight
+    // incubation instead of double-spawning; resume POSTs join only the
+    // identical session. Accepted bound: a hub restart clears the instance
+    // table, so a POST inside the bridges' ≤10s re-registration window may
+    // incubate a duplicate — harmless (both serve, future POSTs dedupe, an
+    // idle one exits in 10min).
     if (url.pathname === "/api/instances" && req.method === "POST") {
       if (!authorized(req, url, token)) {
         res.writeHead(401, { "Content-Type": "text/plain" });
@@ -1058,10 +1120,36 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
         res.end("workspacePath required");
         return;
       }
+      // Optional session resume (ADR-0017); the shape mirrors beforeId's.
+      const rawSid = (body as { sessionId?: unknown } | undefined)?.sessionId;
+      const resumeSid = typeof rawSid === "string" ? rawSid.trim() : "";
+      if (resumeSid && !/^[\w.:-]+$/.test(resumeSid)) {
+        res.writeHead(400, { "Content-Type": "text/plain" });
+        res.end("invalid sessionId — session id expected");
+        return;
+      }
       const known = await listKnownWorkspaces(projectsDbPath);
       if (!known.some((p) => p.workspacePath === workspacePath)) {
         res.writeHead(403, { "Content-Type": "text/plain" });
         res.end("unknown project");
+        return;
+      }
+      if (resumeSid) {
+        // Resume never reuses the live serve bridge: the window IS the
+        // feature, and the answer must be the NEW instance so the attaching
+        // client and the terminal share one bridge (and one backend process)
+        // for the session. A bogus id still opens the window — the REPL
+        // shows the load failure and falls back to a fresh session, the same
+        // honesty as a window that dies early (ADR-0016 §4).
+        const incubation = joinIncubation(workspacePath, "resume", resumeSid);
+        try {
+          const out = await incubation;
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(out));
+        } catch (e) {
+          res.writeHead(502, { "Content-Type": "text/plain" });
+          res.end(e instanceof Error ? e.message : "serve bridge failed");
+        }
         return;
       }
       const existing = findServeInstance(workspacePath);
@@ -1241,6 +1329,10 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
           sessions,
           lastSeen: Date.now(),
           origin: parseOrigin(body.origin),
+          // Incubation correlation (ADR-0016/0017); absent for hand-started
+          // bridges. A re-registration (heartbeat) refreshes it — a bridge's
+          // nonce never changes, so this is inert in practice.
+          ...(typeof body.nonce === "string" && body.nonce ? { nonce: body.nonce } : {}),
         });
       } else {
         instances.delete(id);

--- a/src/remote/session-list-endpoint.ts
+++ b/src/remote/session-list-endpoint.ts
@@ -1,14 +1,19 @@
 /**
- * Remote session history endpoint (ADR-0015), served on the bridge's loopback
- * HTTP server and wrapped by the hub at
+ * Remote session history endpoint (ADR-0015, amended by ADR-0017), served on
+ * the bridge's loopback HTTP server and wrapped by the hub at
  * GET /api/projects/sessions?workspacePath=…
  *
  * Discovery (the heartbeat payload) deliberately lists only RUNNING-scoped
  * sessions — deriving membership from the store would flood it with every
  * retired conversation. This endpoint is the deliberate counterpart: the
- * project's ENTIRE backend session store, including closed conversations no
- * bridge currently holds, so a remote client can pick one and resume it with
- * `session/load` (pass-through resume accepts raw backend ids).
+ * project's backend session store, closed conversations included, so a
+ * remote client can pick one and resume it with `session/load` (pass-through
+ * resume accepts raw backend ids). Conversations this bridge currently
+ * holds — live, or with a turn in flight — are NOT listed: they are
+ * discovery's subject, and offering them for resume would let a client load
+ * one onto a second bridge (two backend processes, one conversation).
+ * Sessions held by a DIFFERENT bridge of the same workspace are invisible
+ * here — the two id spaces are unreconciled by design (ADR-0015 §5).
  *
  * Long-lived projects hold dozens of sessions, so the listing is PAGINATED:
  * newest first (updatedAt descending, sessionId descending as the tiebreak so
@@ -17,14 +22,15 @@
  * row of the previous page, so one millisecond holding more rows than a page
  * never skips or repeats them. The response carries `nextCursor`
  * (`{before, beforeId}`, null on the last page). The backend `session/list`
- * has no native pagination — the full store arrives once and is windowed
- * here; entries are tiny, so that round-trip is cheap.
+ * has no native pagination — the full store arrives once, the live/running
+ * exclusion applies BEFORE the window, and only then is it windowed here;
+ * entries are tiny, so that round-trip is cheap.
  *
- * Each entry carries `live` (this bridge currently holds the conversation
- * with real activity) and `running` (a turn is in flight) so a client can
- * render state from this one call. The workspace is never client-chosen:
- * `listSessions` pins serve mode to the process cwd (ADR-0014), and the
- * editor case passes the bridge's own project cwd.
+ * Returned rows keep the `live`/`running` fields for shape compatibility —
+ * they are always false now (executing conversations never reach a page).
+ * The workspace is never client-chosen: `listSessions` pins serve mode to
+ * the process cwd (ADR-0014), and the editor case passes the bridge's own
+ * project cwd.
  */
 
 import type { IncomingMessage, ServerResponse } from "node:http";
@@ -96,10 +102,22 @@ async function handleList(server: ZcodeAcpServer, req: IncomingMessage, res: Ser
   }
 
   const { sessions } = await listSessions(server, { cwd: server.projectCwd() });
+  // Executing conversations are not resumable history: this bridge's live
+  // sessions (discovery membership, hasActivity-gated) and its in-flight
+  // turns are excluded BEFORE sorting and windowing, so pages stay dense and
+  // every cursor keeps naming the exact next row.
+  const running = runningZcodeSids(server);
+  const live = new Set<string>();
+  for (const [acpSid, summary] of server.sessionSummaries) {
+    if (!summary.hasActivity) continue;
+    const zcodeSid = server.resolveSid(acpSid);
+    if (zcodeSid) live.add(zcodeSid);
+  }
+  const resumable = sessions.filter((s) => !live.has(s.sessionId) && !running.has(s.sessionId));
   // Newest first; the id tiebreak makes the order total, and the composite
   // cursor names the exact last row, so pages never repeat or skip rows —
   // even when a single millisecond holds more rows than a page.
-  const sorted = [...sessions].sort(
+  const sorted = [...resumable].sort(
     (a, b) =>
       updatedAtMs(b.updatedAt) - updatedAtMs(a.updatedAt) ||
       (a.sessionId > b.sessionId ? -1 : a.sessionId < b.sessionId ? 1 : 0),
@@ -123,21 +141,10 @@ async function handleList(server: ZcodeAcpServer, req: IncomingMessage, res: Ser
       ? { before: updatedAtMs(lastRow.updatedAt), beforeId: lastRow.sessionId }
       : null;
 
-  // live/running flags are computed once for the PAGE — the membership gates
-  // are the same as discovery's heartbeat payload.
-  const running = runningZcodeSids(server);
-  const live = new Set<string>();
-  for (const [acpSid, summary] of server.sessionSummaries) {
-    if (!summary.hasActivity) continue;
-    const zcodeSid = server.resolveSid(acpSid);
-    if (zcodeSid) live.add(zcodeSid);
-  }
+  // The flags stay in the row shape but are constant false: a conversation
+  // that was live or running was filtered out above and never reaches a page.
   const body = JSON.stringify({
-    sessions: page.map((s) => ({
-      ...s,
-      live: live.has(s.sessionId),
-      running: running.has(s.sessionId),
-    })),
+    sessions: page.map((s) => ({ ...s, live: false, running: false })),
     nextCursor,
   });
   res.writeHead(200, {

--- a/src/repl/run.ts
+++ b/src/repl/run.ts
@@ -458,19 +458,44 @@ export async function runRepl(): Promise<void> {
     clientInfo: { name: "zcode-acp", title: "zcode-acp REPL", version: AGENT_INFO.version },
   });
 
+  // Hub-incubated session resume (ADR-0017): the .command script exports the
+  // requested backend session id, so a remotely resumed conversation boots
+  // straight into it instead of a fresh prompt line. Empty when started by
+  // hand — plain local runs never see the variable.
+  const bootResumeSid = (process.env.ZCODE_ACP_RESUME_SESSION ?? "").trim();
   try {
-    const fresh = await cx.buildSession(process.cwd()).start();
-    if (resumedDuringStartup) {
-      // The user picked a session from /sessions while this cold-start
-      // round-trip was still in flight — the fresh placeholder is already
-      // obsolete and its default status must not overwrite the resumed
-      // session's own seeded selects. Discard it, keep what they expect.
-      fresh.dispose();
+    if (bootResumeSid) {
+      // Boot directly into the requested session; on a failed load (store
+      // entry gone, foreign workspace refused by serve mode) fall back to a
+      // fresh one so the window still lands on a usable prompt line — the
+      // failure note stays visible above.
+      const resumed = await resumeInto({
+        sessionId: bootResumeSid,
+        cwd: process.cwd(),
+        title: null,
+        updatedAt: null,
+      });
+      if (resumed === "failed") {
+        const fresh = await cx.buildSession(process.cwd()).start();
+        activeSession = fresh;
+        status = seedStatusFromNewSession(status, fresh.newSessionResponse);
+      }
+      // "superseded" (the user raced a /sessions pick during this load)
+      // leaves the state to whichever swap went last — no fallback.
     } else {
-      activeSession = fresh;
-      // The initial config options ride the session/new response body, not a
-      // notification — seed the status from it; later switches push updates.
-      status = seedStatusFromNewSession(status, activeSession.newSessionResponse);
+      const fresh = await cx.buildSession(process.cwd()).start();
+      if (resumedDuringStartup) {
+        // The user picked a session from /sessions while this cold-start
+        // round-trip was still in flight — the fresh placeholder is already
+        // obsolete and its default status must not overwrite the resumed
+        // session's own seeded selects. Discard it, keep what they expect.
+        fresh.dispose();
+      } else {
+        activeSession = fresh;
+        // The initial config options ride the session/new response body, not a
+        // notification — seed the status from it; later switches push updates.
+        status = seedStatusFromNewSession(status, activeSession.newSessionResponse);
+      }
     }
   } catch (err) {
     entries = [
@@ -716,9 +741,13 @@ export async function runRepl(): Promise<void> {
    * request goes out or every replayed message is dropped by the SDK's
    * update router. `attachSession` is @internal in the typings but stable at
    * runtime — the only client-side path from a raw sessionId to update
-   * routing (`buildSession().start()` only covers session/new).
+   * routing (`buildSession().start()` only covers session/new). Resolves
+   * "loaded" once the restored history is seeded, "failed" when the load
+   * request errored (a note is printed; the attached session stays put —
+   * the caller decides any fallback), "superseded" when another swap went
+   * first and owns the state now.
    */
-  async function resumeInto(picked: SessionSummary): Promise<void> {
+  async function resumeInto(picked: SessionSummary): Promise<"loaded" | "failed" | "superseded"> {
     const gen = ++swapGen;
     const loaded = (
       cx as unknown as {
@@ -749,11 +778,11 @@ export async function runRepl(): Promise<void> {
         configOptions?: acp.SessionConfigOption[] | null;
         replayMeta?: { replayedMessages?: number; totalMessages?: number; hasMore?: boolean };
       };
-      if (gen !== swapGen) return; // another swap went first — this load is stale
+      if (gen !== swapGen) return "superseded"; // another swap went first — this load is stale
       status = seedStatusFromNewSession(status, resp);
       resumeMeta = resp.replayMeta ?? null;
     } catch (err) {
-      if (gen !== swapGen) return; // stale — another swap owns the state now
+      if (gen !== swapGen) return "superseded"; // stale — another swap owns the state now
       replayMode = false;
       replayTurn = null;
       entries = [
@@ -764,7 +793,7 @@ export async function runRepl(): Promise<void> {
         },
       ];
       rerender();
-      return;
+      return "failed";
     } finally {
       loadSettled = true;
     }
@@ -779,6 +808,7 @@ export async function runRepl(): Promise<void> {
       { kind: "note", text: `resumed "${title}"${truncated || " — history restored above"}` },
     ];
     rerender();
+    return "loaded";
   }
 
   /** Fresh welcome panel entry; reused by startup and `/new`. */

--- a/tests/hub.test.ts
+++ b/tests/hub.test.ts
@@ -1327,6 +1327,135 @@ describe("hub project session history (ADR-0015)", () => {
   });
 });
 
+describe("hub terminal-REPL session resume (ADR-0017)", () => {
+  const PROJECT = "/Users/dev/Develop/demo";
+  const auth = { Authorization: `Bearer ${TOKEN}`, "Content-Type": "application/json" };
+  const post = (hub: HubHandle, body: Record<string, unknown>): Promise<Response> =>
+    fetch(`http://127.0.0.1:${hub.port}/api/instances`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify(body),
+    });
+
+  let fakeChild: EventEmitter & { pid: number; exitCode: number | null; signalCode: string | null };
+  let spawnCalls: Array<{ cwd: string; env: NodeJS.ProcessEnv; kind: "repl" | "serve" }>;
+
+  beforeEach(() => {
+    listKnownWorkspacesMock.mockReset();
+    listKnownWorkspacesMock.mockResolvedValue([
+      { workspacePath: PROJECT, sessions: 3, lastActive: 1234 },
+    ]);
+    fakeChild = new EventEmitter() as typeof fakeChild;
+    fakeChild.pid = 4242;
+    fakeChild.exitCode = null;
+    fakeChild.signalCode = null;
+    spawnCalls = [];
+  });
+
+  function spawnServeSpy(): (opts: {
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+    kind: "repl" | "serve";
+  }) => import("node:child_process").ChildProcess {
+    return (opts) => {
+      spawnCalls.push(opts);
+      return fakeChild as unknown as import("node:child_process").ChildProcess;
+    };
+  }
+
+  async function registerServeBridge(hub: HubHandle, id: string, nonce?: string): Promise<void> {
+    const res = await fetch(`http://127.0.0.1:${hub.port}/api/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(
+        registerBody({
+          id,
+          workspace: PROJECT,
+          origin: "serve",
+          port: BASE_PORT + 50,
+          pid: 4242,
+          ...(nonce ? { nonce } : {}),
+        }),
+      ),
+    });
+    expect(res.ok).toBe(true);
+  }
+
+  it("incubates a visible resume REPL even when a serve bridge is already live", async () => {
+    // The ADR-0015 listing always incubates a headless serve bridge first —
+    // reusing it here (the old behaviour) is exactly why a resume never
+    // surfaced on the desktop. The POST must spawn a terminal surface with
+    // the requested session in the env, and answer with the NEW instance.
+    const hub = await startTestHub({ spawnServe: spawnServeSpy() });
+    await registerServeBridge(hub, "listing-serve");
+    const pending = post(hub, { workspacePath: PROJECT, sessionId: "sess_closed" });
+    await new Promise((r) => setTimeout(r, 400)); // one poll tick
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0]!.kind).toBe("repl");
+    expect(spawnCalls[0]!.env.ZCODE_ACP_RESUME_SESSION).toBe("sess_closed");
+    // The fresh bridge registers with its incubation nonce: the poll pairs
+    // with it, never with the pre-existing listing bridge (whose id would
+    // put the client's session/load on a different process than the window).
+    await registerServeBridge(hub, "resume-repl", spawnCalls[0]!.env.ZCODE_ACP_SPAWN_NONCE);
+    const res = await pending;
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ id: "resume-repl", reused: false });
+  });
+
+  it("carries the resume env into the .command script so the terminal shell boots into the session", () => {
+    // terminalReplScript exports every ZCODE_ACP_* var; the resume id rides
+    // the same channel (hub-server adds it to the incubation env).
+    const body = terminalReplScript(PROJECT, "/opt/cli.js", {
+      ZCODE_ACP_REMOTE: "1",
+      ZCODE_ACP_RESUME_SESSION: "sess_closed",
+    });
+    expect(body).toContain("export ZCODE_ACP_RESUME_SESSION='sess_closed'");
+  });
+
+  it("joins one incubation for identical concurrent resumes, but not a different session", async () => {
+    const hub = await startTestHub({ spawnServe: spawnServeSpy() });
+    const first = post(hub, { workspacePath: PROJECT, sessionId: "sess_a" });
+    const sameSid = post(hub, { workspacePath: PROJECT, sessionId: "sess_a" });
+    const otherSid = post(hub, { workspacePath: PROJECT, sessionId: "sess_b" });
+    await new Promise((r) => setTimeout(r, 400)); // one poll tick
+    expect(spawnCalls).toHaveLength(2); // sess_a shares one spawn; sess_b is its own
+    expect(spawnCalls[0]!.env.ZCODE_ACP_RESUME_SESSION).toBe("sess_a");
+    expect(spawnCalls[1]!.env.ZCODE_ACP_RESUME_SESSION).toBe("sess_b");
+    // Each window's bridge registers with its OWN nonce — the polls must not
+    // cross-claim (a crossed answer would attach the client to the wrong
+    // bridge and load the session on two backend processes).
+    await registerServeBridge(hub, "resume-a", spawnCalls[0]!.env.ZCODE_ACP_SPAWN_NONCE);
+    await registerServeBridge(hub, "resume-b", spawnCalls[1]!.env.ZCODE_ACP_SPAWN_NONCE);
+    const [ra, rs, ro] = await Promise.all([first, sameSid, otherSid]);
+    expect(await ra.json()).toEqual({ id: "resume-a", reused: false });
+    expect(await rs.json()).toEqual({ id: "resume-a", reused: false });
+    expect(await ro.json()).toEqual({ id: "resume-b", reused: false });
+  });
+
+  it("rejects a malformed sessionId without spawning", async () => {
+    const hub = await startTestHub({ spawnServe: spawnServeSpy() });
+    const res = await post(hub, { workspacePath: PROJECT, sessionId: "bad id" });
+    expect(res.status).toBe(400);
+    expect(await res.text()).toBe("invalid sessionId — session id expected");
+    expect(spawnCalls).toHaveLength(0);
+    // Unknown projects still gate the resume spawn like a create.
+    const unknown = await post(hub, { workspacePath: "/etc", sessionId: "sess_x" });
+    expect(unknown.status).toBe(403);
+  });
+
+  it("answers 502 when the resume REPL never registers", async () => {
+    // The child-death fast-fail fires on the first poll tick — no need to
+    // wait out the full 20s GUI budget.
+    const hub = await startTestHub({ spawnServe: spawnServeSpy() });
+    const pending = post(hub, { workspacePath: PROJECT, sessionId: "sess_closed" });
+    await new Promise((r) => setTimeout(r, 400));
+    fakeChild.exitCode = 1; // the window died before its bridge registered
+    const res = await pending;
+    expect(res.status).toBe(502);
+    expect(await res.text()).toBe("serve bridge exited during startup");
+  });
+});
+
 describe("terminal launch resolution (ADR-0016)", () => {
   it("prefers the explicit command template over everything", () => {
     const out = resolveTerminalLaunch({

--- a/tests/remote-session-list.test.ts
+++ b/tests/remote-session-list.test.ts
@@ -1,10 +1,12 @@
 /**
- * Session history endpoint (ADR-0015): the bridge-side GET /sessions handler
- * through a real loopback HTTP server with an in-memory ZcodeAcpServer and a
- * fake backend. Proves the FULL store listing (closed conversations included —
- * the counterpart to the running-scoped discovery payload), the per-entry
- * live/running flags a remote resume picker renders, and the pagination that
- * keeps long-lived projects browsable (newest first, limit + before cursor).
+ * Session history endpoint (ADR-0015, amended by ADR-0017): the bridge-side
+ * GET /sessions handler through a real loopback HTTP server with an
+ * in-memory ZcodeAcpServer and a fake backend. Proves that currently
+ * executing conversations (live or running on this bridge) are EXCLUDED —
+ * they belong to discovery, and resuming one would load it onto a second
+ * bridge — that closed conversations list with the compatibility row shape,
+ * and the pagination that keeps long-lived projects browsable (newest first,
+ * limit + before cursor, exclusion applied before the window).
  */
 
 import { createServer, type Server } from "node:http";
@@ -70,7 +72,7 @@ function fixture(n: number): Array<{ sessionId: string; title: string; updatedAt
 }
 
 describe("session history endpoint", () => {
-  it("lists the full store — closed sessions included — with live/running flags", async () => {
+  it("excludes sessions this bridge holds live; closed ones list with the row shape", async () => {
     const server = new ZcodeAcpServer();
     server.backend = listBackend([
       { sessionId: "sess_closed", title: "Old work", updatedAt: 800 },
@@ -91,12 +93,17 @@ describe("session history endpoint", () => {
       }>;
       nextCursor: { before: number; beforeId: string } | null;
     };
-    const byId = Object.fromEntries(body.sessions.map((s) => [s.sessionId, s]));
-    expect(Object.keys(byId).sort()).toEqual(["sess_closed", "sess_live"]);
-    // Closed conversation: full entry, no live alias on this bridge.
-    expect(byId.sess_closed).toMatchObject({ title: "Old work", live: false, running: false });
-    expect(typeof byId.sess_closed!.updatedAt).toBe("string");
-    expect(byId.sess_live).toMatchObject({ title: "Current", live: true, running: false });
+    // The executing conversation belongs to discovery, not to the resume
+    // surface — offering it here would let a client load it onto a second
+    // bridge (ADR-0015 as amended by ADR-0017).
+    expect(body.sessions.map((s) => s.sessionId)).toEqual(["sess_closed"]);
+    expect(body.sessions[0]).toMatchObject({
+      title: "Old work",
+      // Shape-compat fields: constant false now.
+      live: false,
+      running: false,
+    });
+    expect(typeof body.sessions[0]!.updatedAt).toBe("string");
     // Fewer rows than the page size — no continuation.
     expect(body.nextCursor).toBeNull();
   });
@@ -198,7 +205,7 @@ describe("session history endpoint", () => {
     expect((await fetch(`${base}/sessions?beforeId=bad%20id`)).status).toBe(400);
   });
 
-  it("marks a conversation with an in-flight turn as running", async () => {
+  it("excludes a conversation with an in-flight turn", async () => {
     const server = new ZcodeAcpServer();
     server.backend = listBackend([{ sessionId: "sess_live", title: "busy", updatedAt: 900 }]);
     server.registerSession("s-live", "sess_live");
@@ -206,19 +213,50 @@ describe("session history endpoint", () => {
     server.pendingTurns.set(7, { zcodeSid: "sess_live", cancelled: false });
 
     const res = await fetch(`${await bootList(server)}/sessions`);
-    const body = (await res.json()) as { sessions: Array<{ sessionId: string; running: boolean }> };
-    expect(body.sessions[0]).toMatchObject({ sessionId: "sess_live", running: true });
+    const body = (await res.json()) as { sessions: unknown[] };
+    expect(body.sessions).toEqual([]);
   });
 
-  it("treats a backend-id-only attachment (pass-through resume) as live", async () => {
+  it("excludes a backend-id-only attachment (pass-through resume)", async () => {
     const server = new ZcodeAcpServer();
     server.backend = listBackend([{ sessionId: "sess_direct", title: "remote", updatedAt: 900 }]);
     server.registerSession("sess_direct", "sess_direct");
     server.markSessionActive("sess_direct");
 
     const res = await fetch(`${await bootList(server)}/sessions`);
-    const body = (await res.json()) as { sessions: Array<{ sessionId: string; live: boolean }> };
-    expect(body.sessions[0]).toMatchObject({ sessionId: "sess_direct", live: true });
+    const body = (await res.json()) as { sessions: unknown[] };
+    expect(body.sessions).toEqual([]);
+  });
+
+  it("filters executing sessions BEFORE windowing, so pages stay dense", async () => {
+    // Regression: excluding after the slice would burn page slots on hidden
+    // rows and strand cursor positions. The live row is dropped pre-sort, so
+    // limit=1 serves the newest RESUMABLE row and the cursor chains on.
+    const server = new ZcodeAcpServer();
+    server.backend = listBackend([
+      { sessionId: "sess_old", title: "old", updatedAt: 800 },
+      { sessionId: "sess_mid", title: "mid", updatedAt: 850 },
+      { sessionId: "sess_busy", title: "busy", updatedAt: 900 },
+    ]);
+    server.registerSession("s-busy", "sess_busy");
+    server.markSessionActive("s-busy");
+    const base = await bootList(server);
+    type Body = {
+      sessions: Array<{ sessionId: string }>;
+      nextCursor: { before: number; beforeId: string } | null;
+    };
+
+    const page1 = (await (await fetch(`${base}/sessions?limit=1`)).json()) as Body;
+    expect(page1.sessions.map((s) => s.sessionId)).toEqual(["sess_mid"]);
+    expect(page1.nextCursor).toEqual({ before: 850, beforeId: "sess_mid" });
+
+    const page2 = (await (
+      await fetch(
+        `${base}/sessions?limit=1&before=${page1.nextCursor!.before}&beforeId=${page1.nextCursor!.beforeId}`,
+      )
+    ).json()) as Body;
+    expect(page2.sessions.map((s) => s.sessionId)).toEqual(["sess_old"]);
+    expect(page2.nextCursor).toBeNull();
   });
 
   it("answers 405 for non-GET and 502 when the backend list fails", async () => {


### PR DESCRIPTION
## Summary

Resuming a closed session from the App never surfaced on the desktop: the ADR-0015 listing incubates a headless serve bridge, and the follow-up `POST /api/instances` found it live and answered `reused:true` — only fresh session-create ever opened a terminal window (ADR-0016). This PR extends the remote surface so resume behaves like create, and tightens the listing contract.

- **Terminal-REPL session-resume (ADR-0017)**: `POST /api/instances` accepts an optional `sessionId` (backend store id from the listing). With it, the hub incubates a visible terminal REPL that boots straight into that conversation — even when a serve bridge is already live. The POST answers with the NEW instance so the attaching client and the window share one bridge and one backend process. Headless/SSH/`ZCODE_ACP_HUB_TERMINAL=0` falls back to the detached serve spawn as before.
- **REPL boot-resume**: the session id travels in `ZCODE_ACP_RESUME_SESSION` (exported into the terminal shell by the existing `.command` env channel). The REPL reuses its `/sessions` resume path (`attachSession` + `session/load` with tail replay); a failed load prints the reason and falls back to a fresh session — the window always lands on a usable prompt line.
- **Incubation↔registration correlation**: every incubation now spawns with `ZCODE_ACP_SPAWN_NONCE`, echoed on registration; the register poll pairs a spawn with its own bridge. This fixes cross-claiming when several incubations race for one workspace (two resumes of different sessions, or create vs resume) and stops a resume poll from matching the listing's pre-existing bridge.
- **Listing excludes executing sessions (ADR-0015 amendment)**: conversations the bridge currently holds — live, or with a turn in flight — are filtered out before sorting and windowing, so they can no longer be offered for resume (loading one onto a second bridge means two backend processes driving one conversation). Pagination stays dense; the `live`/`running` row fields remain for compatibility, always `false`.

Docs: `docs/REMOTE-CLIENTS.md` (resume section + endpoint table). ADR-0017 and the ADR-0015 amendment live in `.zcode/docs/adr/` (untracked, per convention).

## App-side coordination (issue #113)

- §2 resume flow: after listing, call `POST /api/instances {"workspacePath", "sessionId"}` for closed sessions and attach to the RETURNED instance id; conversations shown live in discovery keep the plain in-App attach flow.
- §1 listing: rows no longer carry `live:true` — executing sessions never appear in the history list.

## Test plan

- `tests/hub.test.ts`: +5 tests — resume incubates a visible REPL even with a live serve bridge (and answers with the new instance), nonce-carrying registrations pair exactly (no cross-claim between concurrent different-session resumes), identical concurrent resumes join one incubation, malformed `sessionId` → 400 without spawning, child death → 502.
- `tests/remote-session-list.test.ts`: live/running rows are excluded; exclusion happens before the pagination window (pages stay dense, cursors chain).
- `pnpm typecheck`, `pnpm lint`, `pnpm build` clean; full suite green locally except 3 pre-existing `tests/sandbox.test.ts` failures caused by `ZCODE_ACP_SANDBOX=1` leaking from my dev environment (verified failing on a clean tree too).

feat → minor bump via release-please on merge.
