### PR TITLE
feat(remote): name the resumed TUI tab after the conversation

### DIFF
--- a/docs/REMOTE-CLIENTS.md
+++ b/docs/REMOTE-CLIENTS.md
@@ -264,7 +264,12 @@ POST {hub}/api/instances  body {"workspacePath":"/Users/me/proj",
   bridge the window runs on; attach to it and `session/load` the same id to
   follow along in the client (both surfaces then share one bridge, one
   backend process). A bogus id still opens the window: the bridge logs the
-  load failure and starts a fresh session instead. Resuming the same session
+  load failure and starts a fresh session instead. The terminal tab is named
+  after the conversation: the hub reads the title from the serve bridge's
+  session history (best-effort, 2s budget — a miss falls back to the project
+  name) and the launch script emits it as an OSC 0 title before starting the
+  CLI (Martty never sets a terminal title itself, so the name sticks).
+  Resuming the same session
   twice pops two windows; only identical concurrent requests share one
   incubation.
 - `sessionId` here is the backend store id (`sess_…`), which `session/load`

--- a/src/remote/hub-server.ts
+++ b/src/remote/hub-server.ts
@@ -323,6 +323,13 @@ export function terminalTuiScript(cwd: string, cliJs: string, env: NodeJS.Proces
     `# Hub-incubated TUI session (ADR-0016): closing this window ends the bridge.`,
     `cd ${shQuote(cwd)} || exit 1`,
     ...exports,
+    // OSC 0 names the tab after the conversation — without it terminals show
+    // the running process ("node"). printf reads the \033/\007 escapes from
+    // the format string; %s keeps the value itself shell-safe. martty never
+    // sets a terminal title, so this survives until the window closes.
+    ...(env.ZCODE_ACP_TAB_TITLE !== undefined
+      ? [`printf '\\033]0;%s\\007' "$ZCODE_ACP_TAB_TITLE"`]
+      : []),
     `exec ${shQuote(process.execPath)} ${shQuote(cliJs)}`,
     "",
   ].join("\n");
@@ -517,6 +524,37 @@ const MAX_SESSION_LIST_BYTES = 4 * 1024 * 1024;
  * gives its own query 15s).
  */
 const SESSION_LIST_TIMEOUT_MS = 12_000;
+/** Best-effort budget for the resume tab-title lookup — the window must
+ *  never wait on a slow bridge (the 12s list budget is for listings, not
+ *  for cosmetics). */
+const TITLE_LOOKUP_BUDGET_MS = 2_000;
+
+/**
+ * Tab-title sanitizer: the value is printf'd into the terminal as an OSC
+ * payload, so control characters (an ESC inside a model-generated summary
+ * would inject terminal sequences) become spaces, whitespace collapses, and
+ * the length caps at what a tab can usefully show. Empty/non-string →
+ * undefined (the caller falls back to the project name).
+ */
+export function sanitizeTabTitle(v: unknown): string | undefined {
+  if (typeof v !== "string") return undefined;
+  const clean = v
+    .replace(/[\p{Cc}]/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 80);
+  return clean.length > 0 ? clean : undefined;
+}
+
+/** Resolve with undefined after `ms` — for best-effort lookups that must not
+ *  stall their caller; the losing promise settles into the void (its own
+ *  rejection is the caller's `.catch`, never unhandled). */
+function withTimeout<T>(p: Promise<T>, ms: number): Promise<T | undefined> {
+  const timeout = new Promise<undefined>((resolve) => {
+    setTimeout(() => resolve(undefined), ms).unref?.();
+  });
+  return Promise.race([p, timeout]);
+}
 
 /**
  * Fetch a bridge's GET /sessions payload (ADR-0015), forwarding the
@@ -714,6 +752,7 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
     workspacePath: string,
     kind: "tui" | "serve" | "resume",
     sessionId?: string,
+    tabTitle?: string,
   ): Promise<{ id: string; reused: boolean }> => {
     // Async spawn failures (ENOENT — the dir vanished between the whitelist
     // check and the spawn) arrive as an 'error' event with exitCode still
@@ -754,6 +793,14 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
       // boot-replayed history without waiting for the user's first message.
       // Must ride the env verbatim — martty reads it once at process start.
       env.DSH_TUI_AUTOPROMPT = BOOT_RESUME_TRIGGER;
+    }
+    if (kind !== "serve") {
+      // Tab title (both visible-terminal kinds): a resume carries the
+      // conversation's title when the hub resolved it; session-create and a
+      // failed lookup fall back to the project name. Rides the env —
+      // terminalTuiScript turns it into an OSC 0 before exec'ing the CLI
+      // (terminals otherwise name the tab after the process, "node").
+      env.ZCODE_ACP_TAB_TITLE = tabTitle ?? path.basename(workspacePath);
     }
     try {
       // Resume shares session-create's visible-terminal surface (and its
@@ -825,6 +872,7 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
     workspacePath: string,
     kind: "tui" | "serve" | "resume",
     sessionId?: string,
+    tabTitle?: string,
   ): Promise<{ id: string; reused: boolean }> => {
     const mapKey =
       kind === "resume" ? `${workspacePath}\u0000resume\u0000${sessionId ?? ""}` : workspacePath;
@@ -833,7 +881,7 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
       log(`hub: joining the incubating serve bridge for ${workspacePath}`);
       return inflight.promise;
     }
-    const promise = incubateServe(workspacePath, kind, sessionId);
+    const promise = incubateServe(workspacePath, kind, sessionId, tabTitle);
     serveIncubations.set(mapKey, { kind, promise });
     // Drop the entry once settled (identity-checked — a newer incubation may
     // already have replaced it). The catch keeps the DERIVED promise handled;
@@ -1178,13 +1226,33 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
         return;
       }
       if (resumeSid) {
+        // Tab title, best-effort: the App browsed this conversation through
+        // the serve bridge's /sessions history, which is normally still live
+        // and still holds the title. Every miss (no live instance, id beyond
+        // the page, slow fetch) falls back to the project name inside
+        // incubateServe — the window must never wait on this lookup.
+        let tabTitle: string | undefined;
+        const titleSource = findServeInstance(workspacePath);
+        if (titleSource) {
+          const row = await withTimeout(
+            fetchBridgeSessions(titleSource.port, "?limit=200")
+              .then((payload) =>
+                (payload.sessions ?? []).find(
+                  (s) => (s as { sessionId?: unknown }).sessionId === resumeSid,
+                ),
+              )
+              .catch(() => undefined),
+            TITLE_LOOKUP_BUDGET_MS,
+          );
+          tabTitle = sanitizeTabTitle((row as { title?: unknown } | undefined)?.title);
+        }
         // Resume never reuses the live serve bridge: the window IS the
         // feature, and the answer must be the NEW instance so the attaching
         // client and the terminal share one bridge (and one backend process)
         // for the session. A bogus id still opens the window — the TUI
         // shows the load failure and falls back to a fresh session, the same
         // honesty as a window that dies early (ADR-0016 §4).
-        const incubation = joinIncubation(workspacePath, "resume", resumeSid);
+        const incubation = joinIncubation(workspacePath, "resume", resumeSid, tabTitle);
         try {
           const out = await incubation;
           res.writeHead(200, { "Content-Type": "application/json" });

--- a/tests/hub.test.ts
+++ b/tests/hub.test.ts
@@ -35,6 +35,7 @@ vi.mock("../src/tasks-index.js", () => ({
 import {
   resetQuotaCacheForTest,
   resolveTerminalLaunch,
+  sanitizeTabTitle,
   startHub,
   terminalTuiScript,
   type HubHandle,
@@ -973,6 +974,8 @@ describe("hub remote session-create (ADR-0014)", () => {
     // roots to the project cwd (ADR-0014 whitelist semantics).
     expect(spawnCalls[0]!.env.ZCODE_ACP_REMOTE_ORIGIN).toBe("serve");
     expect(spawnCalls[0]!.env.ZCODE_ACP_REMOTE_PIN_CWD).toBe("1");
+    // Tab title default: no conversation to name, so the project names it.
+    expect(spawnCalls[0]!.env.ZCODE_ACP_TAB_TITLE).toBe("demo");
     await registerServeBridge(hub, PROJECT);
     const res = await pending;
     expect(res.status).toBe(200);
@@ -1420,7 +1423,12 @@ describe("hub terminal-TUI session resume (ADR-0017)", () => {
     };
   }
 
-  async function registerServeBridge(hub: HubHandle, id: string, nonce?: string): Promise<void> {
+  async function registerServeBridge(
+    hub: HubHandle,
+    id: string,
+    nonce?: string,
+    port: number = BASE_PORT + 50,
+  ): Promise<void> {
     const res = await fetch(`http://127.0.0.1:${hub.port}/api/register`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -1429,7 +1437,7 @@ describe("hub terminal-TUI session resume (ADR-0017)", () => {
           id,
           workspace: PROJECT,
           origin: "serve",
-          port: BASE_PORT + 50,
+          port,
           pid: 4242,
           ...(nonce ? { nonce } : {}),
         }),
@@ -1450,6 +1458,9 @@ describe("hub terminal-TUI session resume (ADR-0017)", () => {
     expect(spawnCalls).toHaveLength(1);
     expect(spawnCalls[0]!.kind).toBe("tui");
     expect(spawnCalls[0]!.env.ZCODE_ACP_RESUME_SESSION).toBe("sess_closed");
+    // Dead listing port → the title lookup fails fast → the project names
+    // the tab (the lookup must never block or break the window).
+    expect(spawnCalls[0]!.env.ZCODE_ACP_TAB_TITLE).toBe("demo");
     // The fresh bridge registers with its incubation nonce: the poll pairs
     // with it, never with the pre-existing listing bridge (whose id would
     // put the client's session/load on a different process than the window).
@@ -1475,6 +1486,54 @@ describe("hub terminal-TUI session resume (ADR-0017)", () => {
     expect(body).not.toContain("DSH_IRRELEVANT");
   });
 
+  it("names the tab via OSC 0 when a title rides the incubation env", () => {
+    // Terminals otherwise name the tab after the running process ("node");
+    // the script emits OSC 0 before exec, and martty never sets a terminal
+    // title itself, so the name survives until the window closes.
+    const withTitle = terminalTuiScript(PROJECT, "/opt/cli.js", {
+      ZCODE_ACP_TAB_TITLE: "Fix the login bug",
+    });
+    expect(withTitle).toContain("export ZCODE_ACP_TAB_TITLE='Fix the login bug'");
+    expect(withTitle).toContain(`printf '\\033]0;%s\\007' "$ZCODE_ACP_TAB_TITLE"`);
+    expect(terminalTuiScript(PROJECT, "/opt/cli.js", {})).not.toContain("033]0");
+  });
+
+  it("titles the resume tab with the conversation title from the live serve bridge", async () => {
+    // The App browses history through a serve bridge; the same /sessions
+    // listing is the title source for the resumed tab (the conversation
+    // title, sanitized — model-generated summaries must not carry escape
+    // sequences into the terminal).
+    let seenUrl = "";
+    const bridge = createServer((req, res) => {
+      seenUrl = req.url ?? "";
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          sessions: [
+            { sessionId: "sess_closed", title: "Fix the login bug", updatedAt: 2 },
+            { sessionId: "sess_other", title: "Other", updatedAt: 1 },
+          ],
+        }),
+      );
+    });
+    const bridgePort = await new Promise<number>((resolve) => {
+      bridge.listen(0, "127.0.0.1", () => {
+        const addr = bridge.address();
+        resolve(typeof addr === "object" && addr ? addr.port : 0);
+      });
+    });
+    const hub = await startTestHub({ spawnServe: spawnServeSpy() });
+    await registerServeBridge(hub, "listing-serve", undefined, bridgePort);
+    const pending = post(hub, { workspacePath: PROJECT, sessionId: "sess_closed" });
+    await new Promise((r) => setTimeout(r, 400)); // one poll tick
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0]!.env.ZCODE_ACP_TAB_TITLE).toBe("Fix the login bug");
+    expect(seenUrl).toBe("/sessions?limit=200");
+    await registerServeBridge(hub, "resume-repl", spawnCalls[0]!.env.ZCODE_ACP_SPAWN_NONCE);
+    expect((await pending).status).toBe(200);
+    await new Promise<void>((r) => bridge.close(() => r()));
+  });
+
   it("joins one incubation for identical concurrent resumes, but not a different session", async () => {
     const hub = await startTestHub({ spawnServe: spawnServeSpy() });
     const first = post(hub, { workspacePath: PROJECT, sessionId: "sess_a" });
@@ -1484,6 +1543,8 @@ describe("hub terminal-TUI session resume (ADR-0017)", () => {
     expect(spawnCalls).toHaveLength(2); // sess_a shares one spawn; sess_b is its own
     expect(spawnCalls[0]!.env.ZCODE_ACP_RESUME_SESSION).toBe("sess_a");
     expect(spawnCalls[1]!.env.ZCODE_ACP_RESUME_SESSION).toBe("sess_b");
+    // No live serve bridge → no title lookup → the project names the tab.
+    expect(spawnCalls[0]!.env.ZCODE_ACP_TAB_TITLE).toBe("demo");
     // Each window's bridge registers with its OWN nonce — the polls must not
     // cross-claim (a crossed answer would attach the client to the wrong
     // bridge and load the session on two backend processes).
@@ -1516,6 +1577,23 @@ describe("hub terminal-TUI session resume (ADR-0017)", () => {
     const res = await pending;
     expect(res.status).toBe(502);
     expect(await res.text()).toBe("serve bridge exited during startup");
+  });
+});
+
+describe("tab title sanitization", () => {
+  it("strips control chars (no OSC/CSI injection), collapses whitespace, caps length", () => {
+    // An ESC in a model-generated summary would otherwise inject terminal
+    // sequences through the tab-title printf.
+    expect(sanitizeTabTitle("Fix\u001b]0;evil\u0007 tab")).toBe("Fix ]0;evil tab");
+    expect(sanitizeTabTitle(" a \n\t b ")).toBe("a b");
+    expect(sanitizeTabTitle("x".repeat(120))).toHaveLength(80);
+  });
+
+  it("empty or non-string values read as undefined (caller falls back)", () => {
+    expect(sanitizeTabTitle("   ")).toBeUndefined();
+    expect(sanitizeTabTitle("")).toBeUndefined();
+    expect(sanitizeTabTitle(undefined)).toBeUndefined();
+    expect(sanitizeTabTitle(42)).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Problem

A remote-resumed conversation opens a Warp tab running the TUI, but the tab
is named after the running process ("node") — among several tabs nothing
identifies which conversation the window holds.

## Fix

- The hub resolves the conversation's title when the resume POST arrives:
  the serve bridge that served the App's history listing is normally still
  live, so the hub asks its `/sessions?limit=200` for the row matching the
  requested id. Best-effort by design — a 2s budget races the fetch, every
  miss (no live instance, id beyond the page, slow bridge) falls back to the
  project name, and the window never waits on the lookup.
- The sanitized title rides `ZCODE_ACP_TAB_TITLE` through the incubation
  env; `terminalTuiScript` emits `printf '\033]0;%s\007'` (OSC 0) before
  exec'ing the CLI. Martty never sets a terminal title itself, so the name
  survives until the window closes.
- Titles are model-generated text headed for the terminal, so
  `sanitizeTabTitle` strips control characters (an ESC would inject terminal
  sequences), collapses whitespace, and caps the length at 80.
- Session-create tabs get the project name as their default title.

## Testing

- `tests/hub.test.ts`: OSC line emission (present with a title, absent
  without), title lookup through a live fake serve bridge, project-name
  fallback (no instance / dead port), sanitizer units.
- Full suite (926 tests), lint, typecheck, build green.
- Live-verified from the phone App: the Warp tab opens named after the
  conversation.