### PR TITLE
fix: decline Start Plan provider runtime headers with a clear reason

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -382,6 +382,31 @@ re-registered from the durable store without a resume (or left behind by a
 failed one) therefore replayed nothing. Fixed by explicit backend-loaded
 tracking; the backend also logs a warning now when `session/messages` errors.
 
+### Start Plan (zcode-plan) providers fail headless — 1113 / signing errors
+
+**Symptom:** every turn fails with HTTP 429 error `1113` ("Insufficient
+balance or no resource package") or `ClientRequestSigningV4Error: Client
+signing credential must contain one separator`, while the same account works
+in the ZCode desktop app.
+
+**Cause:** Start Plan providers (`builtin:zai-start-plan`,
+`builtin:bigmodel-start-plan`, baseURL `zcode.z.ai/api/v1/zcode-plan/...`)
+authenticate with the provider's OAuth JWT **plus an Aliyun captcha session**:
+before each model request the backend asks its host via
+`interaction/requestProviderRuntimeHeaders` to solve an Aliyun captcha and
+inject `X-Aliyun-Captcha-Verify-Param`/`-Region` headers. The desktop app
+solves this in its renderer (browser environment, mostly invisible); a
+headless bridge has neither a browser nor the captcha credential. GLM Coding
+Plan providers are unaffected — they use an `id.secret` API key and sign
+requests themselves.
+
+**Workaround:** switch the session's provider to a GLM Coding Plan one
+(model dropdown, or re-enable it in the desktop app so
+`~/.zcode/v2/config.json` marks it `enabled`). The bridge answers the captcha
+request with `headersApplied:false` and the backend surfaces a clear error;
+full Start Plan support headless would require solving the Aliyun captcha
+outside a browser, which this bridge does not do.
+
 ## Log Debugging
 
 ### Enable verbose logging

--- a/src/handlers/server-requests.ts
+++ b/src/handlers/server-requests.ts
@@ -291,10 +291,15 @@ export async function handleServerRequests(
       for (const req of drained) {
         const sid = (req.params as { sessionId?: string }).sessionId;
         if (sid === undefined || sid === mySid) {
-          sendZcodeReply(backend, req.id, {
-            action: "decline",
-            reason: "turn cancelled",
-          });
+          // The captcha-session request must keep its result shape even when
+          // cancelled, or the backend's response validation rejects it.
+          sendZcodeReply(
+            backend,
+            req.id,
+            isProviderRuntimeHeadersRequest(req.method)
+              ? { headersApplied: false, errorMessage: "turn cancelled" }
+              : { action: "decline", reason: "turn cancelled" },
+          );
           declined = true;
         } else {
           backend.requeueServerRequests([req]); // not ours — leave for owner
@@ -350,6 +355,27 @@ async function handleOne(
   const ask = isAskUserQuestion(method, params);
   const perm = isPermissionRequest(method);
   const epm = isExitPlanMode(params);
+
+  // Start Plan providers (zcode-plan endpoints) ask their host to solve an
+  // Aliyun captcha and inject X-Aliyun-Captcha-Verify-* headers before every
+  // model request; the desktop renderer does this from a browser environment.
+  // The headless bridge has neither a browser nor the captcha credential, so
+  // the only honest answer is headersApplied:false — the backend then fails
+  // with its -32031 error carrying our message. Without this, the request
+  // fell through to the generic unsupported-request error and the backend
+  // fell back to client signing with the provider's OAuth JWT, dying with the
+  // misleading "must contain one separator" invalid-config error (#123).
+  if (isProviderRuntimeHeadersRequest(method)) {
+    warn(
+      "  ⚠ provider runtime headers requested (Start Plan captcha session); " +
+        "the headless bridge cannot provide it — declining",
+    );
+    sendZcodeReply(backend, zcodeReqId, {
+      headersApplied: false,
+      errorMessage: PROVIDER_RUNTIME_HEADERS_UNAVAILABLE,
+    });
+    return;
+  }
 
   if (!perm && !(isUserInputRequestUnchecked(method) && (epm || ask))) {
     warn(`  ⚠ unhandled server→client request: ${method} (id=${zcodeReqId})`);
@@ -923,11 +949,7 @@ function sendInteractionReply(
 }
 
 /** Send a zcode response (result) for a server→client request id. */
-function sendZcodeReply(
-  backend: ZcodeBackend,
-  zcodeId: number | string,
-  result: ZcodeInteractionResponse,
-): void {
+function sendZcodeReply(backend: ZcodeBackend, zcodeId: number | string, result: unknown): void {
   // zcode expects {id, result} — but our backend.notify sends {method, params}. Use a raw write.
   // The backend's notify is for notifications; replies need the id. We route via a private seam.
   (backend as unknown as { sendReply: (id: number | string, result: unknown) => void }).sendReply(
@@ -948,3 +970,17 @@ function sendZcodeError(backend: ZcodeBackend, zcodeId: number | string, message
 function isUserInputRequestUnchecked(method: string): boolean {
   return method === "interaction/requestUserInput";
 }
+
+/** @see handleOne — the Start Plan captcha-session request (issue #123). */
+function isProviderRuntimeHeadersRequest(method: string): boolean {
+  return method === "interaction/requestProviderRuntimeHeaders";
+}
+
+/**
+ * Reason surfaced through the backend's -32031 error when it asks for a
+ * provider runtime headers (Aliyun captcha) refresh we cannot serve.
+ */
+const PROVIDER_RUNTIME_HEADERS_UNAVAILABLE =
+  "Start Plan providers require an Aliyun captcha session that only the " +
+  "ZCode desktop app can provide. Use a GLM Coding Plan provider for " +
+  "headless/editor sessions (see docs/TROUBLESHOOTING.md).";

--- a/tests/provider-runtime-headers.test.ts
+++ b/tests/provider-runtime-headers.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Provider runtime headers (Start Plan captcha session) — issue #123.
+ *
+ * Start Plan providers (zcode-plan endpoints) ask their host via
+ * `interaction/requestProviderRuntimeHeaders` to solve an Aliyun captcha and
+ * inject X-Aliyun-Captcha-Verify-* headers; only the desktop renderer can.
+ * The bridge must answer `headersApplied:false` with a clear reason so the
+ * backend fails with its -32031 error — NOT fall through to the generic
+ * unsupported-request error, which made the backend fall back to client
+ * signing with the provider's OAuth JWT and die with the misleading
+ * "must contain one separator" invalid-config error.
+ */
+
+import type * as acp from "@agentclientprotocol/sdk";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ServerRequest, ZcodeBackend } from "../src/backend/client.js";
+import type { PendingTurn, ZcodeAcpServer } from "../src/server.js";
+
+vi.mock("../src/handlers/io.js", () => ({
+  sendSessionUpdate: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { handleServerRequests } from "../src/handlers/server-requests.js";
+
+function makeServer(): ZcodeAcpServer {
+  return {
+    nextId: () => 1,
+    resolveSid: () => undefined,
+  } as unknown as ZcodeAcpServer;
+}
+
+function makeBackend(queue: ServerRequest[]) {
+  return {
+    pollServerRequests: () => queue.splice(0, queue.length),
+    requeueServerRequests: (reqs: ServerRequest[]) => queue.unshift(...reqs),
+    sendReply: vi.fn(),
+    sendError: vi.fn(),
+  } as unknown as ZcodeBackend;
+}
+
+function runtimeHeadersRequest(zcodeId: number): ServerRequest {
+  return {
+    id: zcodeId,
+    method: "interaction/requestProviderRuntimeHeaders",
+    params: {
+      requestId: "zs1:provider-runtime-headers:1725597000000",
+      sessionId: "zs1",
+      turnId: "t1",
+      providerId: "builtin:bigmodel-start-plan",
+      reason: "model-request",
+    },
+  };
+}
+
+describe("interaction/requestProviderRuntimeHeaders", () => {
+  it("declines with headersApplied:false and a clear reason, without touching the editor", async () => {
+    const server = makeServer();
+    const backend = makeBackend([runtimeHeadersRequest(301)]);
+    const cx = { request: vi.fn() } as unknown as acp.AgentContext;
+
+    const handled = await handleServerRequests(server, backend, cx, "s1");
+    expect(handled).toBe(true);
+    expect(backend.sendReply).toHaveBeenCalledTimes(1);
+    const [id, result] = vi.mocked(backend.sendReply).mock.calls[0]!;
+    expect(id).toBe(301);
+    expect(result).toMatchObject({ headersApplied: false });
+    expect((result as { errorMessage?: string }).errorMessage).toContain("Start Plan");
+    // No ACP request forwarded, no unsupported-request protocol error.
+    expect(cx.request).not.toHaveBeenCalled();
+    expect(backend.sendError).not.toHaveBeenCalled();
+  });
+
+  it("keeps the headersApplied result shape when the turn is cancelled", async () => {
+    const server = makeServer();
+    const backend = makeBackend([runtimeHeadersRequest(302)]);
+    const cx = { request: vi.fn() } as unknown as acp.AgentContext;
+    const turn = { cancelled: true, zcodeSid: "zs1" } as unknown as PendingTurn;
+
+    const handled = await handleServerRequests(server, backend, cx, "s1", turn);
+    expect(handled).toBe(true);
+    expect(backend.sendReply).toHaveBeenCalledWith(302, {
+      headersApplied: false,
+      errorMessage: "turn cancelled",
+    });
+  });
+});

--- a/tests/sandbox.test.ts
+++ b/tests/sandbox.test.ts
@@ -40,11 +40,25 @@ import {
   sandboxConfigPath,
 } from "../src/backend/sandbox.js";
 
+// The arm tests redirect os.homedir() to a repo-local fixture (sandboxed
+// agent sessions deny writes to the real $HOME); the passthrough mock keeps
+// every other consumer on the real value until explicitly overridden. The
+// `default` re-export matters: sandbox.ts does a default import.
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof os>();
+  const homedir = vi.fn(actual.homedir);
+  return { ...actual, homedir, default: { ...actual, homedir } };
+});
+
 // os.tmpdir() is symlinked on macOS (/var → /private/var) and Seatbelt
 // matches real paths — every fixture must be realpath'd like production.
 let tmpRoot: string;
 
 beforeEach(() => {
+  // A sandboxed agent session exports ZCODE_ACP_SANDBOX itself; clear it up
+  // front so the first test starts from the "no env" state it asserts (the
+  // afterEach delete only helps tests that run after the first one).
+  delete process.env[SANDBOX_ENV];
   tmpRoot = realpathSync(mkdtempSync(path.join(os.tmpdir(), "sb-test-")));
 });
 
@@ -399,6 +413,24 @@ describe("applySandboxFlip", () => {
 });
 
 describe("armSandboxArgv", () => {
+  // Sandboxed agent sessions deny writes to the real $HOME, which would
+  // EPERM the profile mkdtemp. Redirect the base into the repo — still NOT
+  // $TMPDIR, so the "outside the temp trees" race-proofing assertion below
+  // keeps testing what it always did.
+  let homeBase: string;
+
+  beforeEach(() => {
+    homeBase = mkdtempSync(path.join(realpathSync(process.cwd()), ".sb-home-"));
+    vi.mocked(os.homedir).mockReturnValue(homeBase);
+  });
+
+  afterEach(() => {
+    // Cleanup first: an afterEach that throws halfway (e.g. on a broken
+    // mock) must not leak the fixture dir into the repo.
+    rmSync(homeBase, { recursive: true, force: true });
+    vi.mocked(os.homedir).mockRestore();
+  });
+
   const arm = () =>
     armSandboxArgv(["/usr/local/bin/node", "/glm/zcode.cjs", "app-server", "--stdio"], {
       workspaces: [


### PR DESCRIPTION
## Summary

Start Plan providers (`builtin:zai-start-plan` / `builtin:bigmodel-start-plan`, `zcode.z.ai/api/v1/zcode-plan/...` endpoints) authenticate every model request with an OAuth JWT **plus an Aliyun captcha session**: before each request the backend asks its host via `interaction/requestProviderRuntimeHeaders` to solve the captcha and inject `X-Aliyun-Captcha-Verify-Param`/`-Region` headers. Only the desktop renderer (browser environment) can serve that; the headless bridge answered with `-32601`, so the backend fell back to client signing with the OAuth JWT — which must be `<id>.<secret>` — and died with the misleading `Client signing credential must contain one separator`. After `zcode login` the fallback signed with the CLI key instead, which carries no Start Plan entitlement → `1113`.

GLM Coding Plan providers never send this RPC (their config apiKey already is an `<id>.<secret>` signing credential), so existing usage is untouched.

## Changes

- `handleOne` now recognises `interaction/requestProviderRuntimeHeaders` and answers `{headersApplied: false, errorMessage: ...}` per the backend's strict result schema — the backend then fails fast with its `-32031` error carrying an actionable message instead of the signing fallback.
- The turn-cancelled drain keeps the same result shape for this method (`{action: "decline"}` would be rejected by the backend's zod).
- `sendZcodeReply` result param widened to `unknown` (pure passthrough).
- New tests (`tests/provider-runtime-headers.test.ts`): main path + cancelled path.
- `docs/TROUBLESHOOTING.md`: new section explaining the 1113 / signing-error symptom, the captcha root cause, and the workaround (switch to a GLM Coding Plan provider).
- `tests/sandbox.test.ts`: suite now runs clean inside sandboxed agent sessions (leaked `ZCODE_ACP_SANDBOX` env cleared in `beforeEach`; `armSandboxArgv` fixtures redirected to a repo-local fake `$HOME` — still outside the temp trees so the ADR-0011 race-proofing assertion keeps its meaning).

Cross-reviewed (correctness + adversarial): no surviving findings; permission/ExitPlanMode/AskUserQuestion hot paths byte-identical, reannounce storm and concurrent-drain probes pass, no-progress timer semantics unchanged.

Refs #123