### PR TITLE
docs: record the Start Plan desktop-only boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,15 @@ ZCode protocol types into ACP notifications directly — always translate.
   (src/remote/hub-sandbox.ts; plist in a temp mkdtemp, launchd reads the path
   itself). Don't reconnect this through `open` retries or TCC prompts — the
   attribution is the problem, not a missing permission.
+- **Start Plan providers are desktop-only — do NOT "fix" this with an
+  unofficial provider client**: `zcode-plan` requests need an Aliyun captcha
+  session only the desktop renderer can provide; the bridge answers
+  `interaction/requestProviderRuntimeHeaders` with `headersApplied:false` +
+  an actionable error (PR #128). Impersonating the desktop client, bypassing
+  the captcha/signing anti-abuse measures, or copying from the unlicensed
+  third-party proxies that do this are legal no-gos for a distributed tool
+  (ADR-0019) — decline the feature request and point users at GLM Coding
+  Plan or the desktop app.
 - **ACP wire method names are snake_case** (`session/request_permission`,
   not `session/requestPermission`) — the camelCase spelling is silently
   method-not-found (-32601) on real clients, and an `as never` param cast

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -405,7 +405,11 @@ requests themselves.
 `~/.zcode/v2/config.json` marks it `enabled`). The bridge answers the captcha
 request with `headersApplied:false` and the backend surfaces a clear error;
 full Start Plan support headless would require solving the Aliyun captcha
-outside a browser, which this bridge does not do.
+outside a browser, which this bridge does not do. That boundary is
+deliberate: unofficial clients or proxies that impersonate the desktop app or
+bypass the captcha check won't be shipped or supported here — if the provider
+ever offers an official headless credential path, this bridge will adopt it
+(see #123).
 
 ### Interactive TUI / `script` / `expect` fails with `Operation not permitted` under the sandbox
 


### PR DESCRIPTION
Follow-up to #123 / #128. Headless Start Plan would require impersonating the official desktop client or bypassing the provider's captcha/signing anti-abuse measures (what unofficial proxies do); as a distributed tool that is distributor-level legal exposure this project won't take on. This records the boundary where users will actually look for it:

- **docs/TROUBLESHOOTING.md** — the Start Plan entry now states the boundary is deliberate and what the revisit trigger is (an official headless credential path).
- **AGENTS.md** — gotcha guard so future agent sessions decline this class of feature request instead of implementing it.

Decision record (ADR-0019, with the full third-party-project analysis) stays in the local .zcode docs per repo convention.