### PR TITLE
feat(remote): show resumed history immediately in the booting TUI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,15 @@ ZCode protocol types into ACP notifications directly — always translate.
   `_PIN_CWD`, `ZCODE_ACP_RESUME_SESSION`) is deliberately env-only — per-role
   state, never file-configurable. The TUI script's env embedding is still
   load-bearing for file-less setups (the .command shell sources no rc).
+- **Warp CAN be driven programmatically — don't regress it to "unsupported"**:
+  it refuses `.command` files (warpdotdev/warp#1917) and its `warp` CLI is
+  agent-only, but its URI scheme EXECUTES a script: `open -a Warp
+  "warp://action/new_tab?path=<script>"` opens the script as a new tab in
+  Warp's default mode and runs it (source: warp's open-source
+  app/src/uri/mod.rs → open_file; verified on 0.2026.09.02). That is the
+  `warpUri` launcher in hub-server.ts; Preview = `warppreview://` + the
+  "Warp Preview" bundle. #1917/#3959 describe only the missing .command/CLI
+  paths, which made Warp look impossible for a long time.
 - **The interactive CLI is Martty, a dependency — never hand-roll UI here**
   (ADR-0020): bare `zcode-acp` spawns `martty --agent node --agent-arg
   <dist/index.js>` (src/tui.ts); the in-house Ink REPL was deleted wholesale.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ src/
 │   ├── mcp-discovery.ts    Discover MCP servers from config + plugins
 │   ├── auto-compact.ts     Threshold-based auto-compaction
 │   ├── options.ts          Config options (model/mode/thought dropdowns)
+│   ├── user-config.ts      Global user config (~/.config/zcode-acp/config.json)
 │   └── runtime-model.ts    Model switching overlay
 ├── translators/          ZCode event → ACP translation
 │   ├── event-translator.ts  Stream event → InternalEvent
@@ -116,6 +117,18 @@ ZCode protocol types into ACP notifications directly — always translate.
   unhandledRejection. See `src/remote/broadcast.ts`.
 - **Remote failures never touch stdio**: any remote-side failure (port, hub,
   token) must warn and disable remote only — the editor link stays up.
+- **User remote prefs live in `~/.config/zcode-acp/config.json`, NOT env**:
+  the hub is a detached daemon that idle-exits (~10 min) and is re-spawned by
+  whichever bridge needs it next, so its birth env rotates between
+  GUI-launched editors (no shell vars) and interactive shells — env-carried
+  preferences (terminal app!) drifted with every hub rebirth. Precedence per
+  field: config file (`remote.*`, XDG aware) → env var → default; env stays a
+  full fallback so existing setups keep working. Terminal prefs are re-read
+  LIVE at every incubation (`remoteTerminalPrefs`); token/ports apply when the
+  hub is next (re)born. Per-process plumbing (`ZCODE_ACP_REMOTE_ORIGIN`,
+  `_PIN_CWD`, `ZCODE_ACP_RESUME_SESSION`) is deliberately env-only — per-role
+  state, never file-configurable. The TUI script's env embedding is still
+  load-bearing for file-less setups (the .command shell sources no rc).
 - **The interactive CLI is Martty, a dependency — never hand-roll UI here**
   (ADR-0020): bare `zcode-acp` spawns `martty --agent node --agent-arg
   <dist/index.js>` (src/tui.ts); the in-house Ink REPL was deleted wholesale.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,7 @@ ZCode protocol types into ACP notifications directly — always translate.
 - **Warp CAN be driven programmatically — don't regress it to "unsupported"**:
   it refuses `.command` files (warpdotdev/warp#1917) and its `warp` CLI is
   agent-only, but its URI scheme EXECUTES a script: `open -a Warp
-  "warp://action/new_tab?path=<script>"` opens the script as a new tab in
+"warp://action/new_tab?path=<script>"` opens the script as a new tab in
   Warp's default mode and runs it (source: warp's open-source
   app/src/uri/mod.rs → open_file; verified on 0.2026.09.02). That is the
   `warpUri` launcher in hub-server.ts; Preview = `warppreview://` + the
@@ -140,19 +140,35 @@ ZCode protocol types into ACP notifications directly — always translate.
   paths, which made Warp look impossible for a long time.
 - **The interactive CLI is Martty, a dependency — never hand-roll UI here**
   (ADR-0020): bare `zcode-acp` spawns `martty --agent node --agent-arg
-  <dist/index.js>` (src/tui.ts); the in-house Ink REPL was deleted wholesale.
+<dist/index.js>` (src/tui.ts); the in-house Ink REPL was deleted wholesale.
   Martty folds chunk-delta replay (`user_message_chunk`/`agent_message_chunk`)
   only when the updates arrive AFTER the response on a load/resume path it
   initiated (complete user_message/agent_message updates never fold — verified
-  0.2.35). Boot always sends session/new (fresh-session semantics — replay
-  around it is dropped in both orderings), so the session/new boot-resume
-  interception passes `replayHistory:false` (a full replay would only stall
-  the boot). Its `/resume` prefers session/resume (no replay by ACP design),
-  so `resumeSession` pushes a 200-message turn-aligned chunk tail deferred
-  past the response via `setImmediate`, gated on `clientInfo.name` ≈ martty —
-  editors replay via session/load themselves and would double-render. Martty
-  passes its full env to the spawned agent, which is how
-  ZCODE_ACP_RESUME_SESSION reaches the bridge. `zcode-acp tui --check`
+  0.2.35; this holds for the boot `session/new` interception too — chunks
+  post-response DO fold). Martty's welcome banner, however, paints INSTEAD of
+  the transcript (`ui.rs draw_chat`) and only dives on submitted text, so a
+  boot-resumed TUI showed its replayed history only after the user's first
+  message. Fix (bridge-side, no upstream dependency): the hub incubates resume
+  TUIs with `DSH_TUI_AUTOPROMPT=BOOT_RESUME_TRIGGER` ("resume session" — plain
+  text on purpose: `/` would hit martty's slash dispatch before agent caps are
+  known, `!` runs a local shell). Martty auto-submits it at boot — banner dives
+  immediately, the text queues until the bind — and `runPrompt` answers it with
+  a one-line ack and `end_turn` (no model turn). The one-shot is scoped to the
+  booting CONNECTION (`connectionContext` identity, like the prompt-echo
+  exclusion): a phone app attached to the same bridge during the boot window
+  and prompting first must not spend or disarm it — a global "first prompt"
+  flag let the app's prompt race ahead and the trigger LEAKED TO THE MODEL as
+  a real prompt (observed live; the backend record showed both "hi" and
+  "resume session" as user messages). Only the same connection submitting
+  something else first disarms (the auto-submit was lost). `marttyClientSeen`
+  (sticky) replaces clientName for martty gating — clientName is
+  last-write-wins across multi-client attaches and an app's initialize can
+  land between the TUI's initialize and its session/new. Its `/resume` prefers
+  session/resume (no replay by ACP design), so `resumeSession` pushes a 200-message turn-aligned chunk tail
+  deferred past the response via `setImmediate`, gated on
+  `clientInfo.name` ≈ martty — editors replay via session/load themselves and
+  would double-render. Martty passes its full env to the spawned agent, which
+  is how ZCODE_ACP_RESUME_SESSION reaches the bridge. `zcode-acp tui --check`
   (= `martty --check-runtime` over the built bridge) is the CI smoke.
 - **Aug-28 app-server build (still "0.16.5") ignores `session/stop`**: the
   RPC returns `{}` but the model stream runs to its natural end (verified by
@@ -204,15 +220,15 @@ ZCode protocol types into ACP notifications directly — always translate.
   per-project config in `.zcode/acp/sandbox.json` (deny island — only the
   bridge may write it), dynamic allow = ask → persist → BATCHED backend
   restart (3s window: grants collect, then one cancel-wave + continuation
-  + close — a per-approval restart killed sibling popups still pending on
-  other denied paths; the flush sets a continuation ONLY for sessions with
-  a turn still in flight, orphans would hijack a later cancelled prompt).
-  Ask debounce marks are timestamps: a user decision (or a structural
-  hint) pins forever; a FAILED ask (timeout / killed by another grant's
-  restart / instantly-rejecting client) cools down 60s and may re-ask —
-  the old permanent mute left the model on a bare EPERM with no way out. Well-known system temp trees (/tmp → /private/tmp,
-  /var/tmp, /private/var/folders) are DEFAULT-ALLOWED — tools hardcode /tmp
-  and $TMPDIR names only the per-user /var/folders leaf; don't "tighten"
+  - close — a per-approval restart killed sibling popups still pending on
+    other denied paths; the flush sets a continuation ONLY for sessions with
+    a turn still in flight, orphans would hijack a later cancelled prompt).
+    Ask debounce marks are timestamps: a user decision (or a structural
+    hint) pins forever; a FAILED ask (timeout / killed by another grant's
+    restart / instantly-rejecting client) cools down 60s and may re-ask —
+    the old permanent mute left the model on a bare EPERM with no way out. Well-known system temp trees (/tmp → /private/tmp,
+    /var/tmp, /private/var/folders) are DEFAULT-ALLOWED — tools hardcode /tmp
+    and $TMPDIR names only the per-user /var/folders leaf; don't "tighten"
   them back into popup storms (verify-sandbox.sh fixtures moved to HOME for
   the same reason). Arming is dual-switch: `ZCODE_ACP_SANDBOX=1` globally
   or `enabled: true` in that config per project (auto-created template ships
@@ -226,22 +242,22 @@ ZCode protocol types into ACP notifications directly — always translate.
   HOME + O_EXCL + the profile denies its own dir last; the HOME base is the
   point — every agent-writable path is writable by prior sandboxed
   generations too, so a $TMPDIR profile is raceable across generations), and
-  the config must pass the integrity check before the bridge persists
-  through it (symlink/hardlink pierces the deny island; a config read as
-  armed then EACCES/ENOTDIR/vanished also reads as armed — falling back to
-  the template would silently disarm). `/dev/null` must stay write-allowed
-  or every `git commit` breaks. `openpty` (`/dev/ptmx` + the granted
-  `/dev/ttysNNN`, both `O_RDWR`) needs its two explicit write allows or
-  `script`/`expect`/TUI binaries die with a bare `openpty: Operation not
-  permitted` (#127); the slave allow is extension-gated (`require-all` +
-  `com.apple.sandbox.pty`, Apple `application.sb` form) so only this
-  sandbox's own pty slaves become writable — never widen it to a bare ttys
-  regex. The `pseudo-tty`/read/ioctl operations are already covered by
-  `(allow default)`. When diagnosing ANY bare `Operation not permitted`
-  inside an armed sandbox, suspect the sandbox FIRST — syscall-level denials
-  have no ask popup and tools misreport them as their own bug; the bridge
-  warns once per process on the first failed tool output containing the
-  phrase (`hintSandboxEperm` in dispatch.ts).
+    the config must pass the integrity check before the bridge persists
+    through it (symlink/hardlink pierces the deny island; a config read as
+    armed then EACCES/ENOTDIR/vanished also reads as armed — falling back to
+    the template would silently disarm). `/dev/null` must stay write-allowed
+    or every `git commit` breaks. `openpty` (`/dev/ptmx` + the granted
+    `/dev/ttysNNN`, both `O_RDWR`) needs its two explicit write allows or
+    `script`/`expect`/TUI binaries die with a bare `openpty: Operation not
+permitted` (#127); the slave allow is extension-gated (`require-all` +
+    `com.apple.sandbox.pty`, Apple `application.sb` form) so only this
+    sandbox's own pty slaves become writable — never widen it to a bare ttys
+    regex. The `pseudo-tty`/read/ioctl operations are already covered by
+    `(allow default)`. When diagnosing ANY bare `Operation not permitted`
+    inside an armed sandbox, suspect the sandbox FIRST — syscall-level denials
+    have no ask popup and tools misreport them as their own bug; the bridge
+    warns once per process on the first failed tool output containing the
+    phrase (`hintSandboxEperm` in dispatch.ts).
 - **A hub born inside the Seatbelt wrap silently breaks session-create**:
   macOS TCC attributes the hub's `open -a Terminal` to the requester identity
   "Sandbox" and Terminal refuses the document — while `open` itself exits 0,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,7 +254,13 @@ ZCode protocol types into ACP notifications directly — always translate.
   `launchctl bootstrap gui/$UID` + kickstart before binding
   (src/remote/hub-sandbox.ts; plist in a temp mkdtemp, launchd reads the path
   itself). Don't reconnect this through `open` retries or TCC prompts — the
-  attribution is the problem, not a missing permission.
+  attribution is the problem, not a missing permission. The launchd escape
+  itself FAILS when the hub was spawned from an agent session's own Seatbelt
+  (launchctl is sandboxed there too — observed 2026-09: a nohup'd hub degraded
+  and its serve bridges 502'd every /api/projects/sessions); the only working
+  restart channel from inside such a session is an `open` one (e.g. Warp's
+  `warp://action/new_tab?path=<restart.command>`), which hands execution to a
+  clean user shell.
 - **Start Plan providers are desktop-only — do NOT "fix" this with an
   unofficial provider client**: `zcode-plan` requests need an Aliyun captcha
   session only the desktop renderer can provide; the bridge answers

--- a/docs/REMOTE-CLIENTS.md
+++ b/docs/REMOTE-CLIENTS.md
@@ -46,17 +46,17 @@ ACP editor ────── stdio ──────────┘
 
 ## Discovery API
 
-| Endpoint                                               | Auth     | Purpose                                                                                                                                                     |
-| ------------------------------------------------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `GET /api/health`                                      | none     | Liveness probe; `200` body `ok`.                                                                                                                            |
-| `GET /api/instances`                                   | required | Registered bridge instances. Add `?probe=1` to verify first.                                                                                                |
-| `GET /api/instances/{id}/status`                       | required | Real-time per-session running status of one bridge.                                                                                                         |
-| `POST /api/instances/{id}/sessions/{sessionId}/close`  | required | Retire a session from remote discovery — see [Closing a session](#closing-a-session).                                                                       |
-| `POST /api/instances/{id}/sessions/{sessionId}/rename` | required | Rename a session — see [Renaming a session](#renaming-a-session).                                                                                           |
-| `GET /api/quota`                                       | required | Account-level usage stats — same payload as `account/usage_stats`, no ACP connection needed.                                                                |
-| `POST /api/upgrade`                                    | required | Trigger the hub's own staleness check — see [Hub self-upgrade](#hub-self-upgrade).                                                                          |
-| `GET /api/projects`                                    | required | Known-project list (remote session-create whitelist) — see below.                                                                                           |
-| `GET /api/projects/sessions?workspacePath=`            | required | A project's full session store incl. closed ones — see [Resuming a closed session](#resuming-a-closed-session).                                             |
+| Endpoint                                               | Auth     | Purpose                                                                                                                                                           |
+| ------------------------------------------------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET /api/health`                                      | none     | Liveness probe; `200` body `ok`.                                                                                                                                  |
+| `GET /api/instances`                                   | required | Registered bridge instances. Add `?probe=1` to verify first.                                                                                                      |
+| `GET /api/instances/{id}/status`                       | required | Real-time per-session running status of one bridge.                                                                                                               |
+| `POST /api/instances/{id}/sessions/{sessionId}/close`  | required | Retire a session from remote discovery — see [Closing a session](#closing-a-session).                                                                             |
+| `POST /api/instances/{id}/sessions/{sessionId}/rename` | required | Rename a session — see [Renaming a session](#renaming-a-session).                                                                                                 |
+| `GET /api/quota`                                       | required | Account-level usage stats — same payload as `account/usage_stats`, no ACP connection needed.                                                                      |
+| `POST /api/upgrade`                                    | required | Trigger the hub's own staleness check — see [Hub self-upgrade](#hub-self-upgrade).                                                                                |
+| `GET /api/projects`                                    | required | Known-project list (remote session-create whitelist) — see below.                                                                                                 |
+| `GET /api/projects/sessions?workspacePath=`            | required | A project's full session store incl. closed ones — see [Resuming a closed session](#resuming-a-closed-session).                                                   |
 | `POST /api/instances {workspacePath[, sessionId]}`     | required | Create a bridge for one known project — a visible terminal TUI window (session-create) or one that boots into a closed session (resume, `sessionId`) — see below. |
 
 HTTP auth: `Authorization: Bearer <token>` or `?token=<token>`.
@@ -250,14 +250,16 @@ POST {hub}/api/instances  body {"workspacePath":"/Users/me/proj",
   the client. A cold project (no listing yet) lists first — the listing IS
   the headless incubator.
 - **Resume on the desktop (ADR-0017, amended by ADR-0020)**: `POST
-  /api/instances` with the `sessionId` too — the hub incubates a VISIBLE
+/api/instances` with the `sessionId` too — the hub incubates a VISIBLE
   terminal TUI window that boots straight into that conversation (the same
   terminal/`ZCODE_ACP_HUB_TERMINAL` selection and headless fallback as
-  session-create). The window lands on the right session — later prompts run
-  with the full history in the backend — but the TUI does not render the
-  previous transcript (a fresh boot is a session/new and `/resume` prefers
-  session/resume, which carries no history by protocol design; its status
-  line says `resumed <id> — previous transcript was not replayed`). This happens EVEN when a serve bridge is already live
+  session-create). The window lands on the right session AND shows the previous
+  transcript: the bridge serves the boot `session/new` as a load of the target
+  id, replays a chunk-formatted history tail after the response (Martty folds
+  those), and incubates the window with a `DSH_TUI_AUTOPROMPT` trigger that
+  Martty auto-submits at boot — dropping its welcome banner, which would
+  otherwise cover the transcript until the user's first message — and the
+  bridge answers with a one-line ack instead of a model turn. This happens EVEN when a serve bridge is already live
   (the listing incubated one) — the answer is always the NEW instance, the
   bridge the window runs on; attach to it and `session/load` the same id to
   follow along in the client (both surfaces then share one bridge, one

--- a/docs/REMOTE.md
+++ b/docs/REMOTE.md
@@ -1,10 +1,10 @@
 # Remote Access
 
-With `ZCODE_ACP_REMOTE=1` the bridge additionally accepts ACP connections over
-WebSocket, so a phone or browser can watch and drive the **same sessions** as
-your editor. Zed (or any ACP editor over stdio) remains the primary client and
-owns the process: when the editor disconnects, the bridge — and every remote
-attachment — exits with it.
+With remote access enabled the bridge additionally accepts ACP connections
+over WebSocket, so a phone or browser can watch and drive the **same
+sessions** as your editor. Zed (or any ACP editor over stdio) remains the
+primary client and owns the process: when the editor disconnects, the bridge —
+and every remote attachment — exits with it.
 
 A ready-made client — Android APK plus a self-hostable web build — lives at
 [william0wang/zcode-acp-remote](https://github.com/william0wang/zcode-acp-remote).
@@ -18,8 +18,45 @@ phone / browser ──WS── tunnel ── hub (127.0.0.1:8377, single entry)
 Zed ──────── stdio ────────────────┘
 ```
 
-Enable it per-agent in Zed's settings (Zed merges these into the agent's
-environment):
+## Configuration
+
+Remote access is opt-in and requires a token (the endpoint is expected to sit
+behind a public tunnel, so "loopback-only" is never a safe assumption). The
+authoritative source is the global user config file — every bridge, the hub
+daemon and hub-spawned terminal windows read the same file, so behaviour does
+not depend on which process happened to spawn what:
+
+`~/.config/zcode-acp/config.json` (`$XDG_CONFIG_HOME` aware):
+
+```json
+{
+  "remote": {
+    "enabled": true,
+    "token": "<a-long-random-secret>",
+    "hubPort": 8377,
+    "hubHost": "127.0.0.1",
+    "bridgePort": 8378,
+    "terminal": { "app": "iTerm" }
+  }
+}
+```
+
+All fields are optional. Precedence per field: **config file → environment
+variable → built-in default.** The env vars (`ZCODE_ACP_REMOTE`,
+`ZCODE_ACP_REMOTE_TOKEN`, `ZCODE_ACP_HUB_PORT`, `ZCODE_ACP_HUB_HOST`,
+`ZCODE_ACP_REMOTE_PORT`, `ZCODE_ACP_HUB_TERMINAL*`) keep their semantics and
+fill any gap the file leaves, so existing env-only setups keep working.
+
+Why a file: the hub is a detached daemon that idle-exits (~10 min) and is
+re-spawned by whichever bridge needs it next — its birth env rotates between
+GUI-launched editors (no shell vars) and interactive shells, so env-carried
+preferences drifted with every rebirth. Terminal preferences are re-read
+live at every remote incubation: edit the file, the next session-create uses
+it, no hub restart. Token/port changes apply when the hub is next (re)born —
+rotate while no hub is running, or kill it and let the next bridge re-spawn.
+
+Alternatively, enable it per-agent in Zed's settings (Zed merges these into
+the agent's environment — no config file needed):
 
 ```json
 "agents": {
@@ -74,13 +111,15 @@ paths outside it get 403 (a convenience bound, not a security boundary: a
 token holder can already drive an editor-bridge session in any cwd; the
 trust boundary is the token). On create the hub incubates a VISIBLE
 interactive TUI window in the machine's terminal (ADR-0016 as amended by
-ADR-0020, macOS; headless/SSH or
-`ZCODE_ACP_HUB_TERMINAL=0` falls back to the detached headless
+ADR-0020, macOS; headless/SSH, `remote.terminal.enabled: false` in the config
+file, or `ZCODE_ACP_HUB_TERMINAL=0` falls back to the detached headless
 `zcode-acp serve`); its bridge registers back within seconds (budget ~20s)
 and is reachable like any other instance. The hub itself is a background
 process with no terminal, so nothing is auto-detected: the target terminal
-resolves as `ZCODE_ACP_HUB_TERMINAL_COMMAND` → `ZCODE_ACP_HUB_TERMINAL_APP`
-(built-in launch recipes for Terminal, iTerm, WezTerm, kitty, Alacritty,
+resolves as `remote.terminal.command` → `remote.terminal.app` from the config
+file (re-read live at every incubation; the `ZCODE_ACP_HUB_TERMINAL_COMMAND`
+→ `ZCODE_ACP_HUB_TERMINAL_APP` env vars fill in when the file is silent —
+built-in launch recipes for Terminal, iTerm, WezTerm, kitty, Alacritty,
 Ghostty; other names pass through to `open -a`) → plain Terminal.app. Warp
 cannot execute scripts or commands programmatically (warpdotdev/warp#1917,
 #3959) and is deliberately unsupported — it degrades to the headless bridge.

--- a/docs/REMOTE.md
+++ b/docs/REMOTE.md
@@ -121,8 +121,11 @@ file (re-read live at every incubation; the `ZCODE_ACP_HUB_TERMINAL_COMMAND`
 → `ZCODE_ACP_HUB_TERMINAL_APP` env vars fill in when the file is silent —
 built-in launch recipes for Terminal, iTerm, WezTerm, kitty, Alacritty,
 Ghostty; other names pass through to `open -a`) → plain Terminal.app. Warp
-cannot execute scripts or commands programmatically (warpdotdev/warp#1917,
-#3959) and is deliberately unsupported — it degrades to the headless bridge.
+refuses `.command` files, so `terminal.app: "warp"` (or `"warp-preview"`)
+instead opens `warp://action/new_tab?path=<script>` — its URI scheme executes
+the script as a new tab in Warp's default mode (app/src/uri/mod.rs →
+open_file). Hyper stays unsupported (no programmatic command execution,
+vercel/hyper#3677).
 Create NEVER reuses a live serve-origin instance (ADR-0016 as amended) —
 every create incubates its own window, and identical concurrent requests
 join the same in-flight spawn. A

--- a/src/config/user-config.ts
+++ b/src/config/user-config.ts
@@ -1,0 +1,118 @@
+/**
+ * Global user configuration (~/.config/zcode-acp/config.json).
+ *
+ * The file is the AUTHORITATIVE source for user preferences that must not
+ * depend on how a process was launched: the hub daemon is idle-exited and
+ * re-spawned by whichever bridge needs it next, so its birth env rotates
+ * between GUI-launched editors (no shell rc vars) and interactive shells.
+ * Every read is live (no cache) — editing the file takes effect on the next
+ * use (e.g. the next remote incubation) without restarting the hub.
+ *
+ * Precedence everywhere: config file > environment variable > built-in
+ * default. Env vars remain fully supported as a fallback for setups without
+ * a file and for one-off/test overrides of unspecified fields.
+ *
+ * Per-process plumbing (ZCODE_ACP_REMOTE_ORIGIN, _PIN_CWD,
+ * ZCODE_ACP_RESUME_SESSION) is deliberately NOT file-configurable — those
+ * carry per-request/per-role state, not user preference.
+ */
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+import { warn } from "../utils.js";
+
+/** Terminal incubation preferences for remote session-create (ADR-0016). */
+export interface TerminalPrefs {
+  /** false → remote session-create stays headless (no visible window). */
+  enabled?: boolean;
+  /** Terminal app name (Terminal, iTerm, wezterm, kitty, alacritty, ghostty, …). */
+  app?: string;
+  /** Shell command template; `{script}` is replaced with the quoted script path. */
+  command?: string;
+}
+
+/** The `remote` section of the user config file. */
+export interface RemoteUserConfig {
+  enabled?: boolean;
+  token?: string;
+  hubPort?: number;
+  hubHost?: string;
+  bridgePort?: number;
+  terminal?: TerminalPrefs;
+}
+
+export interface UserConfig {
+  remote?: RemoteUserConfig;
+}
+
+/** Resolve the config file path: $XDG_CONFIG_HOME/zcode-acp or ~/.config/zcode-acp. */
+export function userConfigPath(env: NodeJS.ProcessEnv = process.env): string {
+  const base = (env.XDG_CONFIG_HOME ?? "").trim() || path.join(homedir(), ".config");
+  return path.join(base, "zcode-acp", "config.json");
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Read and validate the user config. Best-effort: a missing file is the
+ * normal no-file path ({}), anything unreadable/malformed warns once and
+ * reads as absent so the env fallback keeps the process working.
+ */
+export function loadUserConfig(env: NodeJS.ProcessEnv = process.env): UserConfig {
+  const file = userConfigPath(env);
+  let raw: string;
+  try {
+    raw = readFileSync(file, "utf8");
+  } catch {
+    return {}; // missing (or unreadable) file — env fallback applies
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    warn(`config: ${file} is not valid JSON — ignoring (${e instanceof Error ? e.message : String(e)})`);
+    return {};
+  }
+  if (!isPlainObject(parsed)) {
+    warn(`config: ${file} is not a JSON object — ignoring`);
+    return {};
+  }
+  const remote = parsed["remote"];
+  if (remote === undefined) return {};
+  if (!isPlainObject(remote)) {
+    warn(`config: "remote" in ${file} is not an object — ignoring the section`);
+    return {};
+  }
+  const out: RemoteUserConfig = {};
+  if (typeof remote["enabled"] === "boolean") out.enabled = remote["enabled"];
+  if (typeof remote["token"] === "string" && remote["token"].trim()) out.token = remote["token"].trim();
+  for (const key of ["hubPort", "bridgePort"] as const) {
+    const v = remote[key];
+    if (v === undefined) continue;
+    if (typeof v !== "number" || !Number.isInteger(v) || v < 1 || v > 65535) {
+      warn(`config: remote.${key}=${JSON.stringify(v)} is not a valid port — ignoring`);
+    } else {
+      out[key] = v;
+    }
+  }
+  if (typeof remote["hubHost"] === "string" && remote["hubHost"].trim()) {
+    out.hubHost = remote["hubHost"].trim();
+  }
+  const terminal = remote["terminal"];
+  if (isPlainObject(terminal)) {
+    const t: TerminalPrefs = {};
+    if (typeof terminal["enabled"] === "boolean") t.enabled = terminal["enabled"];
+    if (typeof terminal["app"] === "string" && terminal["app"].trim()) t.app = terminal["app"].trim();
+    if (typeof terminal["command"] === "string" && terminal["command"].trim()) {
+      t.command = terminal["command"].trim();
+    }
+    if (Object.keys(t).length > 0) out.terminal = t;
+  } else if (terminal !== undefined) {
+    warn(`config: remote.terminal in ${file} is not an object — ignoring`);
+  }
+  return { remote: out };
+}

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -50,7 +50,7 @@ import {
   ProjectionDiffer,
 } from "../translators/index.js";
 import type { InternalEvent } from "../translators/index.js";
-import { log, warn } from "../utils.js";
+import { clientConnectionRoot, log, warn } from "../utils.js";
 import type { PendingTurn, ZcodeAcpServer } from "../server.js";
 import { dispatchEvent } from "./dispatch.js";
 import { sendSessionUpdate, sendTextChunk, withReplayBatch } from "./io.js";
@@ -177,6 +177,21 @@ export function consumeBootResumeTarget(): string | null {
 }
 
 /**
+ * Banner-handshake trigger for a boot-resumed TUI (ADR-0017 follow-up).
+ * Martty's welcome banner paints INSTEAD of the transcript and only dives
+ * when text is submitted — so a boot-resumed TUI showed its replayed history
+ * only after the user's first message. The hub therefore also incubates the
+ * resume TUI with `DSH_TUI_AUTOPROMPT=<this string>`: martty auto-submits it
+ * at boot (banner dives immediately, the text queues until the boot bind),
+ * and the prompt path answers it with a one-line ack instead of a model
+ * turn — scoped to the booting connection (see bootResumeTriggerConnection).
+ * Plain text on purpose: a leading `/` would route through martty's
+ * slash dispatch (whose gates run before agent capabilities are known) and
+ * `!` would run a local shell command.
+ */
+export const BOOT_RESUME_TRIGGER = "resume session";
+
+/**
  * `session/new` → local placeholder id. The real zcode `session/create` is
  * deferred to first use (`ensureRealSession`) so an editor startup that never
  * sends a message leaves no empty session in the backend or the App's task
@@ -193,14 +208,14 @@ export function consumeBootResumeTarget(): string | null {
 export async function newSession(
   server: ZcodeAcpServer,
   params: acp.NewSessionRequest,
+  client?: acp.AgentContext,
 ): Promise<acp.NewSessionResponse> {
   const bootResume = consumeBootResumeTarget();
   if (bootResume) {
     try {
-      // replayHistory:false — the TUI does not render agent-replayed history
-      // (its transcript comes from its own local recording; it says so in its
-      // status line) and waits for this response, so a full replay would only
-      // stall the boot.
+      // replayHistory:false — a PRE-response replay would arrive for a session
+      // id the client has not adopted yet and be dropped; the tail replay is
+      // deferred past the response instead (below).
       const loaded = await loadSession(
         server,
         { sessionId: bootResume } as acp.LoadSessionRequest,
@@ -208,6 +223,29 @@ export async function newSession(
         { replayHistory: false },
       );
       log(`session/new: boot-resume → ${bootResume}`);
+      // Deferred tail replay, same as the TUI's /resume (see resumeSession):
+      // once the session/new response is written the booting martty has
+      // adopted the returned session id, so post-response chunks can fold
+      // into its transcript. The chunks sit BEHIND martty's welcome banner
+      // until text is submitted — the DSH_TUI_AUTOPROMPT handshake armed
+      // below drops the banner for the user.
+      if (isMarttyClient(server)) {
+        // Scope the handshake to THIS connection: a phone app attached to the
+        // same bridge may prompt during the boot window and must not disarm it.
+        server.bootResumeTriggerConnection = clientConnectionRoot(client);
+        const cx = server.clients.broadcast();
+        const zcodeSid = server.resolveSid(bootResume);
+        if (zcodeSid) {
+          setImmediate(() => {
+            replayResumeHistory(server, cx, bootResume, zcodeSid).catch((e) => {
+              warn(
+                `session/new boot-resume: TUI history replay failed (non-fatal): ` +
+                  `${e instanceof Error ? e.message : String(e)}`,
+              );
+            });
+          });
+        }
+      }
       return {
         sessionId: bootResume,
         modes: loaded.modes,
@@ -499,7 +537,9 @@ const MARTTY_RESUME_TAIL = 200;
 
 /** True when the connecting client is Martty, the bundled TUI frontend. */
 function isMarttyClient(server: ZcodeAcpServer): boolean {
-  return (server.clientName ?? "").toLowerCase().includes("martty");
+  // Sticky flag first: clientName is last-write-wins and a remote client's
+  // initialize can land between the TUI's initialize and its session/new.
+  return server.marttyClientSeen || (server.clientName ?? "").toLowerCase().includes("martty");
 }
 
 /**
@@ -756,8 +796,9 @@ export async function prompt(
   params: acp.PromptRequest,
   cx: acp.AgentContext,
   requestId: number | string,
+  client?: acp.AgentContext,
 ): Promise<acp.PromptResponse> {
-  let result = await runPrompt(server, params, cx, requestId);
+  let result = await runPrompt(server, params, cx, requestId, false, client);
   // Sandbox-allow continuation chaining, BOUNDED: each batched restart
   // cancels the in-flight round and queues a continuation for prompt() to
   // consume. A LATER batch (the user approving a second popup seconds after
@@ -821,6 +862,7 @@ async function runPrompt(
   cx: acp.AgentContext,
   requestId: number | string,
   continuationRound = false,
+  client?: acp.AgentContext,
 ): Promise<acp.PromptResponse> {
   // Project-level sandbox flip (ADR-0011): a .zcode/acp/sandbox.json created
   // after the backend spawned unsandboxed must arm on THIS prompt, not on the
@@ -836,6 +878,28 @@ async function runPrompt(
   // A prompt is valid if it has text OR at least one image attachment (a user
   // may drag in an image with no accompanying text).
   if (!text && attachments.length === 0) throw new Error("empty prompt");
+
+  // Boot-resume banner handshake (see BOOT_RESUME_TRIGGER): martty queues the
+  // auto-submitted trigger until its boot bind, so it arrives as the FIRST
+  // prompt OF THAT CONNECTION — ack with one chunk and end the turn without
+  // touching the backend. Scoped to the arming connection's identity: a
+  // phone app attached to the same bridge may prompt inside the boot window
+  // and must neither spend nor disarm the handshake (observed live: its
+  // prompt raced ahead and the trigger leaked to the model). The same
+  // connection submitting anything else first means the auto-submit was
+  // lost — disarm so the trigger text typed manually later stays a normal
+  // prompt.
+  if (
+    server.bootResumeTriggerConnection !== null &&
+    clientConnectionRoot(client) === server.bootResumeTriggerConnection
+  ) {
+    server.bootResumeTriggerConnection = null;
+    if (text === BOOT_RESUME_TRIGGER) {
+      await sendTextChunk(cx, params.sessionId, messages().bootResumeAck, randomUUID());
+      log("session/prompt: boot-resume banner handshake acknowledged");
+      return { stopReason: "end_turn" };
+    }
+  }
 
   // Materialize a lazy session/new placeholder on first use. Placed after the
   // empty-prompt check so an invalid request doesn't create a backend session.

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -121,6 +121,8 @@ export interface Messages {
   askQuestionsTitle: string;
   /** Slash-command feedback lines rendered into the chat. */
   slashCompacted: string;
+  /** Ack for the boot-resume banner handshake (auto-submitted trigger). */
+  bootResumeAck: string;
   slashCompactTimeout: string;
   slashGoalSet: (value: string) => string;
   slashForked: (sessionId: string) => string;
@@ -209,6 +211,7 @@ const zh: Messages = {
   askSkipLabelOption: (lb) => `跳过：${lb}`,
   askQuestionsTitle: "问题",
   slashCompacted: "✓ 已压缩对话上下文",
+  bootResumeAck: "⟲ 已恢复会话 · 历史已回放",
   slashCompactTimeout: "⚠ 压缩超时（300s），后端可能仍在处理——稍等片刻再发送",
   slashGoalSet: (v) => `✓ 目标已设置：${v}`,
   slashForked: (id) => `✓ 已分叉新会话：${id}`,
@@ -301,6 +304,7 @@ const en: Messages = {
   askSkipLabelOption: (lb) => `Skip: ${lb}`,
   askQuestionsTitle: "questions",
   slashCompacted: "✓ compacted conversation context",
+  bootResumeAck: "⟲ session resumed — history replayed",
   slashCompactTimeout:
     "⚠ compact timed out (300s), backend may still be processing — wait a bit before sending",
   slashGoalSet: (v) => `✓ goal set: ${v}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,7 +155,7 @@ function buildAgentApp(server: ZcodeAcpServer, allCommands: ReturnType<typeof bu
       .agent({ name: AGENT_INFO.name })
       .onRequest("initialize", (ctx) => server.initialize(ctx.params))
       .onRequest("session/new", async (ctx) => {
-        const result = await newSession(server, ctx.params);
+        const result = await newSession(server, ctx.params, ctx.client);
         for (const sid of server.sessionAliases(result.sessionId)) {
           sendAvailableCommandsDeferred(server.clients.broadcast(), sid, allCommands);
         }
@@ -207,6 +207,7 @@ function buildAgentApp(server: ZcodeAcpServer, allCommands: ReturnType<typeof bu
           ctx.params,
           server.clients.broadcast(),
           ctx.requestId as number | string,
+          ctx.client,
         );
       })
       .onRequest("session/set_config_option", (ctx) =>

--- a/src/remote/config.ts
+++ b/src/remote/config.ts
@@ -1,32 +1,38 @@
 /**
- * Remote access configuration from environment variables.
+ * Remote access configuration: user config file first, env fallback.
  *
- * Remote access is opt-in via ZCODE_ACP_REMOTE=1 and REQUIRES a token — the
- * endpoint is expected to sit behind a public tunnel (Cloudflare Tunnel, frp),
- * so "loopback-only" is never a safe assumption here. A missing token disables
- * the feature with a warning instead of failing the bridge: the stdio link to
- * the editor must keep working no matter what.
+ * Remote access is opt-in and REQUIRES a token — the endpoint is expected to
+ * sit behind a public tunnel (Cloudflare Tunnel, frp), so "loopback-only" is
+ * never a safe assumption here. A missing token disables the feature with a
+ * warning instead of failing the bridge: the stdio link to the editor must
+ * keep working no matter what.
  *
- * Variables:
- *   ZCODE_ACP_REMOTE=1            enable the remote endpoint (gate)
- *   ZCODE_ACP_REMOTE_TOKEN=<s>    auth token (mandatory when enabled)
- *   ZCODE_ACP_HUB_PORT=8377       hub's fixed port (the one a tunnel maps)
- *   ZCODE_ACP_HUB_HOST=127.0.0.1  hub bind address (e.g. 0.0.0.0 for a
- *                                 containerized tunnel agent)
- *   ZCODE_ACP_REMOTE_PORT=8378    bridge endpoint start port (auto-increment
- *                                 when taken; loopback only)
- *   ZCODE_ACP_REMOTE_ORIGIN=serve registration origin override (ADR-0016: a
- *                                 REPL incubated by the hub in a visible
- *                                 terminal registers as "serve" so the
- *                                 per-workspace dedupe treats it as THE
- *                                 project's remote bridge)
- *   ZCODE_ACP_REMOTE_PIN_CWD=1    pin every session root to the process cwd
- *                                 (bridge-wide serveMode; ADR-0016: keeps
- *                                 ADR-0014's whitelist semantics for a
- *                                 hub-incubated REPL, whose bridge would
- *                                 otherwise trust a remote client's cwd)
+ * Sources, in priority order (per field):
+ *   1. ~/.config/zcode-acp/config.json `remote` section (XDG_CONFIG_HOME
+ *      aware) — the authoritative, launch-context-independent source. The
+ *      hub daemon is idle-exited and re-spawned by arbitrary bridges, so its
+ *      birth env rotates; user preference must not.
+ *   2. Environment variables (unchanged semantics — setups without a file
+ *      keep working, and env fills any field the file leaves unset):
+ *     ZCODE_ACP_REMOTE=1            enable the remote endpoint (gate)
+ *     ZCODE_ACP_REMOTE_TOKEN=<s>    auth token (mandatory when enabled)
+ *     ZCODE_ACP_HUB_PORT=8377       hub's fixed port (the one a tunnel maps)
+ *     ZCODE_ACP_HUB_HOST=127.0.0.1  hub bind address (e.g. 0.0.0.0 for a
+ *                                   containerized tunnel agent)
+ *     ZCODE_ACP_REMOTE_PORT=8378    bridge endpoint start port (auto-increment
+ *                                   when taken; loopback only)
+ *     ZCODE_ACP_HUB_TERMINAL=0      disable the visible-terminal incubation
+ *     ZCODE_ACP_HUB_TERMINAL_APP=<name>   terminal app for the TUI window
+ *     ZCODE_ACP_HUB_TERMINAL_COMMAND=<sh> shell command template ({script})
+ *   3. Built-in defaults.
+ *
+ * Process-role plumbing stays env-only by design (never file-configurable):
+ *   ZCODE_ACP_REMOTE_ORIGIN=serve  registration origin override (ADR-0016)
+ *   ZCODE_ACP_REMOTE_PIN_CWD=1     pin session roots to the process cwd
+ *   ZCODE_ACP_RESUME_SESSION=<id>  per-request boot-resume target (ADR-0017)
  */
 
+import { loadUserConfig, type TerminalPrefs } from "../config/user-config.js";
 import { warn } from "../utils.js";
 
 export interface RemoteConfig {
@@ -65,23 +71,48 @@ function parsePort(raw: string | undefined, fallback: number, envName: string): 
   return port;
 }
 
+/** Shared file>env merge for token/ports/host (already validated by the loader). */
+function mergeCommon(env: NodeJS.ProcessEnv): {
+  token: string;
+  hubPort: number;
+  hubHost: string;
+  bridgePort: number;
+} {
+  const file = loadUserConfig(env).remote ?? {};
+  return {
+    token: file.token ?? (env.ZCODE_ACP_REMOTE_TOKEN ?? "").trim(),
+    hubPort:
+      file.hubPort ?? parsePort(env.ZCODE_ACP_HUB_PORT, DEFAULT_HUB_PORT, "ZCODE_ACP_HUB_PORT"),
+    hubHost: file.hubHost ?? ((env.ZCODE_ACP_HUB_HOST ?? "").trim() || DEFAULT_HUB_HOST),
+    bridgePort:
+      file.bridgePort ??
+      parsePort(env.ZCODE_ACP_REMOTE_PORT, DEFAULT_BRIDGE_PORT, "ZCODE_ACP_REMOTE_PORT"),
+  };
+}
+
 /** Parse remote config; null = disabled (or misconfigured → warned). */
 export function parseRemoteConfig(env: NodeJS.ProcessEnv = process.env): RemoteConfig | null {
-  const gate = (env.ZCODE_ACP_REMOTE ?? "").trim().toLowerCase();
-  if (!["1", "true", "yes", "on"].includes(gate)) return null;
-  const token = (env.ZCODE_ACP_REMOTE_TOKEN ?? "").trim();
+  const file = loadUserConfig(env).remote ?? {};
+  // Gate: the file is authoritative when it says anything; env decides only
+  // when the file is silent (an explicit `enabled: false` wins over env =1).
+  const enabled =
+    file.enabled !== undefined
+      ? file.enabled
+      : ["1", "true", "yes", "on"].includes((env.ZCODE_ACP_REMOTE ?? "").trim().toLowerCase());
+  if (!enabled) return null;
+  const { token, hubPort, hubHost, bridgePort } = mergeCommon(env);
   if (!token) {
     warn(
-      "remote: ZCODE_ACP_REMOTE is enabled but ZCODE_ACP_REMOTE_TOKEN is missing — " +
+      "remote: enabled but no token (config file or ZCODE_ACP_REMOTE_TOKEN) — " +
         "remote access disabled (stdio unaffected)",
     );
     return null;
   }
   return {
     token,
-    hubPort: parsePort(env.ZCODE_ACP_HUB_PORT, DEFAULT_HUB_PORT, "ZCODE_ACP_HUB_PORT"),
-    hubHost: (env.ZCODE_ACP_HUB_HOST ?? "").trim() || DEFAULT_HUB_HOST,
-    bridgePort: parsePort(env.ZCODE_ACP_REMOTE_PORT, DEFAULT_BRIDGE_PORT, "ZCODE_ACP_REMOTE_PORT"),
+    hubPort,
+    hubHost,
+    bridgePort,
     origin: (env.ZCODE_ACP_REMOTE_ORIGIN ?? "").trim() === "serve" ? "serve" : "editor",
     pinCwd: (env.ZCODE_ACP_REMOTE_PIN_CWD ?? "").trim() === "1",
   };
@@ -89,17 +120,34 @@ export function parseRemoteConfig(env: NodeJS.ProcessEnv = process.env): RemoteC
 
 /** Parse hub-side config for the standalone hub entry (`zcode-acp hub`). */
 export function parseHubConfig(env: NodeJS.ProcessEnv = process.env): RemoteConfig | null {
-  const token = (env.ZCODE_ACP_REMOTE_TOKEN ?? "").trim();
+  const { token, hubPort, hubHost, bridgePort } = mergeCommon(env);
   if (!token) {
-    warn("hub: ZCODE_ACP_REMOTE_TOKEN is required — refusing to start without auth");
+    warn("hub: no token (config file or ZCODE_ACP_REMOTE_TOKEN) — refusing to start without auth");
     return null;
   }
   return {
     token,
-    hubPort: parsePort(env.ZCODE_ACP_HUB_PORT, DEFAULT_HUB_PORT, "ZCODE_ACP_HUB_PORT"),
-    hubHost: (env.ZCODE_ACP_HUB_HOST ?? "").trim() || DEFAULT_HUB_HOST,
-    bridgePort: parsePort(env.ZCODE_ACP_REMOTE_PORT, DEFAULT_BRIDGE_PORT, "ZCODE_ACP_REMOTE_PORT"),
+    hubPort,
+    hubHost,
+    bridgePort,
     origin: "editor",
     pinCwd: false,
   };
+}
+
+/**
+ * Terminal incubation preferences for the hub (ADR-0016), merged file > env.
+ * Read LIVE by the hub at every incubation so editing the file takes effect
+ * without a hub restart — the hub outlives the shells that configured it.
+ */
+export function remoteTerminalPrefs(env: NodeJS.ProcessEnv = process.env): TerminalPrefs {
+  const file = loadUserConfig(env).remote?.terminal ?? {};
+  const app = file.app ?? ((env.ZCODE_ACP_HUB_TERMINAL_APP ?? "").trim() || undefined);
+  const command =
+    file.command ?? ((env.ZCODE_ACP_HUB_TERMINAL_COMMAND ?? "").trim() || undefined);
+  const enabled =
+    file.enabled ?? !["0", "false", "off"].includes(
+      (env.ZCODE_ACP_HUB_TERMINAL ?? "").trim().toLowerCase(),
+    );
+  return { enabled, ...(app ? { app } : {}), ...(command ? { command } : {}) };
 }

--- a/src/remote/hub-server.ts
+++ b/src/remote/hub-server.ts
@@ -243,7 +243,13 @@ export type TerminalLaunch =
   | { kind: "openApp"; app: string }
   /** Terminals driven by their own CLI: `open -na <app> --args <args> <sh>
    * <script>` — args come first, the script program is appended. */
-  | { kind: "openAppArgs"; app: string; args: string[] };
+  | { kind: "openAppArgs"; app: string; args: string[] }
+  /** Warp: refuses `.command` files and its CLI is agent-only, but its URI
+   * scheme EXECUTES a script handed to action/new_tab's path param
+   * (app/src/uri/mod.rs → open_file; verified on 0.2026.09.02): the hub opens
+   * `<scheme>://action/new_tab?path=<script>` and Warp runs it as a new tab
+   * in its default mode. Preview uses the warppreview:// scheme. */
+  | { kind: "warpUri"; app: string; scheme: string };
 
 /**
  * Built-in launch recipes for well-known macOS terminals (ADR-0016 §5). Each
@@ -252,11 +258,9 @@ export type TerminalLaunch =
  * WezTerm's `start --` runs an alternative program (wezterm.org/cli/start.html);
  * kitty takes the program as normal positional arguments
  * (sw.kovidgoyal.net/kitty/invocation); Alacritty and Ghostty support the
- * common `-e` flag. The script does its own `cd`, so no per-app cwd flags.
- * Warp is deliberately ABSENT — it cannot execute `.command` files (#1917)
- * and has no programmatic command execution at all (URI scheme opens dirs
- * only; still an open request in #3959/#9083). Hyper is absent for the same
- * reason (#3677).
+ * common `-e` flag; Warp rides its new_tab URI action (see warpUri above).
+ * The script does its own `cd`, so no per-app cwd flags. Hyper is absent — no
+ * programmatic command execution at all (vercel/hyper#3677).
  */
 const TERMINAL_APP_LAUNCHERS: Record<string, TerminalLaunch> = {
   terminal: { kind: "openApp", app: "Terminal" },
@@ -267,6 +271,9 @@ const TERMINAL_APP_LAUNCHERS: Record<string, TerminalLaunch> = {
   kitty: { kind: "openAppArgs", app: "kitty", args: [] },
   alacritty: { kind: "openAppArgs", app: "Alacritty", args: ["-e"] },
   ghostty: { kind: "openAppArgs", app: "Ghostty", args: ["-e"] },
+  warp: { kind: "warpUri", app: "Warp", scheme: "warp" },
+  "warp-preview": { kind: "warpUri", app: "Warp Preview", scheme: "warppreview" },
+  warp_preview: { kind: "warpUri", app: "Warp Preview", scheme: "warppreview" },
 };
 
 /**
@@ -275,9 +282,8 @@ const TERMINAL_APP_LAUNCHERS: Record<string, TerminalLaunch> = {
  * only the app-name normalization lives here. Priority: the explicit command
  * template (the universal escape hatch) → a built-in launcher by app name
  * (aliases are case- and `.app`-suffix-insensitive) → plain Terminal.app
- * (macOS has no default-terminal setting to detect). Warp gets a special
- * warning because it accepts the open but cannot run the script; any other
- * unmatched name passes through to `open -a` unchanged.
+ * (macOS has no default-terminal setting to detect). Any other unmatched
+ * name passes through to `open -a` unchanged.
  */
 export function resolveTerminalLaunch(
   env: NodeJS.ProcessEnv,
@@ -288,19 +294,9 @@ export function resolveTerminalLaunch(
 } {
   if (prefs.command) return { launch: { kind: "shell", command: prefs.command } };
   const raw = prefs.app ?? "";
-  const name = raw.toLowerCase().replace(/\.app$/, "");
+  const name = raw.toLowerCase().replace(/\.app$/, "").replace(/\s+/g, "-");
   const launcher = TERMINAL_APP_LAUNCHERS[name];
   if (launcher) return { launch: launcher };
-  if (name === "warp") {
-    return {
-      launch: { kind: "openApp", app: raw || "Warp" },
-      warning:
-        "Warp cannot execute .command scripts (warpdotdev/warp#1917) and has no " +
-        "programmatic command execution (warpdotdev/warp#3959, #9083) — the window " +
-        "will idle and session-create falls back to a headless bridge after the " +
-        "register timeout; set ZCODE_ACP_HUB_TERMINAL_COMMAND to drive Warp another way",
-    };
-  }
   return { launch: { kind: "openApp", app: raw || "Terminal" } };
 }
 
@@ -363,6 +359,15 @@ async function spawnTerminalTui(opts: {
     argv = ["/bin/sh", "-c", rendered];
   } else if (launch.kind === "openApp") {
     argv = ["open", "-a", launch.app, script];
+  } else if (launch.kind === "warpUri") {
+    // new_tab = Warp's default open mode (like Cmd+T: a tab in the focused
+    // window; Warp opens a window first if none exists).
+    argv = [
+      "open",
+      "-a",
+      launch.app,
+      `${launch.scheme}://action/new_tab?path=${encodeURIComponent(script)}`,
+    ];
   } else {
     argv = ["open", "-na", launch.app, "--args", ...launch.args, "/bin/sh", script];
   }

--- a/src/remote/hub-server.ts
+++ b/src/remote/hub-server.ts
@@ -50,6 +50,7 @@ import { AGENT_INFO, compareVersions, log, warn } from "../utils.js";
 import type { TerminalPrefs } from "../config/user-config.js";
 import { remoteTerminalPrefs } from "./config.js";
 import { accountUsageStats, type UsageStatsResult } from "../handlers/account.js";
+import { BOOT_RESUME_TRIGGER } from "../handlers/session.js";
 import { listKnownWorkspaces } from "../tasks-index.js";
 
 export interface HubOptions {
@@ -294,7 +295,10 @@ export function resolveTerminalLaunch(
 } {
   if (prefs.command) return { launch: { kind: "shell", command: prefs.command } };
   const raw = prefs.app ?? "";
-  const name = raw.toLowerCase().replace(/\.app$/, "").replace(/\s+/g, "-");
+  const name = raw
+    .toLowerCase()
+    .replace(/\.app$/, "")
+    .replace(/\s+/g, "-");
   const launcher = TERMINAL_APP_LAUNCHERS[name];
   if (launcher) return { launch: launcher };
   return { launch: { kind: "openApp", app: raw || "Terminal" } };
@@ -310,7 +314,9 @@ export function resolveTerminalLaunch(
  */
 export function terminalTuiScript(cwd: string, cliJs: string, env: NodeJS.ProcessEnv): string {
   const exports = Object.keys(env)
-    .filter((k) => k.startsWith("ZCODE_ACP_"))
+    // DSH_TUI_AUTOPROMPT is the one non-ZCODE_ACP_* passenger: the boot-resume
+    // banner handshake (martty reads it at its own process start).
+    .filter((k) => k.startsWith("ZCODE_ACP_") || k === "DSH_TUI_AUTOPROMPT")
     .map((k) => `export ${k}=${shQuote(String(env[k]))}`);
   return [
     "#!/bin/sh",
@@ -743,6 +749,11 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
       // TUI boots into it. The detached serve fallback ignores it; the
       // client attaches to the serve bridge and session/loads there instead.
       env.ZCODE_ACP_RESUME_SESSION = sessionId;
+      // Banner handshake (see BOOT_RESUME_TRIGGER): martty auto-submits this
+      // text at boot, which drops its welcome banner and reveals the
+      // boot-replayed history without waiting for the user's first message.
+      // Must ride the env verbatim — martty reads it once at process start.
+      env.DSH_TUI_AUTOPROMPT = BOOT_RESUME_TRIGGER;
     }
     try {
       // Resume shares session-create's visible-terminal surface (and its

--- a/src/remote/hub-server.ts
+++ b/src/remote/hub-server.ts
@@ -47,6 +47,8 @@ import { fileURLToPath } from "node:url";
 import { WebSocket, WebSocketServer, type RawData } from "ws";
 
 import { AGENT_INFO, compareVersions, log, warn } from "../utils.js";
+import type { TerminalPrefs } from "../config/user-config.js";
+import { remoteTerminalPrefs } from "./config.js";
 import { accountUsageStats, type UsageStatsResult } from "../handlers/account.js";
 import { listKnownWorkspaces } from "../tasks-index.js";
 
@@ -226,8 +228,6 @@ function parseOrigin(raw: unknown): "editor" | "serve" {
 const TUI_REGISTER_TIMEOUT_MS = 20_000;
 /** `open -a <terminal>` must answer fast or the incubation falls back. */
 const TERMINAL_OPEN_TIMEOUT_MS = 3_000;
-/** Set ZCODE_ACP_HUB_TERMINAL=0 to keep remote session-create headless. */
-const TERMINAL_GATE_ENV = "ZCODE_ACP_HUB_TERMINAL";
 
 /** Single-quote for sh: ' → '\'' . */
 function shQuote(s: string): string {
@@ -270,21 +270,24 @@ const TERMINAL_APP_LAUNCHERS: Record<string, TerminalLaunch> = {
 };
 
 /**
- * Pick how to open the TUI script. The hub is a background daemon — its env
- * carries no terminal and macOS has no default-terminal setting — so nothing
- * is detected. Priority: the explicit command template (the universal escape
- * hatch) → a built-in launcher by app name (aliases are case- and
- * `.app`-suffix-insensitive) → plain Terminal.app. Warp gets a special warning
- * because it accepts the open but cannot run the script; any other unmatched
- * name passes through to `open -a` unchanged.
+ * Pick how to open the TUI script. Preferences arrive pre-merged from
+ * `remoteTerminalPrefs` (config file first, env fallback — see config.ts);
+ * only the app-name normalization lives here. Priority: the explicit command
+ * template (the universal escape hatch) → a built-in launcher by app name
+ * (aliases are case- and `.app`-suffix-insensitive) → plain Terminal.app
+ * (macOS has no default-terminal setting to detect). Warp gets a special
+ * warning because it accepts the open but cannot run the script; any other
+ * unmatched name passes through to `open -a` unchanged.
  */
-export function resolveTerminalLaunch(env: NodeJS.ProcessEnv): {
+export function resolveTerminalLaunch(
+  env: NodeJS.ProcessEnv,
+  prefs: TerminalPrefs = remoteTerminalPrefs(env),
+): {
   launch: TerminalLaunch;
   warning?: string;
 } {
-  const command = (env.ZCODE_ACP_HUB_TERMINAL_COMMAND ?? "").trim();
-  if (command) return { launch: { kind: "shell", command } };
-  const raw = (env.ZCODE_ACP_HUB_TERMINAL_APP ?? "").trim();
+  if (prefs.command) return { launch: { kind: "shell", command: prefs.command } };
+  const raw = prefs.app ?? "";
   const name = raw.toLowerCase().replace(/\.app$/, "");
   const launcher = TERMINAL_APP_LAUNCHERS[name];
   if (launcher) return { launch: launcher };
@@ -340,8 +343,12 @@ async function spawnTerminalTui(opts: {
   env: NodeJS.ProcessEnv;
 }): Promise<ChildProcess | null> {
   if (process.platform !== "darwin") return null;
-  const gate = (process.env[TERMINAL_GATE_ENV] ?? "").trim().toLowerCase();
-  if (["0", "false", "off"].includes(gate)) return null;
+  // Terminal prefs are read LIVE here (config file first, env fallback): the
+  // hub outlives the shells that configured it, and its birth env rotates
+  // between GUI editors and interactive shells — only the file is stable.
+  // Set remote.terminal.enabled=false in ~/.config/zcode-acp/config.json (or
+  // ZCODE_ACP_HUB_TERMINAL=0) to keep remote session-create headless.
+  if (!remoteTerminalPrefs(process.env).enabled) return null;
   const cliJs = fileURLToPath(new URL("../cli.js", import.meta.url));
   const script = path.join(mkdtempSync(path.join(tmpdir(), "zcode-acp-term-")), "tui.command");
   writeFileSync(script, terminalTuiScript(opts.cwd, cliJs, opts.env), { mode: 0o700 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -175,6 +175,23 @@ export class ZcodeAcpServer {
    */
   clientName: string | null = null;
   /**
+   * Sticky: some client named ≈"martty" completed `initialize` this process.
+   * `clientName` alone is last-write-wins across the stdio editor and remote
+   * WS attaches (a phone app initializing between the TUI's initialize and
+   * its session/new would blank it mid-boot), so martty-gated behavior reads
+   * this flag instead.
+   */
+  marttyClientSeen = false;
+  /**
+   * One-shot banner-handshake scope (see BOOT_RESUME_TRIGGER): the
+   * `connectionContext` identity of the client whose boot-resumed session/new
+   * armed the trigger. Only THAT connection's first `session/prompt` can
+   * spend it — prompts from other attached clients (a phone app racing the
+   * boot window) never disarm it. Null once spent or when the auto-submit was
+   * lost (the same connection's first prompt was something else).
+   */
+  bootResumeTriggerConnection: unknown = null;
+  /**
    * All connected ACP clients (the stdio editor plus any remote WebSocket
    * clients). Handlers push notifications through `clients.broadcast()` so
    * every attached client sees the same stream; the registry replaces the old
@@ -554,6 +571,7 @@ export class ZcodeAcpServer {
   async initialize(params: acp.InitializeRequest): Promise<acp.InitializeResponse> {
     const clientInfo = (params.clientInfo as { name?: string; version?: string } | null) ?? null;
     this.clientName = clientInfo?.name ?? null;
+    if ((this.clientName ?? "").toLowerCase().includes("martty")) this.marttyClientSeen = true;
     this.mergeClientCapabilities((params.clientCapabilities as ClientCapabilities) ?? {});
     log(
       `initialize: client protocolVersion=${params.protocolVersion}` +

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -153,6 +153,17 @@ export function warn(msg: string): void {
 }
 
 /**
+ * Stable identity of an ACP client connection. Each request wraps the
+ * connection in a fresh AgentContext, so the wrappers never compare equal —
+ * `connectionContext` is the SDK's per-connection root (public at runtime,
+ * @internal in the typings, hence the cast). `ctx.client` from a handler is
+ * one such wrapper; two requests from the same editor/TUI/app share the root.
+ */
+export function clientConnectionRoot(client?: unknown): unknown {
+  return (client as { connectionContext?: unknown } | undefined)?.connectionContext;
+}
+
+/**
  * Compare two semver-like version strings numerically (e.g. "10.0.0" > "2.0.0").
  * Falls back to lexicographic comparison for non-numeric segments. Used by
  * plugin/skill/MCP discovery to find the latest cached version directory.

--- a/tests/boot-resume.test.ts
+++ b/tests/boot-resume.test.ts
@@ -13,6 +13,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ZcodeBackend } from "../src/backend/client.js";
 import type { ZcodeMessage } from "../src/backend/types.js";
 import { consumeBootResumeTarget, newSession } from "../src/handlers/session.js";
+import { BOOT_RESUME_TRIGGER, prompt } from "../src/handlers/session.js";
 import { ZcodeAcpServer } from "../src/server.js";
 
 vi.mock("../src/tasks-index.js", () => ({
@@ -134,5 +135,131 @@ describe("session/new boot-resume interception", () => {
 
     expect(server.pendingSessions.has(res.sessionId)).toBe(true);
     expect(calls).toHaveLength(0); // no backend RPC before first use
+  });
+});
+
+describe("boot-resume banner handshake (DSH_TUI_AUTOPROMPT trigger)", () => {
+  afterEach(() => {
+    delete process.env.ZCODE_ACP_RESUME_SESSION;
+  });
+
+  /**
+   * Server armed the way a hub-incubated martty TUI boot leaves it. The
+   * booting connection is `tui` (its connectionContext root is what the
+   * handshake is scoped to); `phone` simulates a remote app attached to the
+   * same bridge.
+   */
+  async function bootedMarttyServer(): Promise<{
+    server: ZcodeAcpServer;
+    calls: Array<{ method: string; params: Record<string, unknown> }>;
+    tui: acp.AgentContext;
+    phone: acp.AgentContext;
+  }> {
+    const server = new ZcodeAcpServer();
+    server.clientName = "martty";
+    const { backend, calls } = fakeBackend();
+    server.backend = backend;
+    server.registerSession("sess_boot", "zsess_boot");
+    vi.spyOn(server.clients, "broadcast").mockReturnValue(stubCx);
+    process.env.ZCODE_ACP_RESUME_SESSION = "sess_boot";
+    const tui = clientWithRoot("tui-conn");
+    await newSession(server, { cwd: process.cwd() }, tui);
+    return { server, calls, tui, phone: clientWithRoot("phone-conn") };
+  }
+
+  function clientWithRoot(id: string): acp.AgentContext {
+    return { notify: async () => {}, connectionContext: { id } } as unknown as acp.AgentContext;
+  }
+
+  it("answers the auto-submitted trigger with an ack, never a model turn", async () => {
+    const { server, calls, tui } = await bootedMarttyServer();
+    expect(server.bootResumeTriggerConnection).toEqual({ id: "tui-conn" });
+
+    const updates: Array<Record<string, unknown>> = [];
+    const cx = {
+      notify: async (method: string, params?: { update?: Record<string, unknown> }) => {
+        if (method === "session/update") updates.push(params?.update ?? {});
+      },
+    } as unknown as acp.AgentContext;
+
+    const res = await prompt(
+      server,
+      { sessionId: "sess_boot", prompt: [{ type: "text", text: BOOT_RESUME_TRIGGER }] },
+      cx,
+      1,
+      tui,
+    );
+
+    expect(res).toEqual({ stopReason: "end_turn" });
+    // One ack chunk (⟲ is in every locale's wording), addressed to the session.
+    expect(updates).toHaveLength(1);
+    expect(updates[0].sessionUpdate).toBe("agent_message_chunk");
+    expect(String(updates[0].content?.text ?? "")).toContain("⟲");
+    // No turn ever reached the backend.
+    expect(calls.some((c) => c.method === "session/send")).toBe(false);
+    // One-shot: consumed.
+    expect(server.bootResumeTriggerConnection).toBeNull();
+  });
+
+  it("keeps the handshake armed while another attached client prompts first", async () => {
+    // Observed live: a phone app attached to the incubated bridge prompted
+    // during the TUI boot window — with a global one-shot that prompt
+    // disarmed the handshake and the auto-submitted trigger leaked to the
+    // model as a real prompt.
+    const { server, tui, phone } = await bootedMarttyServer();
+
+    // The phone's prompt arrives first and does NOT disarm the handshake.
+    // (Unknown session id → ensureRealSession throws after the scoped check.)
+    await expect(
+      prompt(
+        server,
+        { sessionId: "sess_unknown", prompt: [{ type: "text", text: "hi" }] },
+        stubCx,
+        2,
+        phone,
+      ),
+    ).rejects.toThrow();
+    expect(server.bootResumeTriggerConnection).toEqual({ id: "tui-conn" });
+
+    // The TUI's queued trigger then still lands as a no-model-turn ack.
+    const res = await prompt(
+      server,
+      { sessionId: "sess_boot", prompt: [{ type: "text", text: BOOT_RESUME_TRIGGER }] },
+      stubCx,
+      3,
+      tui,
+    );
+    expect(res).toEqual({ stopReason: "end_turn" });
+    expect(server.bootResumeTriggerConnection).toBeNull();
+  });
+
+  it("disarms when the booting connection's first prompt is anything else", async () => {
+    const { server, tui } = await bootedMarttyServer();
+    // Same connection, different text: the auto-submit was lost — disarm so
+    // the trigger typed manually later is a normal prompt.
+    await expect(
+      prompt(
+        server,
+        { sessionId: "sess_unknown", prompt: [{ type: "text", text: "hello" }] },
+        stubCx,
+        4,
+        tui,
+      ),
+    ).rejects.toThrow();
+    expect(server.bootResumeTriggerConnection).toBeNull();
+  });
+
+  it("never arms for non-TUI clients (editors see the trigger as plain text)", async () => {
+    const server = new ZcodeAcpServer();
+    server.clientName = "Zed";
+    const { backend } = fakeBackend();
+    server.backend = backend;
+    server.registerSession("sess_boot", "zsess_boot");
+    vi.spyOn(server.clients, "broadcast").mockReturnValue(stubCx);
+
+    process.env.ZCODE_ACP_RESUME_SESSION = "sess_boot";
+    await newSession(server, { cwd: process.cwd() }, clientWithRoot("zed-conn"));
+
+    expect(server.bootResumeTriggerConnection).toBeNull();
   });
 });

--- a/tests/hub.test.ts
+++ b/tests/hub.test.ts
@@ -1558,11 +1558,18 @@ describe("terminal launch resolution (ADR-0016)", () => {
     });
   });
 
-  it("warns on Warp — it cannot run scripts or commands programmatically", () => {
-    const out = resolveTerminalLaunch({}, { app: "Warp" });
-    expect(out.launch).toEqual({ kind: "openApp", app: "Warp" });
-    expect(out.warning).toContain("warpdotdev/warp#1917");
-    expect(out.warning).toContain("ZCODE_ACP_HUB_TERMINAL_COMMAND");
+  it("maps Warp onto its URI-scheme launcher (new_tab executes the script)", () => {
+    expect(resolveTerminalLaunch({}, { app: "Warp" }).launch).toEqual({
+      kind: "warpUri",
+      app: "Warp",
+      scheme: "warp",
+    });
+    // Preview channel: different app bundle AND scheme.
+    expect(resolveTerminalLaunch({}, { app: "Warp Preview" }).launch).toEqual({
+      kind: "warpUri",
+      app: "Warp Preview",
+      scheme: "warppreview",
+    });
   });
 
   it("passes unknown apps through to open -a and defaults to Terminal.app", () => {

--- a/tests/hub.test.ts
+++ b/tests/hub.test.ts
@@ -1514,67 +1514,67 @@ describe("hub terminal-TUI session resume (ADR-0017)", () => {
 
 describe("terminal launch resolution (ADR-0016)", () => {
   it("prefers the explicit command template over everything", () => {
-    const out = resolveTerminalLaunch({
-      ZCODE_ACP_HUB_TERMINAL_COMMAND: "my-term --run {script}",
-      ZCODE_ACP_HUB_TERMINAL_APP: "iTerm",
-    });
+    const out = resolveTerminalLaunch(
+      {},
+      { command: "my-term --run {script}", app: "iTerm" },
+    );
     expect(out.launch).toEqual({ kind: "shell", command: "my-term --run {script}" });
     expect(out.warning).toBeUndefined();
   });
 
   it("maps well-known apps to their verified launch mechanism", () => {
-    expect(resolveTerminalLaunch({ ZCODE_ACP_HUB_TERMINAL_APP: "WezTerm" }).launch).toEqual({
+    expect(resolveTerminalLaunch({}, { app: "WezTerm" }).launch).toEqual({
       kind: "openAppArgs",
       app: "WezTerm",
       args: ["start", "--"],
     });
-    expect(resolveTerminalLaunch({ ZCODE_ACP_HUB_TERMINAL_APP: "kitty" }).launch).toEqual({
+    expect(resolveTerminalLaunch({}, { app: "kitty" }).launch).toEqual({
       kind: "openAppArgs",
       app: "kitty",
       args: [],
     });
-    expect(resolveTerminalLaunch({ ZCODE_ACP_HUB_TERMINAL_APP: "ghostty" }).launch).toEqual({
+    expect(resolveTerminalLaunch({}, { app: "ghostty" }).launch).toEqual({
       kind: "openAppArgs",
       app: "Ghostty",
       args: ["-e"],
     });
-    expect(resolveTerminalLaunch({ ZCODE_ACP_HUB_TERMINAL_APP: "Alacritty" }).launch).toEqual({
+    expect(resolveTerminalLaunch({}, { app: "Alacritty" }).launch).toEqual({
       kind: "openAppArgs",
       app: "Alacritty",
       args: ["-e"],
     });
     // .command executors; aliases are case- and .app-suffix-insensitive.
-    expect(resolveTerminalLaunch({ ZCODE_ACP_HUB_TERMINAL_APP: "iTerm.app" }).launch).toEqual({
+    expect(resolveTerminalLaunch({}, { app: "iTerm.app" }).launch).toEqual({
       kind: "openApp",
       app: "iTerm",
     });
-    expect(resolveTerminalLaunch({ ZCODE_ACP_HUB_TERMINAL_APP: "iterm2" }).launch).toEqual({
+    expect(resolveTerminalLaunch({}, { app: "iterm2" }).launch).toEqual({
       kind: "openApp",
       app: "iTerm",
     });
-    expect(resolveTerminalLaunch({ ZCODE_ACP_HUB_TERMINAL_APP: "Apple_Terminal" }).launch).toEqual({
+    expect(resolveTerminalLaunch({}, { app: "Apple_Terminal" }).launch).toEqual({
       kind: "openApp",
       app: "Terminal",
     });
   });
 
   it("warns on Warp — it cannot run scripts or commands programmatically", () => {
-    const out = resolveTerminalLaunch({ ZCODE_ACP_HUB_TERMINAL_APP: "Warp" });
+    const out = resolveTerminalLaunch({}, { app: "Warp" });
     expect(out.launch).toEqual({ kind: "openApp", app: "Warp" });
     expect(out.warning).toContain("warpdotdev/warp#1917");
     expect(out.warning).toContain("ZCODE_ACP_HUB_TERMINAL_COMMAND");
   });
 
   it("passes unknown apps through to open -a and defaults to Terminal.app", () => {
-    expect(resolveTerminalLaunch({ ZCODE_ACP_HUB_TERMINAL_APP: "MyTerm" }).launch).toEqual({
+    expect(resolveTerminalLaunch({}, { app: "MyTerm" }).launch).toEqual({
       kind: "openApp",
       app: "MyTerm",
     });
-    expect(resolveTerminalLaunch({}).launch).toEqual({ kind: "openApp", app: "Terminal" });
+    expect(resolveTerminalLaunch({}, {}).launch).toEqual({ kind: "openApp", app: "Terminal" });
     // The hub is a background process — its own env has no terminal, and
     // TERM_PROGRAM (at best an accident of how the hub was launched) is
     // never consulted.
-    expect(resolveTerminalLaunch({ TERM_PROGRAM: "iTerm.app" }).launch).toEqual({
+    expect(resolveTerminalLaunch({ TERM_PROGRAM: "iTerm.app" }, {}).launch).toEqual({
       kind: "openApp",
       app: "Terminal",
     });

--- a/tests/hub.test.ts
+++ b/tests/hub.test.ts
@@ -39,6 +39,7 @@ import {
   terminalTuiScript,
   type HubHandle,
 } from "../src/remote/hub-server.js";
+import { BOOT_RESUME_TRIGGER } from "../src/handlers/session.js";
 import { AGENT_INFO } from "../src/utils.js";
 
 const TOKEN = "test-hub-token";
@@ -1460,12 +1461,18 @@ describe("hub terminal-TUI session resume (ADR-0017)", () => {
 
   it("carries the resume env into the .command script so the terminal shell boots into the session", () => {
     // terminalTuiScript exports every ZCODE_ACP_* var; the resume id rides
-    // the same channel (hub-server adds it to the incubation env).
+    // the same channel (hub-server adds it to the incubation env). The
+    // banner-handshake trigger travels as the one non-ZCODE_ACP_* passenger
+    // (martty reads DSH_TUI_AUTOPROMPT at its own process start).
     const body = terminalTuiScript(PROJECT, "/opt/cli.js", {
       ZCODE_ACP_REMOTE: "1",
       ZCODE_ACP_RESUME_SESSION: "sess_closed",
+      DSH_TUI_AUTOPROMPT: BOOT_RESUME_TRIGGER,
+      DSH_IRRELEVANT: "dropped",
     });
     expect(body).toContain("export ZCODE_ACP_RESUME_SESSION='sess_closed'");
+    expect(body).toContain(`export DSH_TUI_AUTOPROMPT='${BOOT_RESUME_TRIGGER}'`);
+    expect(body).not.toContain("DSH_IRRELEVANT");
   });
 
   it("joins one incubation for identical concurrent resumes, but not a different session", async () => {
@@ -1514,10 +1521,7 @@ describe("hub terminal-TUI session resume (ADR-0017)", () => {
 
 describe("terminal launch resolution (ADR-0016)", () => {
   it("prefers the explicit command template over everything", () => {
-    const out = resolveTerminalLaunch(
-      {},
-      { command: "my-term --run {script}", app: "iTerm" },
-    );
+    const out = resolveTerminalLaunch({}, { command: "my-term --run {script}", app: "iTerm" });
     expect(out.launch).toEqual({ kind: "shell", command: "my-term --run {script}" });
     expect(out.warning).toBeUndefined();
   });

--- a/tests/remote-config.test.ts
+++ b/tests/remote-config.test.ts
@@ -1,10 +1,15 @@
 /**
- * Remote config parsing — env gate, mandatory token, port/host defaults and
- * fallbacks. parseRemoteConfig takes an explicit env so tests never touch the
- * real process environment.
+ * Remote config parsing — file-first precedence (config file > env > default),
+ * mandatory token, port/host defaults and fallbacks. parseRemoteConfig takes
+ * an explicit env so tests never touch the real process environment; every
+ * env carries an XDG_CONFIG_HOME scratch dir so tests never read the
+ * developer's real ~/.config/zcode-acp/config.json either.
  */
 
-import { describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   DEFAULT_BRIDGE_PORT,
@@ -12,37 +17,66 @@ import {
   DEFAULT_HUB_PORT,
   parseHubConfig,
   parseRemoteConfig,
+  remoteTerminalPrefs,
 } from "../src/remote/config.js";
+
+let scratch: string;
+
+beforeEach(() => {
+  scratch = mkdtempSync(path.join(tmpdir(), "zacp-cfg-"));
+});
+
+afterEach(() => {
+  rmSync(scratch, { recursive: true, force: true });
+});
+
+/** Hermetic env: XDG pointed at the scratch dir, plus optional extras. */
+function env(extra: Record<string, string> = {}): Record<string, string> {
+  return { XDG_CONFIG_HOME: scratch, ...extra };
+}
+
+/** Write a config file under the scratch XDG root. */
+function writeConfig(json: unknown): void {
+  mkdirSync(path.join(scratch, "zcode-acp"), { recursive: true });
+  writeFileSync(path.join(scratch, "zcode-acp", "config.json"), JSON.stringify(json));
+}
+
+function writeRawConfig(text: string): void {
+  mkdirSync(path.join(scratch, "zcode-acp"), { recursive: true });
+  writeFileSync(path.join(scratch, "zcode-acp", "config.json"), text);
+}
 
 const BASE_ENV = {
   ZCODE_ACP_REMOTE: "1",
   ZCODE_ACP_REMOTE_TOKEN: "secret",
 };
 
-describe("parseRemoteConfig", () => {
+describe("parseRemoteConfig (env fallback — no config file)", () => {
   it("is disabled when the gate is unset", () => {
-    expect(parseRemoteConfig({})).toBeNull();
+    expect(parseRemoteConfig(env())).toBeNull();
   });
 
   it("is disabled for falsy gate values", () => {
     for (const gate of ["", "0", "false", "off", "nope"]) {
-      expect(parseRemoteConfig({ ZCODE_ACP_REMOTE: gate })).toBeNull();
+      expect(parseRemoteConfig(env({ ZCODE_ACP_REMOTE: gate }))).toBeNull();
     }
   });
 
   it("accepts truthy gate spellings", () => {
     for (const gate of ["1", "true", "YES", "on"]) {
-      expect(parseRemoteConfig({ ...BASE_ENV, ZCODE_ACP_REMOTE: gate })?.token).toBe("secret");
+      expect(parseRemoteConfig(env({ ...BASE_ENV, ZCODE_ACP_REMOTE: gate }))?.token).toBe("secret");
     }
   });
 
   it("requires a token when enabled", () => {
-    expect(parseRemoteConfig({ ZCODE_ACP_REMOTE: "1" })).toBeNull();
-    expect(parseRemoteConfig({ ZCODE_ACP_REMOTE: "1", ZCODE_ACP_REMOTE_TOKEN: "   " })).toBeNull();
+    expect(parseRemoteConfig(env({ ZCODE_ACP_REMOTE: "1" }))).toBeNull();
+    expect(
+      parseRemoteConfig(env({ ZCODE_ACP_REMOTE: "1", ZCODE_ACP_REMOTE_TOKEN: "   " })),
+    ).toBeNull();
   });
 
   it("applies port and host defaults", () => {
-    const config = parseRemoteConfig(BASE_ENV);
+    const config = parseRemoteConfig(env(BASE_ENV));
     expect(config).toEqual({
       token: "secret",
       hubPort: DEFAULT_HUB_PORT,
@@ -54,22 +88,26 @@ describe("parseRemoteConfig", () => {
   });
 
   it("falls back on invalid ports", () => {
-    const config = parseRemoteConfig({
-      ...BASE_ENV,
-      ZCODE_ACP_HUB_PORT: "not-a-port",
-      ZCODE_ACP_REMOTE_PORT: "99999",
-    });
+    const config = parseRemoteConfig(
+      env({
+        ...BASE_ENV,
+        ZCODE_ACP_HUB_PORT: "not-a-port",
+        ZCODE_ACP_REMOTE_PORT: "99999",
+      }),
+    );
     expect(config?.hubPort).toBe(DEFAULT_HUB_PORT);
     expect(config?.bridgePort).toBe(DEFAULT_BRIDGE_PORT);
   });
 
   it("honours explicit ports and host", () => {
-    const config = parseRemoteConfig({
-      ...BASE_ENV,
-      ZCODE_ACP_HUB_PORT: "9000",
-      ZCODE_ACP_HUB_HOST: "0.0.0.0",
-      ZCODE_ACP_REMOTE_PORT: "9001",
-    });
+    const config = parseRemoteConfig(
+      env({
+        ...BASE_ENV,
+        ZCODE_ACP_HUB_PORT: "9000",
+        ZCODE_ACP_HUB_HOST: "0.0.0.0",
+        ZCODE_ACP_REMOTE_PORT: "9001",
+      }),
+    );
     expect(config).toEqual({
       token: "secret",
       hubPort: 9000,
@@ -82,33 +120,142 @@ describe("parseRemoteConfig", () => {
 
   it("reads the hub-incubation overrides (origin, cwd pin) — ADR-0016", () => {
     // A hub-incubated terminal REPL registers as the project's serve bridge
-    // and pins its session roots to the process cwd.
-    const config = parseRemoteConfig({
-      ...BASE_ENV,
-      ZCODE_ACP_REMOTE_ORIGIN: "serve",
-      ZCODE_ACP_REMOTE_PIN_CWD: "1",
-    });
+    // and pins its session roots to the process cwd. These are per-process
+    // role flags — env only, never file-configurable.
+    const config = parseRemoteConfig(
+      env({
+        ...BASE_ENV,
+        ZCODE_ACP_REMOTE_ORIGIN: "serve",
+        ZCODE_ACP_REMOTE_PIN_CWD: "1",
+      }),
+    );
     expect(config?.origin).toBe("serve");
     expect(config?.pinCwd).toBe(true);
-    // Any other spelling reads as editor / unpinned (parseOrigin's rule).
-    const loose = parseRemoteConfig({ ...BASE_ENV, ZCODE_ACP_REMOTE_ORIGIN: "editor" });
+    const loose = parseRemoteConfig(env({ ...BASE_ENV, ZCODE_ACP_REMOTE_ORIGIN: "editor" }));
     expect(loose?.origin).toBe("editor");
     expect(loose?.pinCwd).toBe(false);
   });
 });
 
+describe("parseRemoteConfig (config file > env)", () => {
+  it("enables remote with no env at all — the launch-context-independent path", () => {
+    writeConfig({ remote: { enabled: true, token: "filetok" } });
+    const config = parseRemoteConfig(env());
+    expect(config?.token).toBe("filetok");
+    expect(config?.hubPort).toBe(DEFAULT_HUB_PORT);
+  });
+
+  it("the file wins over env for every field it sets", () => {
+    writeConfig({
+      remote: { enabled: true, token: "filetok", hubPort: 9001, hubHost: "10.0.0.1", bridgePort: 9002 },
+    });
+    const config = parseRemoteConfig(
+      env({
+        ...BASE_ENV,
+        ZCODE_ACP_HUB_PORT: "9000",
+        ZCODE_ACP_HUB_HOST: "0.0.0.0",
+        ZCODE_ACP_REMOTE_PORT: "9003",
+      }),
+    );
+    expect(config).toEqual({
+      token: "filetok",
+      hubPort: 9001,
+      hubHost: "10.0.0.1",
+      bridgePort: 9002,
+      origin: "editor",
+      pinCwd: false,
+    });
+  });
+
+  it("env fills the fields the file leaves unset", () => {
+    writeConfig({ remote: { enabled: true } });
+    const config = parseRemoteConfig(
+      env({ ...BASE_ENV, ZCODE_ACP_HUB_PORT: "9000" }),
+    );
+    expect(config?.token).toBe("secret");
+    expect(config?.hubPort).toBe(9000);
+  });
+
+  it("an explicit enabled:false in the file disables remote even with env =1", () => {
+    writeConfig({ remote: { enabled: false } });
+    expect(parseRemoteConfig(env(BASE_ENV))).toBeNull();
+  });
+
+  it("a malformed file warns and reads as absent — env keeps working", () => {
+    writeRawConfig("{ not json");
+    const config = parseRemoteConfig(env(BASE_ENV));
+    expect(config?.token).toBe("secret");
+  });
+
+  it("a file token enables remote even when env has none", () => {
+    writeConfig({ remote: { enabled: true, token: "filetok" } });
+    const config = parseRemoteConfig(env({ ZCODE_ACP_HUB_PORT: "8500" }));
+    expect(config?.token).toBe("filetok");
+    expect(config?.hubPort).toBe(8500);
+  });
+});
+
 describe("parseHubConfig", () => {
   it("refuses to start without a token", () => {
-    expect(parseHubConfig({})).toBeNull();
+    expect(parseHubConfig(env())).toBeNull();
   });
 
   it("uses hub host/port from env", () => {
-    const config = parseHubConfig({
-      ZCODE_ACP_REMOTE_TOKEN: "t",
-      ZCODE_ACP_HUB_PORT: "8400",
-      ZCODE_ACP_HUB_HOST: "0.0.0.0",
-    });
+    const config = parseHubConfig(
+      env({
+        ZCODE_ACP_REMOTE_TOKEN: "t",
+        ZCODE_ACP_HUB_PORT: "8400",
+        ZCODE_ACP_HUB_HOST: "0.0.0.0",
+      }),
+    );
     expect(config?.hubPort).toBe(8400);
     expect(config?.hubHost).toBe("0.0.0.0");
+  });
+
+  it("reads token and ports from the config file (GUI-born hub path)", () => {
+    // The hub is spawned by whichever bridge needs it; without a file its
+    // birth env may carry no remote config at all.
+    writeConfig({ remote: { token: "hubtok", hubPort: 8500 } });
+    const config = parseHubConfig(env());
+    expect(config?.token).toBe("hubtok");
+    expect(config?.hubPort).toBe(8500);
+  });
+});
+
+describe("remoteTerminalPrefs (file > env, live-read)", () => {
+  it("defaults to enabled with no app or command", () => {
+    expect(remoteTerminalPrefs(env())).toEqual({ enabled: true });
+  });
+
+  it("reads the legacy env vars when no file exists", () => {
+    const prefs = remoteTerminalPrefs(
+      env({ ZCODE_ACP_HUB_TERMINAL_APP: "iTerm", ZCODE_ACP_HUB_TERMINAL_COMMAND: "" }),
+    );
+    expect(prefs).toEqual({ enabled: true, app: "iTerm" });
+  });
+
+  it("the env gate disables incubation when the file is silent", () => {
+    expect(remoteTerminalPrefs(env({ ZCODE_ACP_HUB_TERMINAL: "0" })).enabled).toBe(false);
+  });
+
+  it("the file wins: app/command/enabled override env", () => {
+    writeConfig({
+      remote: { terminal: { app: "ghostty", enabled: false } },
+    });
+    const prefs = remoteTerminalPrefs(
+      env({ ZCODE_ACP_HUB_TERMINAL_APP: "iTerm", ZCODE_ACP_HUB_TERMINAL: "1" }),
+    );
+    expect(prefs).toEqual({ enabled: false, app: "ghostty" });
+  });
+
+  it("the file command beats the file app", () => {
+    writeConfig({
+      remote: { terminal: { app: "iTerm", command: "my-term {script}" } },
+    });
+    expect(remoteTerminalPrefs(env())).toEqual({
+      enabled: true,
+      app: "iTerm",
+      command: "my-term {script}",
+    });
   });
 });

--- a/tests/user-config.test.ts
+++ b/tests/user-config.test.ts
@@ -1,0 +1,111 @@
+/**
+ * The global user config loader (~/.config/zcode-acp/config.json): path
+ * resolution (XDG aware), best-effort parsing (missing/malformed reads as
+ * absent), and per-field validation (invalid values drop with a warn).
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { loadUserConfig, userConfigPath } from "../src/config/user-config.js";
+
+let scratch: string;
+
+beforeEach(() => {
+  scratch = mkdtempSync(path.join(tmpdir(), "zacp-usercfg-"));
+});
+
+afterEach(() => {
+  rmSync(scratch, { recursive: true, force: true });
+});
+
+function writeConfig(text: string): void {
+  mkdirSync(path.join(scratch, "zcode-acp"), { recursive: true });
+  writeFileSync(path.join(scratch, "zcode-acp", "config.json"), text);
+}
+
+describe("userConfigPath", () => {
+  it("honours XDG_CONFIG_HOME when set", () => {
+    expect(userConfigPath({ XDG_CONFIG_HOME: "/xdg" })).toBe(
+      path.join("/xdg", "zcode-acp", "config.json"),
+    );
+  });
+
+  it("falls back to ~/.config", () => {
+    const p = userConfigPath({});
+    // The conventional layout under the home dir, whatever homedir() is here.
+    expect(p.endsWith(path.join(".config", "zcode-acp", "config.json"))).toBe(true);
+    expect(path.isAbsolute(p)).toBe(true);
+  });
+});
+
+describe("loadUserConfig", () => {
+  it("missing file reads as empty (the no-file env-only path)", () => {
+    expect(loadUserConfig({ XDG_CONFIG_HOME: scratch })).toEqual({});
+  });
+
+  it("parses the full remote section", () => {
+    writeConfig(
+      JSON.stringify({
+        remote: {
+          enabled: true,
+          token: " tok ",
+          hubPort: 18377,
+          hubHost: "0.0.0.0",
+          bridgePort: 18378,
+          terminal: { enabled: true, app: "ghostty", command: "gt --run {script}" },
+        },
+      }),
+    );
+    expect(loadUserConfig({ XDG_CONFIG_HOME: scratch })).toEqual({
+      remote: {
+        enabled: true,
+        token: "tok",
+        hubPort: 18377,
+        hubHost: "0.0.0.0",
+        bridgePort: 18378,
+        terminal: { enabled: true, app: "ghostty", command: "gt --run {script}" },
+      },
+    });
+  });
+
+  it("malformed JSON reads as empty", () => {
+    writeConfig("{ nope");
+    expect(loadUserConfig({ XDG_CONFIG_HOME: scratch })).toEqual({});
+  });
+
+  it("non-object JSON (array/scalar) reads as empty", () => {
+    writeConfig("[1,2,3]");
+    expect(loadUserConfig({ XDG_CONFIG_HOME: scratch })).toEqual({});
+    writeConfig('"hello"');
+    expect(loadUserConfig({ XDG_CONFIG_HOME: scratch })).toEqual({});
+  });
+
+  it("drops invalid ports and wrong-typed fields, keeps the valid rest", () => {
+    writeConfig(
+      JSON.stringify({
+        remote: {
+          enabled: true,
+          hubPort: 99999,
+          bridgePort: "not-a-number",
+          token: 42, // wrong type → ignored
+          hubHost: "", // blank → ignored
+          terminal: { app: "  ", enabled: "yes" }, // blank app + wrong type
+        },
+      }),
+    );
+    expect(loadUserConfig({ XDG_CONFIG_HOME: scratch })).toEqual({ remote: { enabled: true } });
+  });
+
+  it("a non-object remote section is ignored wholesale", () => {
+    writeConfig(JSON.stringify({ remote: "oops" }));
+    expect(loadUserConfig({ XDG_CONFIG_HOME: scratch })).toEqual({});
+  });
+
+  it("unknown keys are ignored (forward compatible)", () => {
+    writeConfig(JSON.stringify({ remote: { enabled: true, futureField: "x" }, other: 1 }));
+    expect(loadUserConfig({ XDG_CONFIG_HOME: scratch })).toEqual({ remote: { enabled: true } });
+  });
+});


### PR DESCRIPTION
## Problem

Resuming a conversation from the phone App incubates a CLI TUI on the desktop
(Warp tab via the hub). The session restored and its history replayed into the
transcript correctly — but martty's welcome banner paints INSTEAD of the
transcript and only dives when text is first submitted, so the replay stayed
invisible until the user's first message (source-verified against martty
0.2.35: all `show_banner = false` sites are user-submit actions; the startup
branch never drops it).

## Fix

- The hub incubates resume TUIs with `DSH_TUI_AUTOPROMPT="resume session"`
  (plain text on purpose: a leading `/` routes through martty's slash dispatch
  whose gates run before agent capabilities are known, `!` runs a local shell
  command). Martty auto-submits it at boot, which drops the banner immediately
  and queues the text until the boot bind.
- The bridge intercepts that first prompt and answers with a one-line
  "⟲ resumed" chunk + `end_turn` — no `session/send`, the model is never
  touched.
- **Connection-scoped one-shot** (`bootResumeTriggerConnection`, identity =
  the SDK `connectionContext`): the phone App attaches to the same bridge
  during the boot window and its prompt can arrive FIRST. Other connections
  can neither spend nor disarm the handshake; only the booting connection's
  own first non-trigger prompt disarms it (auto-submit lost — the text typed
  manually later must stay a normal prompt).
- Sticky `marttyClientSeen` flag instead of a bare `clientName` check:
  `clientName` is last-write-wins across `initialize` calls, and an App
  initialize can land between the TUI's initialize and session/new.

A live failure before the scoping fix (App prompt "hi" disarmed the handshake,
the trigger leaked to the model) is covered by a regression test that
reproduces the exact ordering.

## Also on this branch (same remote-resume arc)

- `feat(config)`: migrate remote prefs to `~/.config/zcode-acp/config.json`
  (file > env > default) — hub is a detached daemon whose birth env rotates.
- `feat(remote)`: launch the remote TUI in Warp via its `new_tab` URI action.
- `docs`: note the open-channel hub restart escape from agent-session
  sandboxes.

## Testing

- `tests/boot-resume.test.ts`: trigger ack, one-shot consumption, multi-client
  race (phone prompt first → handshake stays armed → trigger still
  intercepted), same-connection disarm, never arms for non-martty clients.
- `tests/hub.test.ts`: incubation script embeds `DSH_TUI_AUTOPROMPT`.
- Full suite (922 tests), lint, typecheck, build green.
- Live-verified end to end: phone resume → Warp tab shows full history
  immediately, ends with the ack line; model untouched.