### PR TITLE
feat: REPL attaches to live sessions through the hub; fix plan-approval and replay visibility in the CLI

### DIFF
--- a/docs/REMOTE.md
+++ b/docs/REMOTE.md
@@ -109,6 +109,16 @@ editor uses — attaching by id joins the conversation's live notification
 stream, and the hub dedupes sessions shared by several bridges of the same
 project.
 
+**The local REPL is a hub client too** (ADR-0018). Bare `zcode-acp` in a
+shell with the hub env (`ZCODE_ACP_REMOTE_TOKEN` + `ZCODE_ACP_HUB_PORT`)
+merges sessions that are live on hub instances into its `/sessions` picker
+(marked `live`, `●` while a turn runs) and attaches to them through the hub's
+WS proxy as a second ACP client — replay on attach, then live updates, so a
+conversation being driven from the phone advances on the desktop in real
+time. Without a hub configured or reachable, the picker and resumes behave
+exactly as before. Attaching never touches the owning bridge: leaving the
+REPL (or `/new`) only detaches this client.
+
 Auth is `Authorization: Bearer <token>` or `?token=` (browsers cannot set WS
 headers); `/api/*` sends `Access-Control-Allow-Origin: *` — the token is the
 security boundary. A proxied connection stays bound to one instance; switching

--- a/src/remote/hub-server.ts
+++ b/src/remote/hub-server.ts
@@ -41,6 +41,7 @@ import net from "node:net";
 import path from "node:path";
 import process from "node:process";
 import { tmpdir } from "node:os";
+import type { Duplex } from "node:stream";
 import { fileURLToPath } from "node:url";
 
 import { WebSocket, WebSocketServer, type RawData } from "ws";
@@ -837,6 +838,22 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
 
   const wss = new WebSocketServer({ noServer: true });
 
+  /**
+   * Reject a WS upgrade with a real HTTP status before destroying. A bare
+   * destroy leaves the client's upgrade request hanging on an opaque
+   * ECONNRESET — the `ws` client surfaces that as an error on its internal
+   * upgrade request with no clean signal, so machine clients (the REPL's hub
+   * client included) hang or crash on it instead of reading the reason.
+   */
+  const rejectUpgrade = (socket: Duplex, status: number, reason: string): void => {
+    try {
+      socket.write(`HTTP/1.1 ${status} ${reason}\r\nConnection: close\r\n\r\n`);
+    } catch {
+      // best-effort — the destroy below is the actual rejection
+    }
+    socket.destroy();
+  };
+
   const server: Server = createServer((req, res) => {
     // Async handler failures (malformed URL, aborted body) must never escape
     // into the event loop — warn and drop the connection.
@@ -849,18 +866,18 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
   server.on("upgrade", (req, socket, head) => {
     const url = new URL(req.url ?? "/", "http://127.0.0.1");
     if (url.pathname !== "/acp") {
-      socket.destroy();
+      rejectUpgrade(socket, 404, "Not Found");
       return;
     }
     if (!authorized(req, url, token)) {
       warn("hub: unauthorized WS upgrade rejected");
-      socket.destroy();
+      rejectUpgrade(socket, 401, "Unauthorized");
       return;
     }
     const entry = instances.get(url.searchParams.get("instance") ?? "");
     if (!entry) {
       warn("hub: WS upgrade for unknown instance rejected");
-      socket.destroy();
+      rejectUpgrade(socket, 404, "Unknown Instance");
       return;
     }
     // Dial the bridge's loopback endpoint before accepting the client side,
@@ -883,7 +900,7 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
     });
     bridge.once("error", (e) => {
       warn(`hub: dial bridge :${entry.port} failed: ${e.message}`);
-      socket.destroy();
+      rejectUpgrade(socket, 502, "Bridge Unreachable");
     });
   });
 

--- a/src/repl/App.tsx
+++ b/src/repl/App.tsx
@@ -245,6 +245,16 @@ function EntryView({ entry }: { entry: ReplEntry }): ReactElement {
       );
     case "note":
       return <Text dimColor>-- {entry.text}</Text>;
+    case "plan":
+      // Plan approvals print the full plan into the scrollback (the footer
+      // popup cannot scroll a long document); it stays as the record of what
+      // was approved.
+      return (
+        <Box flexDirection="column" marginTop={1}>
+          <Text dimColor>── plan ──</Text>
+          <Text>{colorizeCodeFences(entry.text)}</Text>
+        </Box>
+      );
     case "welcome":
       return <WelcomeView info={entry.info} />;
   }
@@ -1065,6 +1075,10 @@ function SessionPicker({
         const title = s.title?.trim() || "untitled";
         const age = relativeTime(s.updatedAt);
         const elsewhere = s.cwd && s.cwd !== cwd ? ` · ${s.cwd}` : "";
+        // Live sessions are owned by another bridge instance right now —
+        // picking one attaches through the hub and streams updates as they
+        // happen (ADR-0018) instead of replaying a frozen local snapshot.
+        const live = s.live ? (s.running ? " · live ●" : " · live") : "";
         return (
           <Box key={s.sessionId} paddingLeft={1}>
             <Text color={abs === index ? "cyan" : undefined}>
@@ -1074,6 +1088,7 @@ function SessionPicker({
             <Text dimColor>
               {" "}
               {age ? `· ${age}` : ""}· {s.sessionId.slice(0, 8)}
+              {live}
               {elsewhere}
             </Text>
           </Box>

--- a/src/repl/hub.ts
+++ b/src/repl/hub.ts
@@ -1,0 +1,226 @@
+/**
+ * REPL-side hub client (ADR-0018): discover bridge instances through the hub
+ * daemon and open a proxied WebSocket to a session-owning bridge, so the REPL
+ * can attach to a session ANOTHER process is driving (mobile via a serve
+ * bridge) and receive its updates live. The CLI's own backend sees only a
+ * frozen resident snapshot of such sessions — cross-process pushes do not
+ * exist — so live watching requires attaching at the owner, exactly like the
+ * mobile App does.
+ *
+ * Everything here is best-effort discovery plumbing: the REPL degrades to its
+ * plain local-bridge behaviour whenever the hub is unconfigured, unreachable,
+ * or the picked session is not live anywhere.
+ */
+
+import { Duplex } from "node:stream";
+import path from "node:path";
+import process from "node:process";
+
+import { WebSocket } from "ws";
+
+/** Where to reach the hub. The hub itself is what binds and authenticates. */
+export interface HubRef {
+  port: number;
+  token: string;
+  /** http://127.0.0.1:<port> — /api/instances and friends. */
+  baseUrl: string;
+  /** ws://127.0.0.1:<port> — the /acp proxy upgrade endpoint. */
+  wsBase: string;
+}
+
+/**
+ * Resolve the hub from the same env the bridges and hub process use. The
+ * REMOTE gate is deliberately NOT required: this is a client, not a bridge —
+ * the token plus port are enough to talk to an existing hub. Loopback only,
+ * matching bridge registration (remote/endpoint.ts): ZCODE_ACP_HUB_HOST is a
+ * bind address, not a dial address.
+ */
+export function resolveHubClient(env: NodeJS.ProcessEnv = process.env): HubRef | null {
+  const token = env.ZCODE_ACP_REMOTE_TOKEN;
+  if (!token) return null;
+  const parsed = Number.parseInt(env.ZCODE_ACP_HUB_PORT ?? "", 10);
+  const port = Number.isFinite(parsed) && parsed > 0 ? parsed : 8377;
+  return {
+    port,
+    token,
+    baseUrl: `http://127.0.0.1:${port}`,
+    wsBase: `ws://127.0.0.1:${port}`,
+  };
+}
+
+/** One registered bridge instance as /api/instances returns it (additive-only). */
+export interface HubInstance {
+  id: string;
+  port: number;
+  pid: number;
+  startedAt?: string;
+  workspace?: string;
+  origin?: string;
+  sessions?: Array<{
+    sessionId: string;
+    title?: string;
+    updatedAt?: string;
+    status?: string;
+  }>;
+}
+
+/** GET /api/instances (Bearer auth). Rejects on non-2xx, timeout, bad payload. */
+export async function fetchInstances(
+  hub: HubRef,
+  opts: { probe?: boolean; timeoutMs?: number } = {},
+): Promise<HubInstance[]> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? 2000);
+  try {
+    const res = await fetch(`${hub.baseUrl}/api/instances${opts.probe ? "?probe=1" : ""}`, {
+      headers: { Authorization: `Bearer ${hub.token}` },
+      signal: controller.signal,
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data: unknown = await res.json();
+    if (!Array.isArray(data)) throw new Error("unexpected payload");
+    return data as HubInstance[];
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * The instance currently owning a session. The hub dedupes sessions across
+ * instances on write (same session stays only on the freshest instance), so
+ * the first hit is the right one.
+ */
+export function findInstanceForSession(
+  instances: HubInstance[],
+  sessionId: string,
+): HubInstance | null {
+  for (const inst of instances) {
+    if ((inst.sessions ?? []).some((s) => s.sessionId === sessionId)) return inst;
+  }
+  return null;
+}
+
+/**
+ * Whether a hub instance's workspace is the given project directory. Pure
+ * path-resolution compare — a remote attach is only offered for the REPL's
+ * own project, matching what the local session/list already shows.
+ */
+export function sameWorkspace(a: string | undefined, b: string): boolean {
+  if (!a) return false;
+  try {
+    return path.resolve(a) === path.resolve(b);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Bridge a WebSocket to the byte streams `acp.ndJsonStream` expects. Outgoing
+ * bytes are buffered and each "\n"-terminated line is sent as one WS message;
+ * each incoming WS message is re-terminated with "\n" (ACP frames are single
+ * JSON documents — 1 message = 1 frame, the newline is for ndJsonStream's
+ * parser). Close/error end or destroy the stream so the SDK's pending reads
+ * surface the loss instead of hanging.
+ */
+export function wsToStream(ws: WebSocket): Duplex {
+  let pending = "";
+  let ended = false;
+  const duplex = new Duplex({
+    read() {},
+    write(chunk: Buffer | string, _enc, cb) {
+      pending += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+      let idx: number;
+      while ((idx = pending.indexOf("\n")) >= 0) {
+        const line = pending.slice(0, idx);
+        pending = pending.slice(idx + 1);
+        if (line) ws.send(line);
+      }
+      cb();
+    },
+    final(cb) {
+      ws.close();
+      cb();
+    },
+  });
+  ws.on("message", (data: WebSocket.RawData) => {
+    if (ended) return;
+    const bytes = Array.isArray(data)
+      ? Buffer.concat(data)
+      : Buffer.isBuffer(data)
+        ? data
+        : Buffer.from(data as ArrayBuffer);
+    duplex.push(Buffer.concat([bytes, Buffer.from("\n")]));
+  });
+  ws.on("close", () => {
+    if (ended) return;
+    ended = true;
+    duplex.push(null);
+  });
+  ws.on("error", (err: Error) => {
+    if (ended) return;
+    ended = true;
+    duplex.destroy(err);
+  });
+  return duplex;
+}
+
+export interface HubSocket {
+  /** Raw socket — attach close/error listeners for loss detection. */
+  ws: WebSocket;
+  /** ndJson-ready byte stream pair feeding `acp.ndJsonStream`. */
+  duplex: Duplex;
+}
+
+/**
+ * Open the hub's proxied ACP WebSocket to one bridge instance. The hub
+ * destroys the socket without an HTTP error on unknown instance or bad token,
+ * so failures surface as a close/error rather than an HTTP status. Rejects on
+ * open timeout.
+ */
+export async function openHubSocket(
+  hub: HubRef,
+  instanceId: string,
+  timeoutMs = 5000,
+): Promise<HubSocket> {
+  const ws = new WebSocket(
+    `${hub.wsBase}/acp?instance=${encodeURIComponent(instanceId)}&token=${encodeURIComponent(hub.token)}`,
+  );
+  const duplex = wsToStream(ws);
+  await new Promise<void>((resolve, reject) => {
+    // The hub rejects an upgrade with an HTTP status and then destroys the
+    // socket, so an ECONNRESET and the error response can arrive in either
+    // order — two error events on the same ws. The error listener therefore
+    // stays attached for the socket's lifetime and settles once; anything
+    // after the handshake resolved or rejected is swallowed here instead of
+    // reaching the process as an uncaught 'error'.
+    let done = false;
+    const timer = setTimeout(() => {
+      finish(new Error(`hub ws open timeout (${timeoutMs}ms)`));
+      ws.terminate();
+    }, timeoutMs);
+    const onOpen = (): void => finish(null);
+    const onClose = (): void => finish(new Error("hub ws closed during open"));
+    const onError = (err: Error): void => finish(err);
+    const finish = (err: Error | null): void => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      ws.removeListener("open", onOpen);
+      ws.removeListener("close", onClose);
+      if (err) reject(err);
+      else resolve();
+    };
+    ws.once("open", onOpen);
+    ws.once("close", onClose);
+    ws.on("error", onError);
+    // The hub rejects upgrades with a real HTTP status (401/404/502). ws only
+    // surfaces those as `unexpected-response`; with nobody listening it falls
+    // back to abortHandshake, which fires an uncaught error on the upgrade
+    // request. Consume the pair here and settle with a readable reason.
+    ws.on("unexpected-response", (_req, res) => {
+      res.destroy();
+      finish(new Error(`hub rejected the upgrade (HTTP ${res.statusCode})`));
+    });
+  });
+  return { ws, duplex };
+}

--- a/src/repl/model.ts
+++ b/src/repl/model.ts
@@ -202,6 +202,7 @@ export type ReplEntry =
   | { kind: "assistant"; text: string }
   | { kind: "tool"; id?: string; title: string; status: string }
   | { kind: "note"; text: string }
+  | { kind: "plan"; text: string }
   | { kind: "welcome"; info: WelcomeInfo };
 
 /** Live snapshot of a turn in progress (null textBuf/thinkBuf = not streaming). */
@@ -256,6 +257,31 @@ function blockText(content: unknown): string {
 }
 
 /**
+ * Plan text for an ExitPlanMode approval popup. The bridge ships it as the
+ * permission request's `toolCall.rawInput` — `{ plan: string }` on current
+ * backends (server-requests.ts also copies it into the tool_call's content
+ * blocks). A bare string passes through; any other object falls back to
+ * pretty-printed JSON so the reviewer never sees an empty popup. Null when
+ * nothing readable is there.
+ */
+export function planTextFromRawInput(raw: unknown): string | null {
+  if (typeof raw === "string") return raw.trim() ? raw : null;
+  if (raw && typeof raw === "object") {
+    const plan = (raw as { plan?: unknown }).plan;
+    if (typeof plan === "string" && plan.trim()) return plan;
+    // An empty object carries nothing worth showing.
+    if (Object.keys(raw).length === 0) return null;
+    try {
+      const json = JSON.stringify(raw, null, 2);
+      return json.trim() ? json : null;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+/**
  * Fold pending stream buffers into entries. The live tail renders entries
  * first and the streaming buffers last, so a segment that starts later must
  * not stay buffered below entries that streamed earlier — flush on every
@@ -285,6 +311,18 @@ export function applyUpdate(state: TurnState, update: SessionUpdate): TurnState 
     toolTails: state.toolTails,
   };
   switch (update.sessionUpdate) {
+    case "user_message_chunk": {
+      // User turns reach the REPL through two paths — replayed history and the
+      // bridge's echo of a remote client's prompt (io.ts echoUserPromptToOthers).
+      // Both were silently dropped before (no case here), welding neighbouring
+      // assistant text across turn boundaries and hiding what a remote turn was
+      // even asked. A user chunk is a hard boundary: flush pending buffers so
+      // the prompt lands exactly between what streamed before and after it.
+      flushBuffers(next);
+      const chunk = blockText(update.content);
+      if (chunk.trim()) next.entries = [...next.entries, { kind: "user", text: chunk }];
+      return next;
+    }
     case "agent_message_chunk": {
       const chunk = blockText(update.content);
       // Entering prose flushes the thought stream as its own dim entry.
@@ -393,6 +431,10 @@ export interface SessionSummary {
   cwd: string;
   title?: string | null;
   updatedAt?: string | null;
+  /** Session is live on a hub instance right now — attachable with live updates. */
+  live?: boolean;
+  /** A turn is running on the owning instance right now. */
+  running?: boolean;
 }
 
 /**

--- a/src/repl/run.ts
+++ b/src/repl/run.ts
@@ -10,7 +10,7 @@
  */
 
 import { spawn } from "node:child_process";
-import { Readable, Writable } from "node:stream";
+import { type Duplex, Readable, Writable } from "node:stream";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
@@ -18,6 +18,7 @@ import * as acp from "@agentclientprotocol/sdk";
 import type { ActiveSession } from "@agentclientprotocol/sdk";
 import { render } from "ink";
 import { createElement } from "react";
+import type { WebSocket } from "ws";
 import { z } from "zod";
 
 import { queryQuota } from "../quota/index.js";
@@ -41,6 +42,7 @@ import {
   handleLocalCommand,
   parseCommand,
   parseQuestionForm,
+  planTextFromRawInput,
   seedStatusFromNewSession,
   selectLabel,
   type QuestionForm,
@@ -49,6 +51,14 @@ import {
   type TurnState,
 } from "./model.js";
 import { HISTORY_MAX, historyPath, loadHistory, pushHistory, saveHistory } from "./history.js";
+import {
+  fetchInstances,
+  openHubSocket,
+  resolveHubClient,
+  sameWorkspace,
+  type HubInstance,
+  type HubSocket,
+} from "./hub.js";
 import { createLineEditor, replaceText, type LineEditor } from "./input-buffer.js";
 
 export async function runRepl(): Promise<void> {
@@ -170,6 +180,19 @@ export async function runRepl(): Promise<void> {
   // scrollback with thousands of lines in one burst — a bounded recent tail
   // gives context without the wall-of-text scroll jump.
   const RESUME_TAIL_LIMIT = 50;
+  // Hub-proxied attach (ADR-0018): budget for the WebSocket open round-trip.
+  const REMOTE_OPEN_TIMEOUT_MS = 5000;
+  // Non-null while a hub-proxied remote attach is live: the raw socket pair
+  // feeding the remote connection. Teardown is client-side only — the owning
+  // serve bridge and its session are never touched.
+  let remote: { ws: WebSocket; duplex: Duplex } | null = null;
+  // ACP context of the connection that owns activeSession — the local bridge
+  // (assigned once cx exists) or, while attached, the remote bridge.
+  // Out-of-band calls (session/cancel) must reach the OWNING connection.
+  let activeCx: acp.ClientContext | null = null;
+  // Hub discovery from env; null = no hub configured — the picker then works
+  // exactly as before this feature existed.
+  const hubRef = resolveHubClient();
   const sleep = (ms: number): Promise<null> =>
     new Promise((resolve) => setTimeout(() => resolve(null), ms));
   // Prompts submitted while another turn runs (or before the session is
@@ -350,96 +373,119 @@ export async function runRepl(): Promise<void> {
     Writable.toWeb(child.stdin! as Writable),
     Readable.toWeb(child.stdout!) as ReadableStream<Uint8Array>,
   );
-  const app = acp
-    .client({ name: "zcode-acp" })
-    .onRequest("session/request_permission", async (ctx) => {
-      // A remote client (mobile/hub) may answer the broadcast request first;
-      // the bridge then cancels this losing copy and the SDK aborts
-      // ctx.signal — settle here so our picker dismisses instead of hanging.
-      const id = await new Promise<string | null>((resolve) => {
-        const onAbort = () => {
-          permissionResolver = null;
-          permission = null;
+  // One ACP client connection with the REPL's full handler chain — used for
+  // the local bridge AND, per attach, for hub-proxied remote bridges
+  // (ADR-0018): both peers are plain ACP agents, and permission, elicitation,
+  // and turn-state handling are identical.
+  function buildConnection(acpStream: acp.Stream): acp.ClientConnection {
+    const app = acp
+      .client({ name: "zcode-acp" })
+      .onRequest("session/request_permission", async (ctx) => {
+        // A remote client (mobile/hub) may answer the broadcast request first;
+        // the bridge then cancels this losing copy and the SDK aborts
+        // ctx.signal — settle here so our picker dismisses instead of hanging.
+        const id = await new Promise<string | null>((resolve) => {
+          const onAbort = () => {
+            permissionResolver = null;
+            permission = null;
+            rerender();
+            resolve(null);
+          };
+          ctx.signal.addEventListener("abort", onAbort, { once: true });
+          permissionResolver = (v) => {
+            ctx.signal.removeEventListener("abort", onAbort);
+            resolve(v);
+          };
+          const options = ctx.params.options.map((o) => ({ id: o.optionId, name: o.name }));
+          // ExitPlanMode arrives as an approve/reject permission pair (see
+          // interaction/adapter.ts). The plan text rides toolCall.rawInput
+          // ({plan}); the footer popup cannot scroll a long document, so print
+          // the full plan into the transcript and keep the popup to a pointer.
+          const isPlan =
+            options.length === 2 && options.every((o) => o.id === "approve" || o.id === "reject");
+          const raw = ctx.params.toolCall?.rawInput;
+          let detail: string | undefined;
+          if (isPlan) {
+            const plan = planTextFromRawInput(raw);
+            if (plan) {
+              entries = [...entries, { kind: "plan", text: plan }];
+              const firstLine = plan.split("\n").find((l) => l.trim()) ?? "";
+              detail = `plan printed above — ${firstLine.trim().slice(0, 80)}`;
+            } else {
+              detail = "(no plan text in the request)";
+            }
+          } else {
+            detail = typeof raw === "string" ? raw : undefined;
+          }
+          permission = {
+            heading: isPlan ? "plan approval" : "permission requested",
+            title: ctx.params.toolCall?.title ?? "tool call",
+            detail,
+            options,
+          };
           rerender();
-          resolve(null);
-        };
-        ctx.signal.addEventListener("abort", onAbort, { once: true });
-        permissionResolver = (v) => {
-          ctx.signal.removeEventListener("abort", onAbort);
-          resolve(v);
-        };
-        const options = ctx.params.options.map((o) => ({ id: o.optionId, name: o.name }));
-        // ExitPlanMode arrives as an approve/reject permission pair (see
-        // interaction/adapter.ts); head it as a plan approval and show the
-        // plan text so the decision is actually reviewable.
-        const isPlan =
-          options.length === 2 && options.every((o) => o.id === "approve" || o.id === "reject");
-        const raw = ctx.params.toolCall?.rawInput;
-        permission = {
-          heading: isPlan ? "plan approval" : "permission requested",
-          title: ctx.params.toolCall?.title ?? "tool call",
-          detail: typeof raw === "string" ? raw : undefined,
-          options,
-        };
+        });
+        permissionResolver = null;
+        permission = null;
         rerender();
-      });
-      permissionResolver = null;
-      permission = null;
-      rerender();
-      return id === null
-        ? { outcome: { outcome: "cancelled" } }
-        : { outcome: { outcome: "selected", optionId: id } };
-    })
-    .onRequest("elicitation/create", async (ctx) => {
-      // AskUserQuestion arrives as the bridge's form elicitation. Each
-      // question walks the picker sequentially; skipped questions omit
-      // their key (the backend treats them as unanswered).
-      const forms = parseQuestionForm(ctx.params);
-      if (!forms) return { action: "decline", reason: "unsupported elicitation form" };
-      const content: Record<string, string | string[]> = {};
-      for (const form of forms) {
-        const answer = await askQuestion(form, ctx.signal);
-        // A remote client winning the broadcast aborts our request via
-        // ctx.signal — stop answering instead of walking remaining questions.
-        if (ctx.signal.aborted) return { action: "decline", reason: "cancelled" };
-        if (answer === null) continue; // skipped
-        if (form.multiSelect) {
-          const merged = [...answer.picked, ...(answer.custom ? [answer.custom] : [])];
-          if (merged.length > 0) content[form.key] = merged;
-        } else {
-          content[form.key] = answer.custom || answer.picked[0] || "";
+        return id === null
+          ? { outcome: { outcome: "cancelled" } }
+          : { outcome: { outcome: "selected", optionId: id } };
+      })
+      .onRequest("elicitation/create", async (ctx) => {
+        // AskUserQuestion arrives as the bridge's form elicitation. Each
+        // question walks the picker sequentially; skipped questions omit
+        // their key (the backend treats them as unanswered).
+        const forms = parseQuestionForm(ctx.params);
+        if (!forms) return { action: "decline", reason: "unsupported elicitation form" };
+        const content: Record<string, string | string[]> = {};
+        for (const form of forms) {
+          const answer = await askQuestion(form, ctx.signal);
+          // A remote client winning the broadcast aborts our request via
+          // ctx.signal — stop answering instead of walking remaining questions.
+          if (ctx.signal.aborted) return { action: "decline", reason: "cancelled" };
+          if (answer === null) continue; // skipped
+          if (form.multiSelect) {
+            const merged = [...answer.picked, ...(answer.custom ? [answer.custom] : [])];
+            if (merged.length > 0) content[form.key] = merged;
+          } else {
+            content[form.key] = answer.custom || answer.picked[0] || "";
+          }
         }
-      }
-      return { action: "accept", content };
-    })
-    // Out-of-band turn indicator broadcast by the bridge on every prompt start
-    // and end. Drives turns the REPL did NOT start itself: a mobile/second
-    // client prompting this session must render here too — without it those
-    // updates would be silently dropped (the pump only folds updates while a
-    // turn is active).
-    .onNotification(
-      "$/zcode/turnState",
-      z.object({ sessionId: z.string(), running: z.boolean() }),
-      (ctx) => {
-        if (!activeSession || ctx.params.sessionId !== activeSession.sessionId) return;
-        if (ctx.params.running) {
-          // Local prompts already opened the turn in startTurn; idempotent.
-          if (!turnActive && !replayMode) {
-            turn = createTurnState();
-            turnActive = true;
+        return { action: "accept", content };
+      })
+      // Out-of-band turn indicator broadcast by the bridge on every prompt start
+      // and end. Drives turns the REPL did NOT start itself: a mobile/second
+      // client prompting this session must render here too — without it those
+      // updates would be silently dropped (the pump only folds updates while a
+      // turn is active).
+      .onNotification(
+        "$/zcode/turnState",
+        z.object({ sessionId: z.string(), running: z.boolean() }),
+        (ctx) => {
+          if (!activeSession || ctx.params.sessionId !== activeSession.sessionId) return;
+          if (ctx.params.running) {
+            // Local prompts already opened the turn in startTurn; idempotent.
+            if (!turnActive && !replayMode) {
+              turn = createTurnState();
+              turnActive = true;
+              rerender();
+            }
+          } else if (turnActive && !promptInFlight) {
+            // Remote turn finished (no stop message reaches non-initiators).
+            entries = [...entries, ...finishTurn(turn ?? createTurnState())];
+            turn = null;
+            turnActive = false;
+            drainQueue();
             rerender();
           }
-        } else if (turnActive && !promptInFlight) {
-          // Remote turn finished (no stop message reaches non-initiators).
-          entries = [...entries, ...finishTurn(turn ?? createTurnState())];
-          turn = null;
-          turnActive = false;
-          drainQueue();
-          rerender();
-        }
-      },
-    )
-    .connect(stream);
+        },
+      )
+      .connect(acpStream);
+    return app;
+  }
+
+  const app = buildConnection(stream);
   const cx = app.agent;
 
   // Advertise form-elicitation so AskUserQuestion routes here as a
@@ -569,6 +615,15 @@ export async function runRepl(): Promise<void> {
         } else if (turnActive) {
           turn = applyUpdate(turn ?? createTurnState(), msg.update);
           rerender();
+        } else if (msg.update.sessionUpdate === "user_message_chunk") {
+          // A remote-initiated prompt's echo lands BEFORE the turnState
+          // running notification (separate frames through the hub): open the
+          // turn here so the prompt text renders instead of being dropped.
+          // The running:true that follows is idempotent; running:false closes
+          // this turn exactly like any remote turn.
+          turn = applyUpdate(createTurnState(), msg.update);
+          turnActive = true;
+          rerender();
         } else if (statusChanged) {
           rerender();
         }
@@ -667,7 +722,9 @@ export async function runRepl(): Promise<void> {
   function onCancelTurn(): void {
     if (!activeSession || !turn) return;
     try {
-      void cx.notify("session/cancel", { sessionId: activeSession.sessionId });
+      // The connection that OWNS the active session — the local bridge, or
+      // the hub-proxied remote bridge while attached (ADR-0018).
+      void (activeCx ?? cx).notify("session/cancel", { sessionId: activeSession.sessionId });
     } catch {
       // best-effort; a second ctrl-c exits outright
     }
@@ -675,8 +732,10 @@ export async function runRepl(): Promise<void> {
 
   /**
    * `/sessions`: list this project's sessions via ACP `session/list` (the
-   * backend filters by workspace), let the user pick one interactively, then
-   * resume it with `session/load` (full history replayed into the transcript).
+   * backend filters by workspace), merge in sessions currently live on hub
+   * instances (ADR-0018, marked `live`), let the user pick one interactively,
+   * then attach: through the hub when the session is live somewhere (live
+   * updates), otherwise a local `session/load` resume (tail replay).
    */
   async function openSessionPicker(): Promise<void> {
     if (turnActive) {
@@ -714,6 +773,42 @@ export async function runRepl(): Promise<void> {
       title: s.title ?? null,
       updatedAt: s.updatedAt ?? null,
     }));
+    // Live view (ADR-0018): merge sessions currently registered on hub
+    // instances for this project. Best-effort — no hub configured, hub down,
+    // or auth trouble just means no `live` markers and plain local resumes,
+    // exactly like before the feature existed.
+    const liveOn = new Map<string, { inst: HubInstance; running: boolean }>();
+    if (hubRef) {
+      try {
+        for (const inst of await fetchInstances(hubRef, { timeoutMs: 2000 })) {
+          if (!sameWorkspace(inst.workspace, process.cwd())) continue;
+          for (const s of inst.sessions ?? []) {
+            liveOn.set(s.sessionId, { inst, running: s.status === "running" });
+          }
+        }
+      } catch {
+        // hub unreachable — local list only
+      }
+    }
+    for (const [sid, { inst, running }] of liveOn) {
+      const existing = items.find((s) => s.sessionId === sid);
+      const meta = inst.sessions?.find((s) => s.sessionId === sid);
+      if (existing) {
+        existing.live = true;
+        existing.running = running;
+        existing.title = existing.title ?? meta?.title ?? null;
+        existing.updatedAt = existing.updatedAt ?? meta?.updatedAt ?? null;
+      } else {
+        items.push({
+          sessionId: sid,
+          cwd: inst.workspace ?? "",
+          title: meta?.title ?? null,
+          updatedAt: meta?.updatedAt ?? null,
+          live: true,
+          running,
+        });
+      }
+    }
     if (items.length === 0) {
       entries = [...entries, { kind: "note", text: "no previous sessions in this project yet" }];
       rerender();
@@ -730,7 +825,9 @@ export async function runRepl(): Promise<void> {
     const picked = items.find((s) => s.sessionId === sid);
     if (sid && picked) {
       resumedDuringStartup = true;
-      await resumeInto(picked);
+      const live = liveOn.get(sid);
+      if (hubRef && live) await attachRemote(picked, live.inst);
+      else await resumeInto(picked);
     }
   }
 
@@ -754,6 +851,10 @@ export async function runRepl(): Promise<void> {
         attachSession(response: { sessionId: string }): ActiveSession;
       }
     ).attachSession({ sessionId: picked.sessionId });
+    // Switching to a LOCAL session tears down any hub attach first: its
+    // socket, connection context, and permission-handler slot must not
+    // outlive the swap.
+    closeRemoteAttach();
     activeSession?.dispose();
     activeSession = loaded;
     replayTurn = createTurnState();
@@ -765,6 +866,7 @@ export async function runRepl(): Promise<void> {
       replayedMessages?: number;
       totalMessages?: number;
       hasMore?: boolean;
+      turnActive?: boolean;
     } | null = null;
     try {
       const resp = (await cx.request("session/load", {
@@ -795,10 +897,19 @@ export async function runRepl(): Promise<void> {
       rerender();
       return "failed";
     } finally {
-      loadSettled = true;
+      // Same generation guard as attachRemote: a stale resume resolving after
+      // a newer swap must not end that swap's replay drain early.
+      if (gen === swapGen) loadSettled = true;
     }
     const title = picked.title?.trim() || picked.sessionId.slice(0, 8);
     const m = resumeMeta;
+    // Loaded mid-turn (e.g. a hub client prompted this local bridge while the
+    // REPL was detached): the running flag rides the load response — no start
+    // notification will fire for an already-started turn.
+    if (m?.turnActive && !turnActive) {
+      turn = createTurnState();
+      turnActive = true;
+    }
     const truncated =
       m?.hasMore && typeof m.replayedMessages === "number" && typeof m.totalMessages === "number"
         ? ` — showing last ${m.replayedMessages} of ${m.totalMessages} messages`
@@ -809,6 +920,199 @@ export async function runRepl(): Promise<void> {
     ];
     rerender();
     return "loaded";
+  }
+
+  /**
+   * Client-side teardown of a hub-proxied attach. Never touches the owning
+   * bridge: closing the proxied socket just removes this client from the
+   * owner's broadcast registry — the session (and any turn on it) continues.
+   */
+  function closeRemoteAttach(): void {
+    if (!remote) return;
+    try {
+      remote.ws.close();
+    } catch {
+      // ignore
+    }
+    remote = null;
+    activeCx = null;
+  }
+
+  /**
+   * Attach to a session live on ANOTHER bridge instance through the hub's WS
+   * proxy (ADR-0018): the REPL becomes a second ACP client at the owner, so
+   * replay and live stream are native client fan-out — the only way to watch
+   * a session another process is driving (the CLI's own backend holds just a
+   * frozen resident snapshot of those). Any failure falls back to the plain
+   * local resume.
+   */
+  async function attachRemote(picked: SessionSummary, inst: HubInstance): Promise<void> {
+    if (!hubRef) return;
+    const gen = ++swapGen;
+    let socket: HubSocket | null = null;
+    // A remote client can race a prompt into the CURRENT session during the
+    // attach's await windows; swapping then would orphan that turn (same
+    // discipline as /new) — bail out and stay put instead.
+    const racedTurn = (): boolean => {
+      if (gen !== swapGen) {
+        socket?.ws.close();
+        return true;
+      }
+      if (turnActive) {
+        socket?.ws.close();
+        entries = [
+          ...entries,
+          { kind: "note", text: "a turn started while attaching — staying in the current session" },
+        ];
+        rerender();
+        return true;
+      }
+      return false;
+    };
+    try {
+      socket = await openHubSocket(hubRef, inst.id, REMOTE_OPEN_TIMEOUT_MS);
+      const sock = socket;
+      if (racedTurn()) return;
+      const rapp = buildConnection(
+        acp.ndJsonStream(
+          Writable.toWeb(sock.duplex),
+          Readable.toWeb(sock.duplex) as ReadableStream<Uint8Array>,
+        ),
+      );
+      const rcx = rapp.agent;
+      // The bridge answers only initialize until the handshake completes —
+      // same requirement as the local connection's startup.
+      await rcx.request("initialize", {
+        protocolVersion: 1,
+        clientCapabilities: {
+          fs: { readTextFile: false, writeTextFile: false },
+          elicitation: { form: {} },
+        },
+        clientInfo: { name: "zcode-acp", title: "zcode-acp REPL", version: AGENT_INFO.version },
+      });
+      if (racedTurn()) return;
+      // Attach BEFORE the load request goes out — same ordering constraint as
+      // the local resume, or every replayed update is dropped by the SDK's
+      // update router.
+      const loaded = (
+        rcx as unknown as { attachSession(response: { sessionId: string }): ActiveSession }
+      ).attachSession({ sessionId: picked.sessionId });
+      // Loss detection: the hub or the owning bridge going away must not leave
+      // a frozen "live" view (or the pump spinning on a dead read).
+      sock.ws.once("close", () => {
+        // Recovery only when THIS socket is still the active attach. The
+        // generation is deliberately not consulted: if a second attach is
+        // still mid-flight, the first attach's session IS the live view, so
+        // its loss must recover; once another attach (or /new) owns the slot,
+        // the ws identity check is what makes this handler inert.
+        if (remote?.ws !== sock.ws) return;
+        remote = null;
+        activeCx = null;
+        // The remote stream is dead — no stop or turnState will ever arrive,
+        // so any open turn UI is force-closed here rather than left spinning.
+        if (turnActive) {
+          entries = [
+            ...entries,
+            ...finishTurn(turn ?? createTurnState(), "remote connection lost"),
+          ];
+          turn = null;
+          turnActive = false;
+          promptInFlight = false;
+        }
+        entries = [
+          ...entries,
+          {
+            kind: "note",
+            text: "remote attach lost — starting a fresh local session (use /sessions to reload)",
+          },
+        ];
+        rerender();
+        void startFreshSession();
+      });
+      // Any previous attach is torn down first — its socket, its connection
+      // context, and its permission-handler slot all go with it.
+      closeRemoteAttach();
+      activeSession?.dispose();
+      activeSession = loaded;
+      activeCx = rcx;
+      remote = { ws: sock.ws, duplex: sock.duplex };
+      replayTurn = createTurnState();
+      replayMode = true;
+      loadSettled = false;
+      rerender();
+      let resp: {
+        configOptions?: acp.SessionConfigOption[] | null;
+        replayMeta?: {
+          replayedMessages?: number;
+          totalMessages?: number;
+          hasMore?: boolean;
+          turnActive?: boolean;
+        };
+      };
+      try {
+        resp = (await rcx.request("session/load", {
+          sessionId: picked.sessionId,
+          cwd: process.cwd(),
+          mcpServers: [],
+          // Tail replay (ADR-0003), same bound as the local resume.
+          _meta: { zcode: { limit: RESUME_TAIL_LIMIT } },
+        })) as typeof resp;
+      } finally {
+        // The whole backlog is queued once the load resolves — without this
+        // the pump waits for a quiet window that never opens. Generation
+        // guarded: a stale load resolving after a newer swap (which owns the
+        // flag now) must not end that swap's replay drain early.
+        if (gen === swapGen) loadSettled = true;
+      }
+      if (gen !== swapGen) return; // stale — another swap owns the state now
+      status = seedStatusFromNewSession(status, resp);
+      const m = resp.replayMeta ?? null;
+      // A turn already running at attach time (the mobile mid-turn — the main
+      // scenario) never sends a start notification we could hear; this flag in
+      // the load response is the only signal.
+      if (m?.turnActive && !turnActive) {
+        turn = createTurnState();
+        turnActive = true;
+      }
+      const title = picked.title?.trim() || picked.sessionId.slice(0, 8);
+      const truncated =
+        m?.hasMore && typeof m.replayedMessages === "number" && typeof m.totalMessages === "number"
+          ? ` — showing last ${m.replayedMessages} of ${m.totalMessages} messages`
+          : "";
+      entries = [
+        ...entries,
+        {
+          kind: "note",
+          text: `attached live "${title}" via hub (${inst.origin ?? "remote"} instance ${inst.id.slice(0, 8)})${truncated}`,
+        },
+      ];
+      rerender();
+    } catch (err) {
+      const why = err instanceof Error ? err.message : String(err);
+      if (gen !== swapGen) return; // another swap owns the state now
+      try {
+        socket?.ws.close();
+      } catch {
+        // ignore
+      }
+      // Only this attach's own state may be cleared here: a failure BEFORE
+      // installation leaves the previous attach's socket live in `remote`,
+      // and clearing it would orphan that ws (its permission fan-out would
+      // keep reaching this REPL with nothing left to close it).
+      if (socket && remote?.ws === socket.ws) {
+        remote = null;
+        activeCx = null;
+      }
+      entries = [
+        ...entries,
+        { kind: "note", text: `remote attach failed (${why}) — loading locally instead` },
+      ];
+      rerender();
+      // Fall back to the plain local load. If the swap had already completed,
+      // resumeInto disposes the (now stream-less) remote session itself; if it
+      // hadn't, it disposes the previous session as any resume would.
+      await resumeInto(picked);
+    }
   }
 
   /** Fresh welcome panel entry; reused by startup and `/new`. */
@@ -876,6 +1180,9 @@ export async function runRepl(): Promise<void> {
         rerender();
         return;
       }
+      // `/new` means a fresh LOCAL session: a hub-proxied attach is torn down
+      // first (client-side only — the owner keeps running).
+      closeRemoteAttach();
       activeSession?.dispose();
       activeSession = fresh;
       status = seedStatusFromNewSession(status, fresh.newSessionResponse);
@@ -938,6 +1245,13 @@ export async function runRepl(): Promise<void> {
     // not skip the child shutdown and leave the process hanging.
     try {
       activeSession?.dispose();
+    } catch {
+      // ignore
+    }
+    try {
+      // Closing the proxied socket only detaches this client — the owning
+      // serve bridge and its session are never touched from here.
+      closeRemoteAttach();
     } catch {
       // ignore
     }

--- a/tests/repl-hub.test.ts
+++ b/tests/repl-hub.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Tests for the REPL's hub client (src/repl/hub.ts): env resolution, pure
+ * discovery helpers, instance listing against a real hub, and the
+ * WebSocket→stream adapter exercised end-to-end — a scripted fake bridge
+ * behind a real hub's WS proxy serves an SDK ACP client through
+ * openHubSocket, walking the same initialize + session/load path the REPL's
+ * remote attach uses (ADR-0018).
+ */
+
+import { Readable, Writable } from "node:stream";
+
+import * as acp from "@agentclientprotocol/sdk";
+import type { ActiveSession } from "@agentclientprotocol/sdk";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WebSocket, WebSocketServer } from "ws";
+
+// The quota endpoint must not touch the real usage APIs in tests.
+const { accountUsageStatsMock } = vi.hoisted(() => ({
+  accountUsageStatsMock: vi.fn(),
+}));
+vi.mock("../src/handlers/account.js", () => ({
+  accountUsageStats: accountUsageStatsMock,
+}));
+
+// Discovery helpers read the known-project whitelist from tasks-index; mock
+// the module so no real sqlite/App store is touched.
+vi.mock("../src/tasks-index.js", () => ({
+  listKnownWorkspaces: vi.fn().mockReturnValue([]),
+}));
+
+import {
+  fetchInstances,
+  findInstanceForSession,
+  openHubSocket,
+  resolveHubClient,
+  sameWorkspace,
+  type HubInstance,
+  type HubRef,
+} from "../src/repl/hub.js";
+import { startHub, type HubHandle } from "../src/remote/hub-server.js";
+
+const TOKEN = "test-hub-token";
+
+const cleanups: Array<() => Promise<void> | void> = [];
+
+function track<T>(value: T, stop: (v: T) => Promise<void> | void): T {
+  cleanups.push(() => stop(value));
+  return value;
+}
+
+async function startTestHub(): Promise<HubHandle> {
+  const hub = await startHub({ port: 0, host: "127.0.0.1", token: TOKEN });
+  cleanups.push(() => hub.close());
+  return hub;
+}
+
+function hubRefFor(port: number, token = TOKEN): HubRef {
+  return {
+    port,
+    token,
+    baseUrl: `http://127.0.0.1:${port}`,
+    wsBase: `ws://127.0.0.1:${port}`,
+  };
+}
+
+function registerBody(overrides: Record<string, unknown> = {}) {
+  return {
+    token: TOKEN,
+    id: "inst-1",
+    port: 1, // nothing listens unless the test says otherwise
+    pid: 123,
+    workspace: "/tmp/proj",
+    sessions: [{ sessionId: "s1", title: "hello", updatedAt: 1 }],
+    ...overrides,
+  };
+}
+
+async function register(hub: HubHandle, body: unknown): Promise<void> {
+  const res = await fetch(`http://127.0.0.1:${hub.port}/api/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  expect(res.status).toBe(200);
+}
+
+async function closeWs(ws: WebSocket): Promise<void> {
+  if (ws.readyState === WebSocket.CLOSED) return;
+  await new Promise<void>((resolve) => {
+    ws.once("close", () => resolve());
+    ws.close();
+  });
+}
+
+function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`timeout: ${label}`)), ms);
+    p.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(timer);
+        reject(e instanceof Error ? e : new Error(String(e)));
+      },
+    );
+  });
+}
+
+beforeEach(() => {
+  cleanups.length = 0;
+});
+
+afterEach(async () => {
+  while (cleanups.length > 0) {
+    const stop = cleanups.pop();
+    if (stop) await stop();
+  }
+});
+
+describe("resolveHubClient", () => {
+  it("returns null without a token", () => {
+    expect(resolveHubClient({})).toBeNull();
+  });
+
+  it("defaults the port and dials loopback", () => {
+    const hub = resolveHubClient({ ZCODE_ACP_REMOTE_TOKEN: "t" });
+    expect(hub).toMatchObject({
+      port: 8377,
+      baseUrl: "http://127.0.0.1:8377",
+      wsBase: "ws://127.0.0.1:8377",
+    });
+  });
+
+  it("honors a numeric ZCODE_ACP_HUB_PORT and rejects garbage", () => {
+    expect(
+      resolveHubClient({ ZCODE_ACP_REMOTE_TOKEN: "t", ZCODE_ACP_HUB_PORT: "18377" })?.port,
+    ).toBe(18377);
+    expect(resolveHubClient({ ZCODE_ACP_REMOTE_TOKEN: "t", ZCODE_ACP_HUB_PORT: "abc" })?.port).toBe(
+      8377,
+    );
+  });
+});
+
+describe("discovery helpers", () => {
+  const instances: HubInstance[] = [
+    {
+      id: "a",
+      port: 1,
+      pid: 1,
+      workspace: "/tmp/proj",
+      sessions: [{ sessionId: "s1" }],
+    },
+    {
+      id: "b",
+      port: 2,
+      pid: 2,
+      workspace: "/tmp/other",
+      sessions: [{ sessionId: "s2" }, { sessionId: "s3" }],
+    },
+  ];
+
+  it("finds the instance owning a session", () => {
+    expect(findInstanceForSession(instances, "s2")?.id).toBe("b");
+    expect(findInstanceForSession(instances, "nope")).toBeNull();
+  });
+
+  it("matches instance workspace by resolved path", () => {
+    expect(sameWorkspace("/tmp/proj/", "/tmp/proj")).toBe(true);
+    expect(sameWorkspace("/tmp/other", "/tmp/proj")).toBe(false);
+    expect(sameWorkspace(undefined, "/tmp/proj")).toBe(false);
+  });
+});
+
+describe("fetchInstances", () => {
+  it("lists registered instances with Bearer auth", async () => {
+    const hub = await startTestHub();
+    await register(hub, registerBody());
+    const list = await fetchInstances(hubRefFor(hub.port));
+    expect(list).toHaveLength(1);
+    expect(list[0]).toMatchObject({ id: "inst-1", workspace: "/tmp/proj" });
+    expect(list[0]?.sessions?.[0]?.sessionId).toBe("s1");
+  });
+
+  it("rejects on bad auth", async () => {
+    const hub = await startTestHub();
+    await expect(fetchInstances(hubRefFor(hub.port, "wrong"))).rejects.toThrow("HTTP 401");
+  });
+});
+
+describe("openHubSocket + wsToStream through the hub proxy", () => {
+  /**
+   * A scripted ACP agent behind the hub: answers initialize and session/load,
+   * pushing one replayed update before the load response — the exact shape
+   * the REPL's remote attach consumes.
+   */
+  function startScriptedBridge(): Promise<{ server: WebSocketServer; port: number }> {
+    return new Promise((resolve) => {
+      const server = new WebSocketServer({ port: 0, host: "127.0.0.1" }, () => {
+        const addr = server.address();
+        resolve({ server, port: typeof addr === "object" && addr ? addr.port : 0 });
+      });
+      server.on("connection", (ws) => {
+        ws.on("message", (data) => {
+          const msg = JSON.parse(data.toString()) as {
+            id?: number;
+            method?: string;
+            params?: { sessionId?: string };
+          };
+          if (msg.method === "initialize") {
+            ws.send(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                id: msg.id,
+                result: { protocolVersion: 1, agentInfo: { name: "fake-bridge" } },
+              }),
+            );
+          } else if (msg.method === "session/load") {
+            ws.send(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                method: "session/update",
+                params: {
+                  sessionId: msg.params?.sessionId,
+                  update: {
+                    sessionUpdate: "agent_message_chunk",
+                    content: { type: "text", text: "replayed line" },
+                  },
+                },
+              }),
+            );
+            ws.send(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                id: msg.id,
+                result: {
+                  configOptions: [],
+                  replayMeta: { replayedMessages: 1, totalMessages: 1, hasMore: false },
+                },
+              }),
+            );
+          } else {
+            ws.send(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: {} }));
+          }
+        });
+      });
+    });
+  }
+
+  it("walks initialize + session/load + live updates through the proxy", async () => {
+    const hub = await startTestHub();
+    const bridge = track(
+      await startScriptedBridge(),
+      ({ server }) => new Promise<void>((resolve) => server.close(() => resolve())),
+    );
+    await register(
+      hub,
+      registerBody({
+        port: bridge.port,
+        sessions: [{ sessionId: "s1", title: "t", updatedAt: 1 }],
+      }),
+    );
+
+    const { ws, duplex } = await openHubSocket(hubRefFor(hub.port), "inst-1");
+    track(ws, (w) => closeWs(w));
+
+    const app = acp
+      .client({ name: "zcode-acp" })
+      .connect(
+        acp.ndJsonStream(
+          Writable.toWeb(duplex),
+          Readable.toWeb(duplex) as ReadableStream<Uint8Array>,
+        ),
+      );
+    const cx = app.agent;
+
+    const init = (await withTimeout(
+      cx.request("initialize", { protocolVersion: 1, clientCapabilities: {} }),
+      5000,
+      "initialize",
+    )) as { agentInfo?: { name?: string } };
+    expect(init.agentInfo?.name).toBe("fake-bridge");
+
+    // Same @internal seam the local resume uses: attach before load, or the
+    // SDK's update router drops the replay.
+    const session = (
+      cx as unknown as { attachSession(r: { sessionId: string }): ActiveSession }
+    ).attachSession({ sessionId: "s1" });
+    const resp = (await withTimeout(
+      cx.request("session/load", { sessionId: "s1", cwd: "/tmp/proj", mcpServers: [] }),
+      5000,
+      "session/load",
+    )) as { replayMeta?: { replayedMessages?: number } };
+    expect(resp.replayMeta?.replayedMessages).toBe(1);
+
+    const update = await withTimeout(session.nextUpdate(), 5000, "replayed update");
+    expect(update.kind).toBe("session_update");
+    if (update.kind === "session_update") {
+      expect(update.update).toMatchObject({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "replayed line" },
+      });
+    }
+  });
+
+  it("rejects when the instance is unknown (hub destroys the socket)", async () => {
+    const hub = await startTestHub();
+    await expect(openHubSocket(hubRefFor(hub.port), "missing-instance", 3000)).rejects.toThrow();
+  });
+});

--- a/tests/repl-model.test.ts
+++ b/tests/repl-model.test.ts
@@ -26,6 +26,7 @@ import {
   isOneShotCommandValue,
   lastToolTail,
   parseCommand,
+  planTextFromRawInput,
   relativeTime,
   parseQuestionForm,
   selectLabel,
@@ -723,5 +724,59 @@ describe("formatQuotaLine", () => {
     expect(formatQuotaLine({ kind: "auth_error" })).toBeNull();
     expect(formatQuotaLine({ kind: "unavailable" })).toBeNull();
     expect(formatQuotaLine(null)).toBeNull();
+  });
+});
+
+describe("user_message_chunk", () => {
+  const userChunk = (text: string): SessionUpdateLike =>
+    ({ sessionUpdate: "user_message_chunk", content: { type: "text", text } }) as SessionUpdateLike;
+
+  it("renders user turns as entries instead of dropping them", () => {
+    // Replayed history and the remote-prompt echo both arrive as user chunks;
+    // without this case, neighbouring assistant text welded across the turn
+    // boundary and the prompt vanished from the transcript.
+    let s = createTurnState();
+    s = applyUpdate(s, chunk("agent_message_chunk", "answer one"));
+    s = applyUpdate(s, userChunk("second question"));
+    s = applyUpdate(s, chunk("agent_message_chunk", "answer two"));
+    const done = finishTurn(s);
+    expect(done.map((e) => e.kind)).toEqual(["assistant", "user", "assistant"]);
+    expect(done[1]).toMatchObject({ kind: "user", text: "second question" });
+  });
+
+  it("flushes a pending thought stream before the user turn lands", () => {
+    let s = createTurnState();
+    s = applyUpdate(s, chunk("agent_thought_chunk", "pondering"));
+    s = applyUpdate(s, userChunk("next prompt"));
+    const done = finishTurn(s);
+    expect(done.map((e) => e.kind)).toEqual(["thinking", "user"]);
+  });
+
+  it("ignores whitespace-only user chunks", () => {
+    let s = createTurnState();
+    s = applyUpdate(s, userChunk("   \n"));
+    expect(finishTurn(s)).toEqual([]);
+  });
+});
+
+describe("planTextFromRawInput", () => {
+  it("passes a bare string through", () => {
+    expect(planTextFromRawInput("## plan\n- step")).toBe("## plan\n- step");
+    expect(planTextFromRawInput("   ")).toBeNull();
+  });
+
+  it("extracts the plan field from the object shape the bridge ships", () => {
+    expect(planTextFromRawInput({ plan: "- do X\n- do Y", other: 1 })).toBe("- do X\n- do Y");
+  });
+
+  it("falls back to pretty-printed JSON for unknown object shapes", () => {
+    expect(planTextFromRawInput({ steps: ["a"] })).toBe('{\n  "steps": [\n    "a"\n  ]\n}');
+  });
+
+  it("returns null for empty objects and non-objects", () => {
+    expect(planTextFromRawInput({})).toBeNull();
+    expect(planTextFromRawInput({ plan: "   " })).toBe('{\n  "plan": "   "\n}');
+    expect(planTextFromRawInput(undefined)).toBeNull();
+    expect(planTextFromRawInput(42)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- **Hub attach for the REPL (ADR-0018)**: bare `zcode-acp` can now watch a session that another process (mobile/web client) is driving. `/sessions` merges the hub's live instances (marked `· live`); picking one opens a second ACP client at the owning bridge through the hub's WS proxy — native replay + live fan-out instead of the CLI backend's frozen resident snapshot. Any failure falls back to the plain local resume; socket loss force-closes the turn UI and recovers into a fresh local session.
- **Plan-approval visibility**: the plan-mode permission popup previously showed approve/reject with no plan text. The bridge already ships the plan (tool_call content + rawInput); the REPL now renders the full plan as a transcript entry and keeps the popup detail short.
- **Replay ordering**: replayed/echoed `user_message_chunk` updates now render (flush + append) instead of being dropped, which welded assistant text across turn boundaries.
- **Hub hardening**: WS upgrade rejections now write a real HTTP status line before destroy (bare `socket.destroy()` surfaced as uncaught `ECONNRESET`/404 errors on clients).

## Review

Four review rounds (strong-model Review agent). Rounds 1–2: 1 Critical + 5 Important, all fixed (pump deadloop on missing `loadSettled` reset, stale-remote teardown, idle echo drop, attach await-window turn races, gen-guarded `finally`s). Round 4 release gate: round-3 deltas verified PASS; found and fixed an orphaned-socket case in the attach failure path (`remote` cleared only when the failing attach had already installed itself) and an ADR reference in the new test file.

## Test plan

- [x] `pnpm typecheck` / `pnpm lint` / prettier on changed files — clean
- [x] `tests/repl-hub.test.ts` (9) + `tests/repl-model.test.ts` (60) — 69/69 green
- [x] Full suite green locally except the 3 known environmental `tests/sandbox.test.ts` failures (fail on clean trees too, green in CI)