### PR TITLE
fix: keep active tools alive past stale freeze

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -266,6 +266,7 @@ editor still has it open).
     | no protocol         |
     | progress (120s)     | -> check read watermark
     |   watermark moved   | -> forward throttled usage -> defer (alive)
+    |   active tool       | -> refresh in_progress -> defer (alive)
     |   frozen < 10 min   | -> defer decision
     |   frozen >= 10 min  | -> fetch reply -> end_turn
     |                       |   no reply, no output -> max_turn_requests
@@ -289,9 +290,11 @@ bridge also forwards authoritative progress at most once per minute: a
 known active tool while its watermark is temporarily quiet. These updates are
 state-bearing; the bridge never fabricates transcript text as a heartbeat. A
 watermark frozen for 10 minutes (STALE_FREEZE_MS) still marks the projection as
-truly stale — the turn then ends gently (reply fetch first, bounded stop only
-when nothing was ever delivered). Already-queued events win the deadline race
-and are consumed first.
+truly stale unless a known foreground tool remains nonterminal. An active tool
+is direct lifecycle evidence that the turn has not completed, so the bridge
+keeps waiting and refreshing its existing card. Without an active tool, the
+turn ends gently (reply fetch first, bounded stop only when nothing was ever
+delivered). Already-queued events win the deadline race and are consumed first.
 
 ### Tool lifecycle
 

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -1841,8 +1841,9 @@ export async function runEventTurn(
   // (verified: a sub-agent turn advanced the watermark for 5+ minutes with
   // zero stream events). A live turn may still freeze the watermark for a
   // while (long CoT, quiet tools — observed 60s+ pauses), so a freeze alone
-  // never kills: only a freeze sustained past STALE_FREEZE_MS ends the turn,
-  // reply-fetch first, stop as the last resort.
+  // never kills: only a freeze sustained past STALE_FREEZE_MS with no known
+  // active foreground tool ends the turn, reply-fetch first, stop as the last
+  // resort.
   const STALE_FREEZE_MS = 600_000;
   // Upstream ACP clients commonly enforce their own idle deadline (some use
   // 300s). A session/read watermark can prove that ZCode is still
@@ -1943,14 +1944,24 @@ export async function runEventTurn(
         return { stopReason: "max_turn_requests" };
       } else {
         const frozenMs = Date.now() - lastWatermarkAdvanceAt;
-        if (frozenMs < STALE_FREEZE_MS) {
+        const activeTools = [...translator.seenToolIds].filter(
+          (toolId) => !translator.finalToolIds.has(toolId),
+        ).length;
+        if (activeTools > 0) {
+          // A nonterminal foreground tool is direct evidence that the turn is
+          // not complete, even when token/turn counters are quiet. In
+          // particular, TaskOutput can legitimately span the generic stale
+          // budget while the backend still owns the prompt. Keep forwarding
+          // its state-bearing refreshes instead of inventing end_turn.
+          log(
+            `  [stall] watermark frozen ${Math.round(frozenMs / 1000)}s with ${activeTools} active tool(s); deferring terminal decision`,
+          );
+          nextNoProgressDecisionAt = Date.now() + NO_PROGRESS_MS;
+        } else if (frozenMs < STALE_FREEZE_MS) {
           // The read watermark moved recently — direct evidence the backend is
           // still making progress (typically a sub-agent or slow tool working
           // behind a silent stream). Keep waiting; the 15s stall-reconcile
           // below keeps refreshing the watermark via session/read.
-          const activeTools = [...translator.seenToolIds].filter(
-            (toolId) => !translator.finalToolIds.has(toolId),
-          ).length;
           log(
             `  [stall] watermark advanced within the last ${Math.round(frozenMs / 1000)}s (activeTools=${activeTools}); deferring terminal decision`,
           );

--- a/tests/stale-running-recovery.test.ts
+++ b/tests/stale-running-recovery.test.ts
@@ -245,6 +245,53 @@ describe("stall termination policy (watermark-based)", () => {
     await expect(turn).resolves.toEqual({ stopReason: "end_turn" });
   });
 
+  it("does not infer end_turn while a known tool is active past the stale budget", async () => {
+    // A frozen projection does not override the foreground tool lifecycle.
+    // TaskOutput and other long-running tools can legitimately cross the
+    // generic 10-minute stale budget; treating their in-progress card as
+    // delivered output would falsely report success while the backend still
+    // owns the prompt.
+    const control = staleRunningBackend();
+    control.setWatermarkMode("frozen");
+    const turn = prompt(setup(control.backend), params, cx, 6);
+    let settled: acp.PromptResponse | undefined;
+    void turn.then((value) => {
+      settled = value;
+    });
+    await waitForSend(control.sendRequests);
+
+    control.emit({
+      type: "tool.updated",
+      payload: { kind: "started", toolCallId: "tool-long", toolName: "TaskOutput" },
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    vi.mocked(cx.notify).mockClear();
+
+    await vi.advanceTimersByTimeAsync(700_000);
+
+    expect(settled).toBeUndefined();
+    expect(control.backend.send).not.toHaveBeenCalled();
+    const refreshes = vi
+      .mocked(cx.notify)
+      .mock.calls.map(([, payload]) => (payload as { update?: acp.SessionUpdate }).update)
+      .filter(
+        (update) =>
+          update?.sessionUpdate === "tool_call_update" &&
+          update.toolCallId === "tool-long" &&
+          update.status === "in_progress",
+      );
+    expect(refreshes.length).toBeGreaterThanOrEqual(9);
+
+    control.emit({
+      type: "tool.updated",
+      payload: { kind: "result", toolCallId: "tool-long", result: { content: "done" } },
+    });
+    control.emit({ type: "turn.completed", payload: { resultType: "success" } });
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    await expect(turn).resolves.toEqual({ stopReason: "end_turn" });
+  });
+
   it("ends a watermark-frozen turn after the stale-freeze budget (no output → stop)", async () => {
     // PR #85's original goal stays: a projection stuck at `running` whose
     // watermark never advances must eventually converge instead of hanging
@@ -271,8 +318,9 @@ describe("stall termination policy (watermark-based)", () => {
   });
 
   it("ends a watermark-frozen turn gently when output was already delivered", async () => {
-    // Same freeze, but a tool card was already streamed: the turn is treated
-    // as completed-but-terminal-event-lost — end_turn, no backend stop.
+    // Same freeze, but a completed tool card was already streamed: the turn
+    // is treated as completed-but-terminal-event-lost — end_turn, no backend
+    // stop. A nonterminal tool is covered separately and must stay alive.
     const control = staleRunningBackend();
     control.setWatermarkMode("frozen");
     const turn = prompt(setup(control.backend), params, cx, 3);
@@ -285,6 +333,10 @@ describe("stall termination policy (watermark-based)", () => {
     control.emit({
       type: "tool.updated",
       payload: { kind: "started", toolCallId: "tool-1", toolName: "Read" },
+    });
+    control.emit({
+      type: "tool.updated",
+      payload: { kind: "result", toolCallId: "tool-1", result: { content: "done" } },
     });
     await vi.advanceTimersByTimeAsync(0);
 


### PR DESCRIPTION
## Summary

- treat a known nonterminal foreground tool as direct turn-liveness evidence
- keep the existing throttled `in_progress` refresh active after the generic frozen-watermark budget
- preserve the existing 10-minute convergence behavior when no active tool remains
- document the active-tool branch in the turn state machine

## Root cause

The stall branch counted active tools only while the authoritative watermark was still inside `STALE_FREEZE_MS`. Once the budget expired, any previously delivered tool output allowed `session/prompt` to return successful `end_turn`, even if that tool had never emitted `result` or `error`.

That can release the ACP caller while ZCode still owns the active prompt. A continuation is then rejected as `active prompt exists` and may eventually collapse into a generic `Internal error`.

This follows #109 / #110: those changes made authoritative silent progress visible to upstream ACP clients, while intentionally preserving the existing 10-minute frozen-watermark policy. This PR closes the remaining terminal-decision gap.

## Behavior

- A nonterminal tool defers the terminal decision and keeps receiving state-bearing refreshes.
- A real tool terminal event followed by `turn.completed` resolves normally.
- A frozen turn with no active tool still follows the existing reply-fetch / bounded-stop policy.
- A completed tool with a lost turn terminal event still converges gently without stopping the backend.

## TDD evidence

The new public `session/prompt` regression failed before the implementation:

```text
expected { stopReason: 'end_turn' } to be undefined
```

After the implementation, the focused stale-running suite passes 6/6, including the prior bounded-convergence cases.

## Verification

- full Vitest suite: 69 files, 1002 tests
- TypeScript typecheck
- TypeScript build
- ESLint
- stdio smoke test
- Prettier on changed files
- `git diff --check`

Fixes #121
