### PR TITLE
fix(remote): session-create always incubates a visible terminal REPL (ADR-0016 amendment)

### DIFF
--- a/docs/REMOTE-CLIENTS.md
+++ b/docs/REMOTE-CLIENTS.md
@@ -182,9 +182,14 @@ POST {hub}/api/instances  body {"workspacePath":"/Users/me/proj"}
   Warp cannot execute scripts or commands programmatically at all
   (warpdotdev/warp#1917, #3959, #9083) — naming it warns, and the flow
   degrades to the headless bridge after the register timeout.
-- A live serve-origin instance for the same workspace is reused
-  (`reused:true`) instead of spawning a second one; concurrent creates join
-  the same in-flight spawn instead of racing a duplicate.
+- Create NEVER reuses a live serve-origin instance (ADR-0016 amendment):
+  the App flow lists project history first, which incubates a headless serve
+  bridge, and reuse meant the promised terminal window could never open once
+  a project was browsed. Every create incubates its own window and answers
+  with the NEW instance; concurrent identical creates join the same in-flight
+  spawn instead of racing a duplicate. A client that wants a HEADLESS attach
+  should not POST at all — attach to the instance id the history listing
+  already returns.
 - Lifetime depends on the surface: a terminal-REPL instance lives while its
   window lives (the owner closing it retires the bridge — re-create on
   demand); the headless fallback exists for remote interest only and exits
@@ -237,11 +242,13 @@ POST {hub}/api/instances  body {"workspacePath":"/Users/me/proj",
 - The first listing of a cold project incubates its serve bridge (the same
   machinery as remote session-create; budget ~12s) — later listings and the
   follow-up load reuse it.
-- **Resume in the App (no local surface)**: `POST /api/instances` with just
-  the `workspacePath` (answers `reused:true` with the listing's instance),
-  attach `WS /acp?instance=<id>`, then
-  `session/load {"sessionId":"<the listed id>"}` — history replays and the
-  conversation continues with `session/prompt`, entirely in the client.
+- **Resume in the App (no local surface)**: attach DIRECTLY to the instance
+  the listing already returned (`WS /acp?instance=<listing instance id>` —
+  no POST; a bare POST would now pop a desktop window, see the amendment
+  above), then `session/load {"sessionId":"<the listed id>"}` — history
+  replays and the conversation continues with `session/prompt`, entirely in
+  the client. A cold project (no listing yet) lists first — the listing IS
+  the headless incubator.
 - **Resume on the desktop (ADR-0017)**: `POST /api/instances` with the
   `sessionId` too — the hub incubates a VISIBLE terminal REPL that boots
   straight into that conversation (history replays in the window; the same

--- a/src/remote/hub-server.ts
+++ b/src/remote/hub-server.ts
@@ -755,14 +755,17 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
     );
     const budget = kind === "serve" ? SERVE_REGISTER_TIMEOUT_MS : REPL_REGISTER_TIMEOUT_MS;
     const deadline = Date.now() + budget;
-    // A resume incubates NEXT TO the serve bridge the listing already
-    // incubated, and several incubations can race for one workspace: the poll
-    // matches only a registration that is neither a pre-existing instance nor
-    // another incubation's bridge. A nonce-less registration means a bridge
-    // older than the nonce protocol — accept it, or a legacy spawn could
-    // never satisfy its own incubation.
+    // A visible-terminal incubation (create OR resume) runs NEXT TO the serve
+    // bridge the listing already incubated, and several incubations can race
+    // for one workspace: the poll matches only a registration that is neither
+    // a pre-existing instance nor another incubation's bridge — otherwise a
+    // create would answer with the listing's headless bridge and the window
+    // would never be the returned instance. Only "serve" (the ensure-a-bridge
+    // listing) accepts any live registration. A nonce-less registration means
+    // a bridge older than the nonce protocol — accept it, or a legacy spawn
+    // could never satisfy its own incubation.
     const preexisting = new Set<string>(
-      kind === "resume" ? findServeInstances(workspacePath).map((e) => e.id) : [],
+      kind === "serve" ? [] : findServeInstances(workspacePath).map((e) => e.id),
     );
     for (;;) {
       await new Promise<void>((resolve) => setTimeout(resolve, SERVE_REGISTER_POLL_MS).unref?.());
@@ -1105,24 +1108,24 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
       }
       return;
     }
-    // POST /api/instances — create (or reuse) a bridge for one known project,
-    // or RESUME one of its closed sessions (optional sessionId, ADR-0017).
-    // Session-create incubates a VISIBLE interactive REPL in the user's
-    // terminal (ADR-0016, macOS; ZCODE_ACP_HUB_TERMINAL=0 / headless falls
-    // back to the detached `zcode-acp serve` of ADR-0014). With a sessionId —
-    // the backend store id from the ADR-0015 listing — the hub incubates a
-    // visible REPL that boots straight into that session, EVEN when a serve
-    // bridge is already live (the listing incubated one; a resume must still
-    // surface on the desktop). The hub waits for the bridge's heartbeat
-    // registration; the bridge lives its own life afterwards (a terminal REPL
-    // until the window closes, a serve bridge on its idle timer). Dedupe: one
-    // serve-origin instance per workspace for plain creates — an existing
-    // live one is reused, and concurrent POSTs join the same in-flight
-    // incubation instead of double-spawning; resume POSTs join only the
-    // identical session. Accepted bound: a hub restart clears the instance
-    // table, so a POST inside the bridges' ≤10s re-registration window may
-    // incubate a duplicate — harmless (both serve, future POSTs dedupe, an
-    // idle one exits in 10min).
+    // POST /api/instances — create a bridge for one known project, or RESUME
+    // one of its closed sessions (optional sessionId, ADR-0017). BOTH paths
+    // incubate a VISIBLE interactive REPL in the user's terminal (ADR-0016 as
+    // amended, macOS; ZCODE_ACP_HUB_TERMINAL=0 / headless falls back to the
+    // detached `zcode-acp serve` of ADR-0014). Without a sessionId the REPL
+    // starts a fresh conversation; with one — the backend store id from the
+    // ADR-0015 listing — it boots straight into that session. Neither path
+    // reuses a live serve bridge: the App flow always runs the history
+    // listing first, which incubates a headless serve instance, and reuse
+    // would mean the window can never open (the pre-amendment behaviour).
+    // The hub waits for the bridge's heartbeat registration; the bridge lives
+    // its own life afterwards (a terminal REPL until the window closes, a
+    // serve bridge on its idle timer). Concurrent identical POSTs join one
+    // in-flight incubation; a create and a resume, or two different sessions,
+    // each get their own window. Accepted bound: a hub restart clears the
+    // instance table, so a POST inside the bridges' ≤10s re-registration
+    // window may incubate a duplicate — harmless (the extra window is
+    // closable; background serve bridges dedupe by workspace elsewhere).
     if (url.pathname === "/api/instances" && req.method === "POST") {
       if (!authorized(req, url, token)) {
         res.writeHead(401, { "Content-Type": "text/plain" });
@@ -1169,17 +1172,15 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
         }
         return;
       }
-      const existing = findServeInstance(workspacePath);
-      if (existing) {
-        log(`hub: serve instance for ${workspacePath} already live (${existing.id}) — reusing`);
-        res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ id: existing.id, reused: true }));
-        return;
-      }
-      // Session-create incubates a VISIBLE terminal REPL (ADR-0016) — the
-      // user gets a real local CLI window, not an invisible daemon; the
-      // detached serve spawn is the fallback (no GUI / gated off / macOS
-      // open failure).
+      // Session-create ALWAYS incubates a VISIBLE terminal REPL (ADR-0016 as
+      // amended): the App flow lists the project's history first, which
+      // incubates a headless serve bridge — reusing that instance (the
+      // original behaviour) meant a window could NEVER open once the project
+      // was browsed, and every create ran invisibly in the background. The
+      // answer is the NEW window's instance; concurrent identical POSTs join
+      // one incubation, and the detached headless serve spawn remains the
+      // fallback (no GUI / gated off / open failure). Clients that want a
+      // headless attach use the listing's instance id instead of this POST.
       const incubation = joinIncubation(workspacePath, "repl");
       try {
         const out = await incubation;

--- a/tests/hub.test.ts
+++ b/tests/hub.test.ts
@@ -906,17 +906,22 @@ describe("hub remote session-create (ADR-0014)", () => {
     };
   }
 
-  async function registerServeBridge(hub: HubHandle, workspace: string): Promise<void> {
+  async function registerServeBridge(
+    hub: HubHandle,
+    workspace: string,
+    opts: { id?: string; nonce?: string } = {},
+  ): Promise<void> {
     const res = await fetch(`http://127.0.0.1:${hub.port}/api/register`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(
         registerBody({
-          id: `serve-${workspace}`,
+          id: opts.id ?? `serve-${workspace}`,
           workspace,
           origin: "serve",
           port: BASE_PORT + 50,
           pid: 4242,
+          ...(opts.nonce ? { nonce: opts.nonce } : {}),
         }),
       ),
     });
@@ -973,17 +978,31 @@ describe("hub remote session-create (ADR-0014)", () => {
     expect(await res.json()).toEqual({ id: `serve-${PROJECT}`, reused: false });
   });
 
-  it("reuses an existing serve instance instead of spawning a second one", async () => {
+  it("create ALWAYS incubates a visible REPL even when a serve bridge is already live", async () => {
+    // Regression (ADR-0016 amendment): the App flow lists project history
+    // first, which incubates a headless serve bridge — the old reuse made
+    // every subsequent create answer reused:true and run invisibly in the
+    // background, so the promised terminal window could never open. The POST
+    // must spawn a terminal surface and answer with ITS new instance.
     const hub = await startTestHub({ spawnServe: spawnServeSpy() });
-    await registerServeBridge(hub, PROJECT);
-    const res = await fetch(`http://127.0.0.1:${hub.port}/api/instances`, {
+    await registerServeBridge(hub, PROJECT); // the listing's headless bridge
+    const pending = fetch(`http://127.0.0.1:${hub.port}/api/instances`, {
       method: "POST",
       headers: { ...auth, "Content-Type": "application/json" },
       body: JSON.stringify({ workspacePath: PROJECT }),
     });
+    await new Promise((r) => setTimeout(r, 400)); // one poll tick
+    expect(spawnCount).toBe(1);
+    expect(spawnCalls[0]!.kind).toBe("repl");
+    // The window's bridge registers with its incubation nonce: the poll pairs
+    // with it, never with the pre-existing headless listing bridge.
+    await registerServeBridge(hub, PROJECT, {
+      id: "serve-window",
+      nonce: spawnCalls[0]!.env.ZCODE_ACP_SPAWN_NONCE,
+    });
+    const res = await pending;
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ id: `serve-${PROJECT}`, reused: true });
-    expect(spawnCount).toBe(0);
+    expect(await res.json()).toEqual({ id: "serve-window", reused: false });
   });
 
   it("concurrent POSTs for the same workspace join one incubation (no double spawn)", async () => {
@@ -1007,9 +1026,17 @@ describe("hub remote session-create (ADR-0014)", () => {
     expect(rb.status).toBe(200);
     expect(await ra.json()).toEqual({ id: `serve-${PROJECT}`, reused: false });
     expect(await rb.json()).toEqual({ id: `serve-${PROJECT}`, reused: false });
-    // Settled incubation is gone: the next POST reuses the registered one.
-    expect(await (await post()).json()).toEqual({ id: `serve-${PROJECT}`, reused: true });
-    expect(spawnCount).toBe(1);
+    // Settled incubation is gone, and create never reuses: the next POST
+    // incubates a second window of its own (nonce-paired, so the answer is
+    // the new registration, not the bridge above).
+    const next = post();
+    await new Promise((r) => setTimeout(r, 400));
+    expect(spawnCount).toBe(2);
+    await registerServeBridge(hub, PROJECT, {
+      id: "serve-window-2",
+      nonce: spawnCalls[1]!.env.ZCODE_ACP_SPAWN_NONCE,
+    });
+    expect(await (await next).json()).toEqual({ id: "serve-window-2", reused: false });
   });
 
   it("dedupes across path spellings: a symlinked row matches the resolved registration", async () => {
@@ -1019,20 +1046,49 @@ describe("hub remote session-create (ADR-0014)", () => {
     const real = await mkdtemp(path.join(tmpdir(), "hub-dedupe-"));
     const link = path.join(path.dirname(real), `${path.basename(real)}-link`);
     await symlink(real, link);
+    // The listing proxies the bridge's /sessions — a bare fake server stands
+    // in for the loopback endpoint the reused instance would answer on.
+    const sessions = track(
+      await new Promise<{ server: Server; port: number }>((resolve) => {
+        const server = createServer((_req, res) => {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ sessions: [], nextCursor: null }));
+        });
+        server.listen(0, "127.0.0.1", () => {
+          const addr = server.address();
+          resolve({ server, port: typeof addr === "object" && addr ? addr.port : 0 });
+        });
+      }),
+      ({ server }) => new Promise<void>((r) => server.close(() => r())),
+    );
     try {
       listKnownWorkspacesMock.mockResolvedValue([
         { workspacePath: link, sessions: 1, lastActive: 1 },
       ]);
       const hub = await startTestHub({ spawnServe: spawnServeSpy() });
-      // The bridge registers with its resolved cwd spelling.
-      await registerServeBridge(hub, real);
-      const res = await fetch(`http://127.0.0.1:${hub.port}/api/instances`, {
+      // The bridge registers with its resolved cwd spelling; the listing is
+      // asked with the symlinked whitelist spelling.
+      const reg = await fetch(`http://127.0.0.1:${hub.port}/api/register`, {
         method: "POST",
-        headers: { ...auth, "Content-Type": "application/json" },
-        body: JSON.stringify({ workspacePath: link }),
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(
+          registerBody({
+            id: `serve-${real}`,
+            workspace: real,
+            origin: "serve",
+            port: sessions.port,
+            pid: 4242,
+          }),
+        ),
       });
+      expect(reg.ok).toBe(true);
+      const res = await fetch(
+        `http://127.0.0.1:${hub.port}/api/projects/sessions?workspacePath=${encodeURIComponent(link)}`,
+        { headers: auth },
+      );
       expect(res.status).toBe(200);
-      expect(await res.json()).toEqual({ id: `serve-${real}`, reused: true });
+      const body = (await res.json()) as { instance: { id: string } };
+      expect(body.instance).toEqual({ id: `serve-${real}`, origin: "serve" });
       expect(spawnCount).toBe(0);
     } finally {
       await rm(link, { force: true });


### PR DESCRIPTION
## Summary

Create/resume from the App never opened a visible terminal — everything ran headless in the background. Root cause (verified live on the reporting machine):

- The App always lists project history first (`GET /api/projects/sessions`), which incubates a **headless** serve bridge (ADR-0015 — by design).
- `POST /api/instances` then hit `findServeInstance` and answered `reused:true` — the ADR-0016 terminal path only ran for a *cold* project, which never happens in the real flow. Live evidence: zero `zcode-acp-term-*` script dirs on a machine that has used the feature daily.

## Fix (ADR-0016 amendment)

- **Create never reuses a live serve bridge**: every `POST /api/instances {workspacePath}` incubates a visible terminal REPL and answers with the NEW instance — the same reasoning ADR-0017 applied to resume ("the window IS the feature; reuse means it can never open"). Headless fallback (no GUI / `ZCODE_ACP_HUB_TERMINAL=0` / open failure) unchanged.
- **Nonce-paired polling for every bridge-spawning incubation**: the register poll's pre-existing-instance exclusion now covers `repl` (create) as well as `resume`, so a create can never be answered with the listing's headless bridge.
- **Contract docs** (`docs/REMOTE-CLIENTS.md`): clients wanting a headless attach must not POST — they attach to the instance id the listing already returns.

## Client notes

- **Create**: works with existing client builds — no client change needed; a window now opens every time.
- **Desktop resume**: clients should send `sessionId` (ADR-0017) so the window boots into the resumed conversation; a bare POST now pops a fresh-session window instead of silently reusing.
- **In-App (headless) resume**: attach to the listing's `instance.id` directly; no POST.

## Test plan

- `tests/hub.test.ts`: reuse test flipped to "create ALWAYS incubates a visible REPL even when a serve bridge is already live" (nonce-paired answer); concurrency test tail updated (settled incubation → next POST spawns its own window); symlink dedupe regression re-homed on the listing endpoint (the only remaining `findServeInstance` consumer). 60/60 pass.
- `pnpm typecheck`, `pnpm lint`, `pnpm build` clean; full suite 998 passed (3 pre-existing `tests/sandbox.test.ts` failures are dev-environment `ZCODE_ACP_SANDBOX` leakage, verified failing on a clean tree).

fix → patch bump via release-please on merge.
