### PR TITLE
feat(tui): resident quota dock + project-bound terminal incubation

### DIFF
--- a/assets/martty-plugins/quota-dock/plugin.json
+++ b/assets/martty-plugins/quota-dock/plugin.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": 0,
+  "id": "zcode-acp-quota",
+  "kind": "ui",
+  "name": "zcode-acp quota dock",
+  "purpose": "Reads the read-only quota config option and session context stats and renders them in the composer dock.",
+  "source": {
+    "pluginId": "plugin-zcode-acp-quota",
+    "packageId": "pkg-zcode-acp-quota-1"
+  },
+  "code": {
+    "client": "// zcode-acp quota-dock plugin v1 (seeded by zcode-acp-server, ADR-0021)\nreturn {\n  inject: [\"tuiSlots\", \"acpSessionConfig\", \"acpSessionStats\"],\n  apply: (ctx) => {\n    let panel\n    let quotaText = null\n    let context = null\n    const compactSize = (n) => {\n      if (n >= 1000000) return (Math.round(n / 100000) / 10) + \"M\"\n      if (n >= 1000) return Math.round(n / 1000) + \"K\"\n      return String(n)\n    }\n    const readQuota = () => {\n      const options = ctx.acpSessionConfig.list()\n      const found = (options || []).filter((o) => o && o.id === \"quota\")[0]\n      const v = found && typeof found.currentValue === \"string\" ? found.currentValue : null\n      quotaText = v && v.length > 0 ? v : null\n    }\n    const readStats = () => {\n      const cur = ctx.acpSessionStats.current ? ctx.acpSessionStats.current() : null\n      const c = cur && cur.context ? cur.context : null\n      context = c && typeof c.used === \"number\" && typeof c.size === \"number\" && c.size > 0 ? c : null\n    }\n    const nodes = () => {\n      const parts = []\n      if (context) parts.push(\"ctx \" + (Math.round((context.used / context.size) * 1000) / 10) + \"%/\" + compactSize(context.size))\n      if (quotaText) parts.push(quotaText)\n      if (parts.length === 0) return []\n      return [{ id: \"zcode-acp-quota-gauge\", kind: \"generic\", title: parts.join(\" · \"), body: \"\" }]\n    }\n    const render = () => { if (panel) { try { panel.update(nodes()) } catch (err) {} } }\n    const stopSlot = ctx.tuiSlots.inject(\"conversation.composer.dock\", () => {\n      panel = ctx.tuiSlots.register({ name: \"conversation.composer.dock\", id: \"zcode-acp-quota\" }, nodes())\n      return () => panel.dispose()\n    })\n    readQuota()\n    readStats()\n    const stopSub = ctx.acpSessionConfig.subscribe((snap) => { readQuota(); render() })\n    let stopStats = null\n    if (ctx.acpSessionStats.subscribe) stopStats = ctx.acpSessionStats.subscribe(() => { readStats(); render() })\n    return () => { stopSub && stopSub(); stopStats && stopStats(); stopSlot && stopSlot() }\n  },\n}"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "types": "dist/index.d.ts",
   "files": [
     "dist",
+    "assets",
     "README.md",
     "LICENSE",
     "docs"

--- a/src/config/options.ts
+++ b/src/config/options.ts
@@ -14,7 +14,13 @@ import { readFileSync } from "node:fs";
 import type * as acp from "@agentclientprotocol/sdk";
 
 import type { ZcodeReadResult } from "../backend/types.js";
-import { CONFIG_DISPATCH, CONFIG_META, log, ZCODE_CREDS_PATH } from "../utils.js";
+import {
+  clientConnectionRoot,
+  CONFIG_DISPATCH,
+  CONFIG_META,
+  log,
+  ZCODE_CREDS_PATH,
+} from "../utils.js";
 import type { ZcodeAcpServer } from "../server.js";
 import { sendSessionUpdate } from "../handlers/io.js";
 
@@ -199,7 +205,17 @@ export async function buildModes(
  * (GLM-5.3: low/high/max; GLM-5-Turbo: enabled/off; others may differ).
  * Unknown tokens keep their config order after the known ones.
  */
-const THOUGHT_ORDER = ["low", "medium", "high", "xhigh", "max", "ultra", "enabled", "disabled", "off"];
+const THOUGHT_ORDER = [
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+  "ultra",
+  "enabled",
+  "disabled",
+  "off",
+];
 
 export function orderThoughtVariants(variants: string[]): Array<{ value: string; name: string }> {
   const known = THOUGHT_ORDER.filter((t) => variants.includes(t));
@@ -210,10 +226,14 @@ export function orderThoughtVariants(variants: string[]): Array<{ value: string;
 /** Build the ACP configOptions array (3 items: model/mode/thought).
  *  zcodeSid null = pending session — skip the backend read and use defaults;
  *  mode defaults to "yolo" (the mode session/create hardcodes) so the dropdown
- *  matches the mode indicator for a fresh session. */
+ *  matches the mode indicator for a fresh session.
+ *  `receiverRoot` is the clientConnectionRoot of the client the array is
+ *  delivered to — the quota pseudo-option is appended only for martty
+ *  connections (ADR-0021); other receivers get the spec-clean 3 options. */
 export async function buildConfigOptions(
   server: ZcodeAcpServer,
   zcodeSid: string | null,
+  receiverRoot?: unknown,
 ): Promise<acp.SessionConfigOption[]> {
   let currentProviderId = "";
   let currentModelId = DEFAULT_MODEL_ID;
@@ -243,12 +263,14 @@ export async function buildConfigOptions(
       currentModelId = cur.modelId;
       try {
         const cfg = readConfig() as ConfigShape;
-        const m = (cfg.provider?.[cur.providerId]?.models as
-          | Record<
-              string,
-              { reasoning?: { enabled?: boolean; variants?: string[]; defaultVariant?: string } }
-            >
-          | undefined)?.[cur.modelId];
+        const m = (
+          cfg.provider?.[cur.providerId]?.models as
+            | Record<
+                string,
+                { reasoning?: { enabled?: boolean; variants?: string[]; defaultVariant?: string } }
+              >
+            | undefined
+        )?.[cur.modelId];
         const reasoning = m?.reasoning;
         const variants = reasoning?.variants;
         if (reasoning?.enabled !== false && variants && variants.length > 0) {
@@ -276,7 +298,8 @@ export async function buildConfigOptions(
       const tlSet = (settings.thoughtLevel as Record<string, unknown>) ?? {};
       // `current` is absent right after session/create — fall back to the
       // backend's defaultLevel (the level the session actually runs at).
-      currentThought = (tlSet.current as string) ?? (tlSet.defaultLevel as string) ?? currentThought;
+      currentThought =
+        (tlSet.current as string) ?? (tlSet.defaultLevel as string) ?? currentThought;
       const tlAvail = (tlSet.available as Array<Record<string, string>>) ?? [];
       if (tlAvail.length > 0) {
         thoughtOptions = tlAvail.map((a) => ({ value: a.value, name: a.label ?? a.value }));
@@ -309,7 +332,7 @@ export async function buildConfigOptions(
   }
   if (!thoughtOptions) thoughtOptions = [...CONFIG_META.thought.options];
 
-  return [
+  const options: acp.SessionConfigOption[] = [
     {
       id: "model",
       name: CONFIG_META.model.name,
@@ -340,6 +363,27 @@ export async function buildConfigOptions(
       options: thoughtOptions,
     },
   ];
+
+  // Read-only quota pseudo-option (ADR-0021): martty-only, no category (never
+  // lands in a settings menu), string type per the probe-verified shape — the
+  // SDK's union stops at select/boolean, so the cast carries the agent-owned
+  // extension through typecheck. `set_config_option` on it is a no-op.
+  // Gated on the RECEIVER's connection identity, not process state — a
+  // non-martty client must never see the spec-external string option.
+  if (
+    server.quotaDock &&
+    receiverRoot !== undefined &&
+    server.marttyConnectionRoots.has(receiverRoot)
+  ) {
+    options.push({
+      id: "quota",
+      name: "GLM Coding Plan quota",
+      title: "GLM Coding Plan quota",
+      type: "string",
+      currentValue: server.quotaDock,
+    } as unknown as acp.SessionConfigOption);
+  }
+  return options;
 }
 
 /**
@@ -387,7 +431,7 @@ export async function emitConfigOptionUpdate(
   zcodeSid: string,
   kind: "model" | "mode" | "thought",
 ): Promise<acp.SessionConfigOption[]> {
-  const options = await buildConfigOptions(server, zcodeSid);
+  const options = await buildConfigOptions(server, zcodeSid, clientConnectionRoot(cx));
   await sendSessionUpdate(cx, acpSid, {
     sessionUpdate: "config_option_update",
     configOptions: options,

--- a/src/handlers/dispatch.ts
+++ b/src/handlers/dispatch.ts
@@ -26,7 +26,7 @@ import {
 import { messages } from "../i18n.js";
 import type { InternalEvent } from "../translators/types.js";
 import type { ZcodeAcpServer } from "../server.js";
-import { warn } from "../utils.js";
+import { clientConnectionRoot, warn } from "../utils.js";
 import { sendSessionUpdate } from "./io.js";
 
 /** True once the EPERM hint fired for this process — throttled to one shot. */
@@ -135,7 +135,7 @@ async function dispatchConfigChanged(
     // Fall back to null (defaults) only if the session mapping isn't live yet —
     // events routed through a registered turn loop always have it.
     const zcodeSid = server.resolveSid(acpSid) ?? null;
-    const options = await buildConfigOptions(server, zcodeSid);
+    const options = await buildConfigOptions(server, zcodeSid, clientConnectionRoot(cx));
     // Find by id — the array order buildConfigOptions returns is not a
     // contract; index-based writes would silently hit the wrong option if
     // that order ever changed (emitModeViaConfigOption already does this).

--- a/src/handlers/extensions.ts
+++ b/src/handlers/extensions.ts
@@ -19,7 +19,7 @@ import { emitInitialUsage } from "../config/model-cache.js";
 import { applyModelSwitch } from "../config/runtime-model.js";
 import { buildConfigOptions, buildModes } from "../config/options.js";
 import { ProjectionDiffer } from "../translators/projection-differ.js";
-import { log, warn } from "../utils.js";
+import { clientConnectionRoot, log, warn } from "../utils.js";
 import type { ZcodeAcpServer } from "../server.js";
 import { sendSessionUpdate } from "./io.js";
 import { ensureRealSession } from "./session.js";
@@ -235,7 +235,7 @@ export async function setMode(
   log(`session/setMode → ${mode}`);
   // Re-build configOptions (settings.mode.current is now updated) and emit
   // config_option_update + current_mode_update so the editor UI reflects it.
-  const options = await buildConfigOptions(server, zcodeSid);
+  const options = await buildConfigOptions(server, zcodeSid, clientConnectionRoot(cx));
   await sendSessionUpdate(cx, acpSid, {
     sessionUpdate: "config_option_update",
     configOptions: options,

--- a/src/handlers/server-requests.ts
+++ b/src/handlers/server-requests.ts
@@ -45,7 +45,7 @@ import {
 import { buildConfigOptions, buildModes } from "../config/options.js";
 import { messages } from "../i18n.js";
 import type { ClientLike } from "../remote/broadcast.js";
-import { log, warn } from "../utils.js";
+import { clientConnectionRoot, log, warn } from "../utils.js";
 import type { PendingTurn, ZcodeAcpServer } from "../server.js";
 import { sendSessionUpdate } from "./io.js";
 
@@ -81,7 +81,7 @@ async function emitModeViaConfigOption(
   try {
     const modes = await buildModes(server, zcodeSid);
     server.lastMode.set(acpSid, modes.currentModeId);
-    const options = await buildConfigOptions(server, zcodeSid);
+    const options = await buildConfigOptions(server, zcodeSid, clientConnectionRoot(cx));
     const modeOpt = options.find((o) => o.id === "mode");
     if (modeOpt) modeOpt.currentValue = modes.currentModeId;
     await sendSessionUpdate(cx, acpSid, {

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -29,10 +29,15 @@ import type {
 import {
   buildModes,
   buildConfigOptions,
+  DEFAULT_MODEL_ID,
+  DEFAULT_PROVIDER_ID,
   formatModelValue,
   loadAllModels,
+  modelContextWindow,
+  parseModelValue,
 } from "../config/options.js";
-import { emitInitialUsage } from "../config/model-cache.js";
+import { currentModelCached, emitInitialUsage } from "../config/model-cache.js";
+import { forceRefreshQuota, startQuotaRefresher } from "../quota/live.js";
 import { buildProviderRegistry } from "../config/provider-registry.js";
 import { buildResumeRuntimeModel } from "../config/runtime-model.js";
 import { messages } from "../i18n.js";
@@ -210,6 +215,13 @@ export async function newSession(
   params: acp.NewSessionRequest,
   client?: acp.AgentContext,
 ): Promise<acp.NewSessionResponse> {
+  // Martty bookkeeping (ADR-0021): start the lazy refresher when THIS
+  // connection is martty. Identity is per-connection — recorded at the
+  // connection's own initialize (server.ts), never the sticky process flag,
+  // so a phone app's session/new must not become a quota-dock target.
+  if (server.marttyConnectionRoots.has(clientConnectionRoot(client))) {
+    startQuotaRefresher(server);
+  }
   const bootResume = consumeBootResumeTarget();
   if (bootResume) {
     try {
@@ -246,6 +258,7 @@ export async function newSession(
           });
         }
       }
+      emitBootUsageUpdate(server, bootResume);
       return {
         sessionId: bootResume,
         modes: loaded.modes,
@@ -284,11 +297,58 @@ export async function newSession(
   // pending session's real values arrive via updates once materialized).
   const modes = await buildModes(server, null);
   server.lastMode.set(acpSid, modes.currentModeId);
+  emitBootUsageUpdate(server, acpSid);
   return {
     sessionId: acpSid,
     modes,
-    configOptions: await buildConfigOptions(server, null),
+    configOptions: await buildConfigOptions(server, null, clientConnectionRoot(client)),
   };
+}
+
+/**
+ * Initial usage_update after a session/new binding (ADR-0021): martty only —
+ * unlike emitInitialUsage this does NOT skip used=0, so the TUI's context
+ * window (size at least) shows from the very first screen. Deferred past the
+ * session/new response via setImmediate: a pre-response notification carries
+ * a session id the client has not adopted yet and would be dropped.
+ */
+function emitBootUsageUpdate(server: ZcodeAcpServer, acpSid: string): void {
+  if (!isMarttyClient(server)) return;
+  const cx = server.clients.broadcast();
+  setImmediate(() => {
+    void (async () => {
+      try {
+        const zcodeSid = server.resolveSid(acpSid);
+        let used = 0;
+        if (zcodeSid) {
+          const backend = server.ensureBackend();
+          const resp = await backend.request(
+            server.nextId(),
+            "session/read",
+            { sessionId: zcodeSid },
+            5000,
+          );
+          const proj = ((resp.result ?? {}) as { projection?: ZcodeProjection }).projection;
+          used = proj?.contextUsed || proj?.totalTokenCount || 0;
+        }
+        let providerId = loadAllModels()[0]?.providerId ?? DEFAULT_PROVIDER_ID;
+        let modelId = loadAllModels()[0]?.modelId ?? DEFAULT_MODEL_ID;
+        if (zcodeSid) {
+          ({ providerId, modelId } = parseModelValue(await currentModelCached(server, zcodeSid)));
+        }
+        await sendSessionUpdate(cx, acpSid, {
+          sessionUpdate: "usage_update",
+          used,
+          size: modelContextWindow(providerId, modelId),
+        });
+      } catch (e) {
+        log(
+          `session/new: boot usage_update failed (non-fatal): ` +
+            `${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
+    })();
+  });
 }
 
 /**
@@ -652,7 +712,7 @@ export async function resumeSession(
   server.lastMode.set(acpSid, modes.currentModeId);
   return {
     modes,
-    configOptions: await buildConfigOptions(server, zcodeSid),
+    configOptions: await buildConfigOptions(server, zcodeSid, clientConnectionRoot(cx)),
   };
 }
 
@@ -770,7 +830,7 @@ export async function loadSession(
   const turnActive = [...server.pendingTurns.values()].some((t) => t.zcodeSid === zcodeSid);
   const result = {
     modes,
-    configOptions: await buildConfigOptions(server, zcodeSid),
+    configOptions: await buildConfigOptions(server, zcodeSid, clientConnectionRoot(cx)),
     // Additive replay metadata — the anchor for load_earlier pagination.
     replayMeta: { ...slice.meta, turnActive },
   };
@@ -1260,6 +1320,9 @@ async function runPrompt(
     // runtime was demonstrably live through this turn.
     server.markSessionActive(params.sessionId);
     server.markBackendLoaded(params.sessionId);
+    // Turn end = quota refresh point (ADR-0021): usage moved, the dock should
+    // catch up immediately instead of waiting for the 60s interval.
+    void forceRefreshQuota();
     // Report "running" only while no other turn for the session took over
     // (preempt): the preempting turn's own running:true must survive.
     const stillBusy = [...server.pendingTurns.values()].some((t) => t.zcodeSid === zcodeSid);
@@ -1287,6 +1350,17 @@ export async function setConfigOptionHandler(
 ): Promise<acp.SetSessionConfigOptionResponse> {
   if (typeof params.value !== "string") {
     throw new Error(`unsupported config value type: ${String(params.value)}`);
+  }
+  // The `quota` option (ADR-0021) is a read-only display channel for the TUI
+  // dock — setting it is a no-op that returns the current options unchanged.
+  if (params.configId === "quota") {
+    return {
+      configOptions: await buildConfigOptions(
+        server,
+        server.resolveSid(params.sessionId) ?? null,
+        clientConnectionRoot(cx),
+      ),
+    };
   }
   // Materialize a lazy session/new placeholder on first use.
   const zcodeSid = await ensureRealSession(server, params.sessionId);
@@ -2646,7 +2720,7 @@ export async function emitModeIfChanged(
     const last = server.lastMode.get(acpSid);
     if (last === modes.currentModeId) return;
     server.lastMode.set(acpSid, modes.currentModeId);
-    const options = await buildConfigOptions(server, zcodeSid);
+    const options = await buildConfigOptions(server, zcodeSid, clientConnectionRoot(cx));
     await sendSessionUpdate(cx, acpSid, {
       sessionUpdate: "config_option_update",
       configOptions: options,

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,7 +153,7 @@ function buildAgentApp(server: ZcodeAcpServer, allCommands: ReturnType<typeof bu
   return (
     acp
       .agent({ name: AGENT_INFO.name })
-      .onRequest("initialize", (ctx) => server.initialize(ctx.params))
+      .onRequest("initialize", (ctx) => server.initialize(ctx.params, ctx.client))
       .onRequest("session/new", async (ctx) => {
         const result = await newSession(server, ctx.params, ctx.client);
         for (const sid of server.sessionAliases(result.sessionId)) {

--- a/src/quota/format.ts
+++ b/src/quota/format.ts
@@ -282,3 +282,44 @@ export function formatQuotaPlain(result: QuotaResult, opts?: FormatOptions): str
   const card = formatQuota(result, opts);
   return result.kind === "success" ? card.replace(/^```text\n/, "").replace(/\n```$/, "") : card;
 }
+
+// ---------- quota dock (ADR-0021) ----------
+
+/**
+ * Format a compact one-line quota string for the Martty TUI's resident dock
+ * (ADR-0021): `5h 45% · wk 12% · reset 2h13m` — 5h-window used percent, weekly
+ * used percent, and the time left until the 5h window resets. MCP quota is
+ * deliberately omitted (the dock line must stay short).
+ *
+ * Returns `null` when there is nothing to show (non-success result, or a
+ * success with no 5h/weekly windows) so the caller hides the dock instead of
+ * rendering a placeholder.
+ */
+export function formatQuotaDock(result: QuotaResult, now: () => number = Date.now): string | null {
+  if (result.kind !== "success") return null;
+  const byKey = new Map(result.items.map((item) => [item.key, item]));
+  const fiveHour = byKey.get("token_5h");
+  const weekly = byKey.get("token_week");
+  if (!fiveHour) return null;
+
+  const parts: string[] = [`5h ${fiveHour.usedPercent}%`];
+  if (weekly) parts.push(`wk ${weekly.usedPercent}%`);
+  const reset = formatResetRemaining(fiveHour.nextResetTime, now);
+  if (reset) parts.push(`reset ${reset}`);
+  return parts.join(" · ");
+}
+
+/**
+ * Remaining-time rendering for the dock: `2h13m` (minutes zero-padded when
+ * hours are present), `43m` under an hour, `0m` when already due (a negative
+ * remaining reads as due-now rather than confusing the user with "-").
+ */
+function formatResetRemaining(nextResetTime: number | undefined, now: () => number): string | null {
+  if (nextResetTime === undefined || !Number.isFinite(nextResetTime)) return null;
+  const leftMs = nextResetTime - now();
+  if (!Number.isFinite(leftMs)) return null;
+  const leftMin = Math.max(0, Math.floor(leftMs / 60_000));
+  const h = Math.floor(leftMin / 60);
+  const m = leftMin % 60;
+  return h > 0 ? `${h}h${String(m).padStart(2, "0")}m` : `${m}m`;
+}

--- a/src/quota/live.ts
+++ b/src/quota/live.ts
@@ -1,0 +1,161 @@
+/**
+ * Quota dock refresher (ADR-0021) — keeps the Martty TUI's resident quota line
+ * up to date.
+ *
+ * A lazy process-wide singleton: started on first martty session activity, it
+ * refreshes every 60s and on every forceRefresh() (wired at turn end). Each
+ * successful refresh stores the formatted string on `server.quotaDock` and
+ * pushes a `config_option_update` (full options array — martty's subscribe is
+ * full-replace semantics) to the martty connections only.
+ *
+ * Cross-process sharing is hub-first: when the remote hub is reachable, its
+ * cached /api/quota/dock endpoint serves the string (~500ms budget); any
+ * failure falls back silently to a direct queryQuota() — the fallback is the
+ * normal path for local-only users (the hub is opt-in and idle-exits).
+ */
+
+import type * as acp from "@agentclientprotocol/sdk";
+
+import { buildConfigOptions } from "../config/options.js";
+import { parseRemoteConfig } from "../remote/config.js";
+import { log, warn } from "../utils.js";
+import type { ZcodeAcpServer } from "../server.js";
+import { enqueueSessionSend } from "../handlers/io.js";
+import { formatQuotaDock } from "./format.js";
+import { queryQuota } from "./index.js";
+
+/** Interval between background refreshes. */
+export const QUOTA_REFRESH_INTERVAL_MS = 60_000;
+/** Budget for the hub-first lookup before falling back to a direct query. */
+const HUB_TIMEOUT_MS = 500;
+
+interface RefresherState {
+  server: ZcodeAcpServer;
+  timer: ReturnType<typeof setInterval>;
+  /** Collapses concurrent refreshes (interval + forceRefresh) into one fetch. */
+  inFlight: Promise<void> | null;
+}
+
+let state: RefresherState | null = null;
+
+/**
+ * Start the refresher (idempotent). No-op unless a martty client has been
+ * seen — editor-only setups never poll the quota API in the background.
+ */
+export function startQuotaRefresher(server: ZcodeAcpServer): void {
+  if (state || !server.marttyClientSeen) return;
+  const entry: RefresherState = {
+    server,
+    timer: setInterval(() => void refresh(entry), QUOTA_REFRESH_INTERVAL_MS),
+    inFlight: null,
+  };
+  entry.timer.unref?.();
+  state = entry;
+  void refresh(entry);
+}
+
+/** Best-effort immediate refresh (called at every turn end). Never rejects. */
+export function forceRefreshQuota(): Promise<void> {
+  if (!state) return Promise.resolve();
+  return refresh(state);
+}
+
+/** Stop and forget the singleton (test helper). */
+export function resetQuotaRefresherForTest(): void {
+  if (state) clearInterval(state.timer);
+  state = null;
+}
+
+async function refresh(entry: RefresherState): Promise<void> {
+  if (entry.inFlight) return entry.inFlight;
+  entry.inFlight = runRefresh(entry.server)
+    .catch((e) => {
+      log(`quota-dock: refresh failed (${e instanceof Error ? e.message : String(e)})`);
+    })
+    .finally(() => {
+      entry.inFlight = null;
+    });
+  return entry.inFlight;
+}
+
+async function runRefresh(server: ZcodeAcpServer): Promise<void> {
+  const text = await fetchDockText();
+  const prev = server.quotaDock;
+  server.quotaDock = text;
+  // ADR-0021: on failure/no-data the dock hides — no update is emitted.
+  if (text === null || text === prev) return;
+  await emitQuotaOptions(server);
+}
+
+/** Hub-first dock string, falling back to a direct query. */
+export async function fetchDockText(env: NodeJS.ProcessEnv = process.env): Promise<string | null> {
+  const remote = parseRemoteConfig(env);
+  if (remote) {
+    try {
+      const resp = await fetch(`http://${remote.hubHost}:${remote.hubPort}/api/quota/dock`, {
+        headers: { Authorization: `Bearer ${remote.token}` },
+        signal: AbortSignal.timeout(HUB_TIMEOUT_MS),
+      });
+      if (resp.ok) {
+        const body = (await resp.json()) as { formatted?: unknown };
+        if (body.formatted === null) return null;
+        if (typeof body.formatted === "string") return body.formatted;
+      }
+    } catch {
+      // hub absent/restarting — silent fallback below
+    }
+  }
+  return formatQuotaDock(await queryQuota());
+}
+
+/**
+ * Push a `config_option_update` carrying the full options array (quota
+ * included) to every martty connection, for every live session alias. Other
+ * clients are untouched — the quota option is martty-only by contract.
+ */
+async function emitQuotaOptions(server: ZcodeAcpServer): Promise<void> {
+  if (server.marttyConnectionRoots.size === 0) return;
+  const targets = server.clients
+    .snapshot()
+    .filter((cx) => server.marttyConnectionRoots.has(connectionRootOf(cx)));
+  if (targets.length === 0) return;
+
+  // Build the options once per zcode session (aliases share the same list).
+  const byZcodeSid = new Map<string | null, acp.SessionConfigOption[]>();
+  const emitFor = async (acpSid: string): Promise<void> => {
+    const zcodeSid = server.resolveSid(acpSid) ?? null;
+    let options = byZcodeSid.get(zcodeSid);
+    if (!options) {
+      // All targets are martty connections by construction — any target's
+      // root unlocks the quota pseudo-option for the shared options array.
+      options = await buildConfigOptions(server, zcodeSid, connectionRootOf(targets[0]!));
+      byZcodeSid.set(zcodeSid, options);
+    }
+    await enqueueSessionSend(acpSid, async () => {
+      const results = await Promise.allSettled(
+        targets.map((cx) =>
+          cx.notify("session/update", {
+            sessionId: acpSid,
+            update: { sessionUpdate: "config_option_update", configOptions: options },
+          }),
+        ),
+      );
+      for (const r of results) {
+        if (r.status === "rejected") {
+          warn(
+            `quota-dock: config_option_update failed on one client: ` +
+              `${r.reason instanceof Error ? r.reason.message : String(r.reason)}`,
+          );
+        }
+      }
+    });
+  };
+
+  const acpSids = [...server.sessionMap.keys(), ...server.pendingSessions.keys()];
+  for (const acpSid of acpSids) await emitFor(acpSid);
+}
+
+/** clientConnectionRoot equivalent for a raw ClientLike (see utils.ts). */
+function connectionRootOf(cx: unknown): unknown {
+  return (cx as { connectionContext?: unknown }).connectionContext;
+}

--- a/src/remote/hub-server.ts
+++ b/src/remote/hub-server.ts
@@ -25,7 +25,16 @@
 
 import { spawn, type ChildProcess } from "node:child_process";
 import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
-import { chmodSync, mkdtempSync, realpathSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  realpathSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import type { Dirent } from "node:fs";
 import { readdir, readFile, stat } from "node:fs/promises";
 import {
@@ -337,6 +346,53 @@ export function terminalTuiScript(cwd: string, cliJs: string, env: NodeJS.Proces
   ].join("\n");
 }
 
+/** Stale TUI scripts older than this are swept on the next incubation. */
+const TUI_SCRIPT_MAX_AGE_MS = 60 * 60 * 1000;
+
+/**
+ * Write the throwaway .command script for a terminal TUI incubation.
+ *
+ * Preferred location: `<workspace>/.zcode/tmp/tui-XXXX.command`. Terminal apps
+ * bind the new tab's project root to the script's PARENT directory (Warp's
+ * open_file opens a session in the file's dir before executing it), so a
+ * tmpdir script leaves the tab bound to a throwaway directory — the in-script
+ * `cd` only moves the shell cwd and never re-binds the terminal project, which
+ * blinds diff/git panels. Any failure writing there (read-only workspace,
+ * permissions, …) falls back to the historical mkdtemp(tmpdir()) path.
+ */
+export function writeTuiScript(workspace: string, cliJs: string, env: NodeJS.ProcessEnv): string {
+  const contents = terminalTuiScript(workspace, cliJs, env);
+  const dir = path.join(workspace, ".zcode", "tmp");
+  try {
+    mkdirSync(dir, { recursive: true });
+    // Best-effort sweep of stale scripts (>1h old): an unlinked-but-running
+    // script keeps executing on unix, and a fresh one may back a live
+    // incubation, so only clearly-stale files go.
+    const cutoff = Date.now() - TUI_SCRIPT_MAX_AGE_MS;
+    for (const entry of readdirSync(dir)) {
+      if (!entry.startsWith("tui-") || !entry.endsWith(".command")) continue;
+      const stale = path.join(dir, entry);
+      try {
+        if (statSync(stale).mtimeMs < cutoff) unlinkSync(stale);
+      } catch {
+        // best-effort — a racing removal must not abort the incubation
+      }
+    }
+    const script = path.join(dir, `tui-${randomUUID().slice(0, 8)}.command`);
+    writeFileSync(script, contents, { mode: 0o700 });
+    chmodSync(script, 0o700);
+    return script;
+  } catch (e) {
+    warn(
+      `hub: cannot place the TUI script in ${dir} (${e instanceof Error ? e.message : String(e)}) — using the system tmpdir`,
+    );
+  }
+  const fallback = path.join(mkdtempSync(path.join(tmpdir(), "zcode-acp-term-")), "tui.command");
+  writeFileSync(fallback, contents, { mode: 0o700 });
+  chmodSync(fallback, 0o700);
+  return fallback;
+}
+
 /**
  * Spawn session-create as a VISIBLE interactive TUI (ADR-0016): write a
  * throwaway .command script (`cd <project> && exec node cli.js`) and hand it
@@ -361,9 +417,7 @@ async function spawnTerminalTui(opts: {
   // ZCODE_ACP_HUB_TERMINAL=0) to keep remote session-create headless.
   if (!remoteTerminalPrefs(process.env).enabled) return null;
   const cliJs = fileURLToPath(new URL("../cli.js", import.meta.url));
-  const script = path.join(mkdtempSync(path.join(tmpdir(), "zcode-acp-term-")), "tui.command");
-  writeFileSync(script, terminalTuiScript(opts.cwd, cliJs, opts.env), { mode: 0o700 });
-  chmodSync(script, 0o700);
+  const script = writeTuiScript(opts.cwd, cliJs, opts.env);
   const { launch, warning } = resolveTerminalLaunch(process.env);
   if (warning) warn(`hub: ${warning}`);
   let argv: string[];

--- a/src/remote/hub-server.ts
+++ b/src/remote/hub-server.ts
@@ -51,6 +51,8 @@ import type { TerminalPrefs } from "../config/user-config.js";
 import { remoteTerminalPrefs } from "./config.js";
 import { accountUsageStats, type UsageStatsResult } from "../handlers/account.js";
 import { BOOT_RESUME_TRIGGER } from "../handlers/session.js";
+import { formatQuotaDock } from "../quota/format.js";
+import { queryQuota } from "../quota/index.js";
 import { listKnownWorkspaces } from "../tasks-index.js";
 
 export interface HubOptions {
@@ -494,6 +496,31 @@ function getQuota(): Promise<UsageStatsResult> {
 export function resetQuotaCacheForTest(): void {
   quotaCache = null;
   quotaInflight = null;
+}
+
+/**
+ * Cached dock string for GET /api/quota/dock (ADR-0021) — the compact one-line
+ * quota format consumed by the Martty TUI refresher. Shorter TTL than
+ * /api/quota (15s): the dock is resident UI, freshness beats upstream load.
+ * `formatted: null` (no data) is cached too, so a credentials-less machine
+ * does not hammer the API on every 60s refresh.
+ */
+const DOCK_TTL_MS = 15_000;
+let dockCache: { formatted: string | null; at: number } | null = null;
+
+function getQuotaDock(): Promise<{ formatted: string | null; fetchedAt: number }> {
+  if (dockCache && Date.now() - dockCache.at < DOCK_TTL_MS) {
+    return Promise.resolve({ formatted: dockCache.formatted, fetchedAt: dockCache.at });
+  }
+  return queryQuota().then((result) => {
+    dockCache = { formatted: formatQuotaDock(result), at: Date.now() };
+    return { formatted: dockCache.formatted, fetchedAt: dockCache.at };
+  });
+}
+
+/** Reset the dock cache (test helper). */
+export function resetDockCacheForTest(): void {
+  dockCache = null;
 }
 
 /**
@@ -1065,6 +1092,25 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
           "Cache-Control": "no-store",
         });
         res.end(JSON.stringify(result));
+      } catch {
+        res.writeHead(502, { "Content-Type": "text/plain" });
+        res.end("quota query failed");
+      }
+      return;
+    }
+    // GET /api/quota/dock — the compact quota-dock string for the TUI
+    // refresher (ADR-0021). Account-level like /api/quota; hub-side cache is
+    // the only caching layer, so clients must not store stale copies.
+    if (url.pathname === "/api/quota/dock" && req.method === "GET") {
+      if (!authorized(req, url, token)) {
+        res.writeHead(401, { "Content-Type": "text/plain" });
+        res.end("unauthorized");
+        return;
+      }
+      try {
+        const { formatted, fetchedAt } = await getQuotaDock();
+        res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-store" });
+        res.end(JSON.stringify({ formatted, fetchedAt }));
       } catch {
         res.writeHead(502, { "Content-Type": "text/plain" });
         res.end("quota query failed");

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,7 +20,7 @@ import { BackgroundTaskListener } from "./handlers/background-tasks.js";
 import { enqueueSessionSend } from "./handlers/io.js";
 import { SandboxRestartBatcher, flushSandboxGrants } from "./handlers/sandbox-allow.js";
 import { ClientRegistry } from "./remote/broadcast.js";
-import { AGENT_INFO, PROTOCOL_VERSION, log, warn } from "./utils.js";
+import { AGENT_INFO, clientConnectionRoot, PROTOCOL_VERSION, log, warn } from "./utils.js";
 
 /** Client capabilities advertised in the initialize request. */
 export interface ClientCapabilities {
@@ -182,6 +182,22 @@ export class ZcodeAcpServer {
    * this flag instead.
    */
   marttyClientSeen = false;
+  /**
+   * Connection roots (clientConnectionRoot identity) of connections known to
+   * be Martty — recorded at THAT connection's `initialize`, never inherited
+   * from the process-wide sticky flag (a phone app initializing after the TUI
+   * must not become a dock target). The quota dock refresher (ADR-0021)
+   * targets exactly these connections with `config_option_update`s, and
+   * buildConfigOptions appends the pseudo `quota` option only for them;
+   * editors must not see it.
+   */
+  readonly marttyConnectionRoots = new Set<unknown>();
+  /**
+   * Latest formatted quota dock string (ADR-0021), or null when the last
+   * refresh failed / has nothing to show. Maintained by src/quota/live.ts;
+   * read by buildConfigOptions when appending the read-only `quota` option.
+   */
+  quotaDock: string | null = null;
   /**
    * One-shot banner-handshake scope (see BOOT_RESUME_TRIGGER): the
    * `connectionContext` identity of the client whose boot-resumed session/new
@@ -567,11 +583,21 @@ export class ZcodeAcpServer {
     this.clientCapabilities = next;
   }
 
-  /** Handle `initialize`: negotiate version + declare agent capabilities. */
-  async initialize(params: acp.InitializeRequest): Promise<acp.InitializeResponse> {
+  /** Handle `initialize`: negotiate version + declare agent capabilities.
+   *  `client` is the calling connection's AgentContext — martty identity is
+   *  recorded PER CONNECTION here, so later non-martty attaches never inherit
+   *  quota-dock targeting from the sticky process flag. */
+  async initialize(
+    params: acp.InitializeRequest,
+    client?: acp.AgentContext,
+  ): Promise<acp.InitializeResponse> {
     const clientInfo = (params.clientInfo as { name?: string; version?: string } | null) ?? null;
     this.clientName = clientInfo?.name ?? null;
-    if ((this.clientName ?? "").toLowerCase().includes("martty")) this.marttyClientSeen = true;
+    if ((this.clientName ?? "").toLowerCase().includes("martty")) {
+      this.marttyClientSeen = true;
+      const root = clientConnectionRoot(client);
+      if (root !== undefined) this.marttyConnectionRoots.add(root);
+    }
     this.mergeClientCapabilities((params.clientCapabilities as ClientCapabilities) ?? {});
     log(
       `initialize: client protocolVersion=${params.protocolVersion}` +

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -15,12 +15,14 @@
  */
 
 import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { createRequire } from "node:module";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
-import { warn } from "./utils.js";
+import { log, warn } from "./utils.js";
 
 /** Path to Martty's Node wrapper (bin/martty.js), or null when not installed. */
 export function resolveMarttyJs(): string | null {
@@ -59,6 +61,7 @@ export async function runTui(): Promise<void> {
   if (!marttyJs) {
     throw new Error("martty is not installed — reinstall the zcode-acp-server package");
   }
+  seedMarttyQuotaPlugin();
   const child = spawn(process.execPath, [marttyJs, ...buildTuiArgs(agentEntryJs())], {
     stdio: "inherit",
   });
@@ -82,6 +85,93 @@ export async function checkTuiRuntime(): Promise<boolean> {
     { stdio: "inherit" },
   );
   return (await settle(child)) === 0;
+}
+
+// ---------- quota dock plugin seeding (ADR-0021) ----------
+
+/** Martty home resolution: env MARTTY_HOME → $DSH_HOME/.martty → ~/.martty. */
+export function resolveMarttyHome(env: NodeJS.ProcessEnv = process.env): string {
+  if (env.MARTTY_HOME) return env.MARTTY_HOME;
+  if (env.DSH_HOME) return path.join(env.DSH_HOME, ".martty");
+  return path.join(homedir(), ".martty");
+}
+
+/** What the seeder decided for an existing plugin.json. */
+export interface SeedPlan {
+  /** "write" = create/update the file; "none" = nothing to do; "skip" = never overwrite. */
+  action: "write" | "none" | "skip";
+  /** "current" = ours, same version · "update" = ours, older · others = skip reasons. */
+  reason: "fresh" | "current" | "update" | "foreign" | "modified" | "unparseable";
+}
+
+/**
+ * Decide whether to seed the quota dock plugin, comparing the on-disk
+ * plugin.json against our shipped asset. We write only when the file is
+ * missing or provably our own OLDER version (source.pluginId marker + the
+ * version suffix of source.packageId, mirroring the martty plugin store's
+ * artifact format). Same-version files that differ from our asset, foreign
+ * plugins, and unparseable files are never touched (user modifications).
+ * Pure — exported for unit tests.
+ */
+export function planQuotaSeed(existingContent: string | null, assetContent: string): SeedPlan {
+  if (existingContent === null) return { action: "write", reason: "fresh" };
+  let existing: {
+    source?: { pluginId?: unknown; packageId?: unknown };
+  };
+  try {
+    existing = JSON.parse(existingContent);
+  } catch {
+    return { action: "skip", reason: "unparseable" };
+  }
+  const asset = JSON.parse(assetContent) as {
+    source: { pluginId: string; packageId: string };
+  };
+  const src = existing.source ?? {};
+  if (src.pluginId !== asset.source.pluginId) return { action: "skip", reason: "foreign" };
+  const versionOf = (pkgId: unknown): number => {
+    const m = typeof pkgId === "string" ? /-(\d+)$/.exec(pkgId) : null;
+    return m ? Number(m[1]) : Number.NaN;
+  };
+  const current = versionOf(src.packageId);
+  const wanted = versionOf(asset.source.packageId);
+  if (!Number.isFinite(current) || current > wanted) return { action: "skip", reason: "foreign" };
+  if (current < wanted) return { action: "write", reason: "update" };
+  // Same version: identical content = done; anything else = user edit, keep it.
+  if (existingContent.trim() === assetContent.trim()) return { action: "none", reason: "current" };
+  return { action: "skip", reason: "modified" };
+}
+
+/**
+ * Seed the quota dock plugin into $MARTTY_HOME/plugins/<artifactId>/ before
+ * martty starts (ADR-0021). Best-effort: any failure warns and never blocks
+ * the TUI. The asset ships with the npm package (assets/martty-plugins), one
+ * directory level above the compiled dist/tui.js.
+ */
+export function seedMarttyQuotaPlugin(env: NodeJS.ProcessEnv = process.env): boolean {
+  try {
+    const assetPath = fileURLToPath(
+      new URL("../assets/martty-plugins/quota-dock/plugin.json", import.meta.url),
+    );
+    const assetContent = readFileSync(assetPath, "utf8");
+    const target = path.join(resolveMarttyHome(env), "plugins", "zcode-acp-quota", "plugin.json");
+    const existing = existsSync(target) ? readFileSync(target, "utf8") : null;
+    const plan = planQuotaSeed(existing, assetContent);
+    if (plan.action === "write") {
+      mkdirSync(path.dirname(target), { recursive: true });
+      writeFileSync(target, assetContent);
+      log(`tui: seeded quota dock plugin (${plan.reason}) → ${target}`);
+      return true;
+    }
+    if (plan.action === "skip") {
+      warn(`tui: quota dock plugin at ${target} is ${plan.reason} — leaving it untouched`);
+    }
+    return false;
+  } catch (e) {
+    warn(
+      `tui: quota dock plugin seeding failed (non-fatal): ${e instanceof Error ? e.message : String(e)}`,
+    );
+    return false;
+  }
 }
 
 /** Resolve on child exit; forward terminal signals while it runs. */

--- a/tests/boot-usage.test.ts
+++ b/tests/boot-usage.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Initial usage_update after session/new (ADR-0021): martty-gated, deferred
+ * past the response, and — unlike emitInitialUsage — NOT skipped when the
+ * projection reports 0 tokens, so the TUI context window shows from boot.
+ * Also covers the read-only `quota` config option no-op on set_config_option.
+ */
+
+import type * as acp from "@agentclientprotocol/sdk";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ZcodeBackend } from "../src/backend/client.js";
+import { buildConfigOptions } from "../src/config/options.js";
+import { newSession, setConfigOptionHandler } from "../src/handlers/session.js";
+import { ZcodeAcpServer } from "../src/server.js";
+
+vi.mock("../src/tasks-index.js", () => ({
+  upsertSessionTask: async () => true,
+  updateSessionTitle: async () => true,
+}));
+
+// Keep the quota refresher offline in these tests (it starts on martty
+// session/new): no hub, and a direct query that reports unavailable.
+vi.mock("../src/quota/index.js", () => ({ queryQuota: async () => ({ kind: "unavailable" }) }));
+vi.mock("../src/remote/config.js", () => ({ parseRemoteConfig: () => null }));
+
+/** Fake backend answering the minimal session/read surface. */
+function fakeBackend(contextUsed = 0): ZcodeBackend {
+  return {
+    isDead: false,
+    request: async (_id: number, method: string) => {
+      if (method === "session/read") {
+        return { result: { projection: { status: "idle", contextUsed } } };
+      }
+      return { result: {} };
+    },
+    send: () => {},
+    pollServerRequests: () => [],
+    registerEventListener: () => {},
+    unregisterEventListener: () => {},
+  } as unknown as ZcodeBackend;
+}
+
+interface RecordedUpdate {
+  sessionId: string;
+  update: Record<string, unknown>;
+}
+
+function recordingCx(connectionContext?: unknown): {
+  cx: acp.AgentContext;
+  updates: RecordedUpdate[];
+} {
+  const updates: RecordedUpdate[] = [];
+  return {
+    updates,
+    cx: {
+      connectionContext,
+      notify: async (
+        _method: string,
+        params: { sessionId: string; update: Record<string, unknown> },
+      ) => {
+        updates.push({ sessionId: params.sessionId, update: params.update });
+      },
+    } as unknown as acp.AgentContext,
+  };
+}
+
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+afterEach(() => {
+  delete process.env.ZCODE_ACP_RESUME_SESSION;
+});
+
+describe("boot usage_update", () => {
+  it("emits an initial usage_update (used may be 0) for martty after session/new", async () => {
+    const server = new ZcodeAcpServer();
+    server.backend = fakeBackend(0);
+    server.marttyClientSeen = true;
+    const { cx, updates } = recordingCx();
+    vi.spyOn(server.clients, "broadcast").mockReturnValue(cx);
+
+    const resp = await newSession(server, { cwd: "/tmp/proj" } as acp.NewSessionRequest, cx);
+    expect(resp.sessionId).toBeTruthy();
+    await flush();
+
+    const usage = updates.filter((u) => u.update.sessionUpdate === "usage_update");
+    expect(usage.length).toBe(1);
+    // Lazy placeholder: no backend projection yet → used 0, size from config.
+    expect(usage[0]!.update.used).toBe(0);
+    expect(typeof usage[0]!.update.size).toBe("number");
+  });
+
+  it("is skipped for non-martty clients", async () => {
+    const server = new ZcodeAcpServer();
+    server.backend = fakeBackend(0);
+    const { cx, updates } = recordingCx();
+    vi.spyOn(server.clients, "broadcast").mockReturnValue(cx);
+
+    await newSession(server, { cwd: "/tmp/proj" } as acp.NewSessionRequest, cx);
+    await flush();
+    expect(updates.filter((u) => u.update.sessionUpdate === "usage_update")).toHaveLength(0);
+  });
+
+  it("covers the boot-resume interception path (used 0 is NOT skipped)", async () => {
+    const server = new ZcodeAcpServer();
+    server.backend = fakeBackend(0);
+    server.marttyClientSeen = true;
+    server.registerSession("sess_boot", "zsess_boot");
+    const { cx, updates } = recordingCx();
+    vi.spyOn(server.clients, "broadcast").mockReturnValue(cx);
+    process.env.ZCODE_ACP_RESUME_SESSION = "sess_boot";
+
+    await newSession(server, { cwd: "/tmp/proj" } as acp.NewSessionRequest, cx);
+    await flush();
+
+    const usage = updates.filter(
+      (u) => u.update.sessionUpdate === "usage_update" && u.sessionId === "sess_boot",
+    );
+    expect(usage.length).toBe(1);
+    expect(usage[0]!.update.used).toBe(0);
+  });
+});
+
+describe("per-connection martty gating (ADR-0021)", () => {
+  it("initialize records the martty connection's root, not a process-wide flag", async () => {
+    const server = new ZcodeAcpServer();
+    const tuiRoot = { id: "tui" };
+    const appRoot = { id: "app" };
+    await server.initialize(
+      { clientInfo: { name: "Martty" } } as acp.InitializeRequest,
+      recordingCx(tuiRoot).cx,
+    );
+    await server.initialize(
+      { clientInfo: { name: "Paseo iOS" } } as acp.InitializeRequest,
+      recordingCx(appRoot).cx,
+    );
+    expect(server.marttyClientSeen).toBe(true);
+    expect(server.marttyConnectionRoots.has(tuiRoot)).toBe(true);
+    expect(server.marttyConnectionRoots.has(appRoot)).toBe(false);
+  });
+
+  it("session/new from a non-martty connection does not become a dock target", async () => {
+    const server = new ZcodeAcpServer();
+    server.backend = fakeBackend(0);
+    server.quotaDock = "5h 50%";
+    // A TUI connected earlier in the process (sticky flag set, its root known).
+    const tuiRoot = { id: "tui" };
+    await server.initialize(
+      { clientInfo: { name: "Martty" } } as acp.InitializeRequest,
+      recordingCx(tuiRoot).cx,
+    );
+    const appRoot = { id: "app" };
+    const { cx } = recordingCx(appRoot);
+    vi.spyOn(server.clients, "broadcast").mockReturnValue(cx);
+
+    const resp = await newSession(server, { cwd: "/tmp/proj" } as acp.NewSessionRequest, cx);
+    expect(server.marttyConnectionRoots.has(appRoot)).toBe(false);
+    // The app's response must not carry the spec-external quota pseudo-option.
+    expect(resp.configOptions.some((o) => o.id === "quota")).toBe(false);
+    expect(resp.configOptions.some((o) => o.id === "model")).toBe(true);
+  });
+
+  it("session/new from the martty connection keeps the quota option", async () => {
+    const server = new ZcodeAcpServer();
+    server.backend = fakeBackend(0);
+    server.quotaDock = "5h 50%";
+    const tuiRoot = { id: "tui" };
+    await server.initialize(
+      { clientInfo: { name: "Martty" } } as acp.InitializeRequest,
+      recordingCx(tuiRoot).cx,
+    );
+    const { cx } = recordingCx(tuiRoot);
+    vi.spyOn(server.clients, "broadcast").mockReturnValue(cx);
+
+    const resp = await newSession(server, { cwd: "/tmp/proj" } as acp.NewSessionRequest, cx);
+    expect(resp.configOptions.some((o) => o.id === "quota")).toBe(true);
+  });
+
+  it("buildConfigOptions appends quota only for a martty receiver root", async () => {
+    const server = new ZcodeAcpServer();
+    server.quotaDock = "5h 50%";
+    const tuiRoot = { id: "tui" };
+    server.marttyConnectionRoots.add(tuiRoot);
+    const withMartty = await buildConfigOptions(server, null, tuiRoot);
+    expect(withMartty.some((o) => o.id === "quota")).toBe(true);
+    const withApp = await buildConfigOptions(server, null, { id: "app" });
+    expect(withApp.some((o) => o.id === "quota")).toBe(false);
+    const withNone = await buildConfigOptions(server, null);
+    expect(withNone.some((o) => o.id === "quota")).toBe(false);
+  });
+});
+
+describe("quota config option no-op", () => {
+  it("set_config_option on quota returns the options without error", async () => {
+    const server = new ZcodeAcpServer();
+    const { cx } = recordingCx();
+    const resp = await setConfigOptionHandler(
+      server,
+      { sessionId: "s", configId: "quota", value: "5h 99%" } as acp.SetSessionConfigOptionRequest,
+      cx,
+    );
+    expect(Array.isArray(resp.configOptions)).toBe(true);
+    expect(resp.configOptions.some((o) => o.id === "model")).toBe(true);
+  });
+});

--- a/tests/hub-tui-script.test.ts
+++ b/tests/hub-tui-script.test.ts
@@ -1,0 +1,110 @@
+/**
+ * writeTuiScript tests — where the terminal-TUI .command script lands.
+ *
+ * The script must go into `<workspace>/.zcode/tmp/` (terminal apps bind the
+ * tab's project root to the script's parent dir), sweep stale tui-*.command
+ * leftovers (>1h), and silently fall back to the mkdtemp(tmpdir()) path when
+ * the workspace is not writable. node:fs is mocked with a Map/Set fake
+ * filesystem (same pattern as plugin-commands.test.ts).
+ */
+
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mkdtempSyncMock, unlinkSyncMock, writeFileSyncMock } = vi.hoisted(() => ({
+  mkdtempSyncMock: vi.fn(),
+  unlinkSyncMock: vi.fn(),
+  writeFileSyncMock: vi.fn(),
+}));
+
+// Fake filesystem: known files map to mtimeMs; dirs are a Set.
+const mockFiles = new Map<string, number>();
+const mockDirs = new Set<string>();
+const mkdirFailures = new Set<string>();
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    mkdirSync: (p: string, _opts?: { recursive?: boolean }) => {
+      if (mkdirFailures.has(p)) throw new Error("EACCES: read-only file system");
+      mockDirs.add(p);
+      return p;
+    },
+    readdirSync: (p: string) => {
+      const prefix = p.endsWith("/") ? p : p + "/";
+      return [...mockFiles.keys()]
+        .map((f) => (f.startsWith(prefix) ? f.slice(prefix.length) : null))
+        .filter((e): e is string => e !== null && !e.includes("/"));
+    },
+    statSync: (p: string) =>
+      ({ mtimeMs: mockFiles.get(p) ?? 0 }) as ReturnType<typeof actual.statSync>,
+    unlinkSync: (p: string) => {
+      mockFiles.delete(p);
+      unlinkSyncMock(p);
+    },
+    writeFileSync: (p: string, contents: string, opts?: { mode?: number }) => {
+      mockFiles.set(p, Date.now());
+      writeFileSyncMock(p, contents, opts);
+    },
+    chmodSync: () => {},
+    mkdtempSync: (p: string) => {
+      mkdtempSyncMock(p);
+      const dir = p + "abc123/";
+      mockDirs.add(dir);
+      return dir;
+    },
+  };
+});
+
+// Import after mocks.
+import { writeTuiScript } from "../src/remote/hub-server.js";
+
+const WORKSPACE = "/tmp/proj";
+
+beforeEach(() => {
+  mockFiles.clear();
+  mockDirs.clear();
+  mkdirFailures.clear();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("writeTuiScript", () => {
+  it("places the script under <workspace>/.zcode/tmp/", () => {
+    const script = writeTuiScript(WORKSPACE, "/dist/cli.js", {});
+    expect(script.startsWith(path.join(WORKSPACE, ".zcode", "tmp", "tui-"))).toBe(true);
+    expect(script.endsWith(".command")).toBe(true);
+    expect(mkdtempSyncMock).not.toHaveBeenCalled();
+    expect(writeFileSyncMock).toHaveBeenCalledWith(script, expect.any(String), { mode: 0o700 });
+  });
+
+  it("falls back to mkdtemp(tmpdir()) when the workspace dir is not writable", () => {
+    mkdirFailures.add(path.join(WORKSPACE, ".zcode", "tmp"));
+    const script = writeTuiScript(WORKSPACE, "/dist/cli.js", {});
+    expect(script).toBe(path.join(tmpdir(), "zcode-acp-term-abc123", "tui.command"));
+    expect(writeFileSyncMock).toHaveBeenCalledWith(script, expect.any(String), { mode: 0o700 });
+  });
+
+  it("sweeps tui-*.command scripts older than 1h but keeps fresh and unrelated ones", () => {
+    const dir = path.join(WORKSPACE, ".zcode", "tmp");
+    const hour = 60 * 60 * 1000;
+    mockFiles.set(path.join(dir, "tui-old.command"), Date.now() - 2 * hour);
+    mockFiles.set(path.join(dir, "tui-fresh.command"), Date.now() - 5 * 1000);
+    mockFiles.set(path.join(dir, "other.command"), Date.now() - 2 * hour);
+    mockFiles.set(path.join(dir, "tui-notes.txt"), Date.now() - 2 * hour);
+
+    writeTuiScript(WORKSPACE, "/dist/cli.js", {});
+
+    expect(unlinkSyncMock).toHaveBeenCalledTimes(1);
+    expect(unlinkSyncMock).toHaveBeenCalledWith(path.join(dir, "tui-old.command"));
+    expect(mockFiles.has(path.join(dir, "tui-fresh.command"))).toBe(true);
+    expect(mockFiles.has(path.join(dir, "other.command"))).toBe(true);
+    expect(mockFiles.has(path.join(dir, "tui-notes.txt"))).toBe(true);
+  });
+});

--- a/tests/hub.test.ts
+++ b/tests/hub.test.ts
@@ -23,6 +23,10 @@ vi.mock("../src/handlers/account.js", () => ({
   accountUsageStats: accountUsageStatsMock,
 }));
 
+// The quota dock endpoint (ADR-0021) queries via queryQuota — mock it too.
+const { queryQuotaMock } = vi.hoisted(() => ({ queryQuotaMock: vi.fn() }));
+vi.mock("../src/quota/index.js", () => ({ queryQuota: queryQuotaMock }));
+
 // The session-create endpoints read the known-project whitelist from
 // tasks-index; mock the module so no real sqlite/App store is touched.
 const { listKnownWorkspacesMock } = vi.hoisted(() => ({
@@ -33,6 +37,7 @@ vi.mock("../src/tasks-index.js", () => ({
 }));
 
 import {
+  resetDockCacheForTest,
   resetQuotaCacheForTest,
   resolveTerminalLaunch,
   sanitizeTabTitle,
@@ -419,6 +424,73 @@ describe("hub quota endpoint", () => {
     });
     expect(res.status).toBe(404);
     expect(accountUsageStatsMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("hub quota dock endpoint", () => {
+  const dockUrl = (hub: HubHandle) => `http://127.0.0.1:${hub.port}/api/quota/dock`;
+
+  beforeEach(() => {
+    queryQuotaMock.mockReset();
+    resetDockCacheForTest();
+  });
+
+  it("rejects /api/quota/dock without a token", async () => {
+    const hub = await startTestHub();
+    expect((await fetch(dockUrl(hub))).status).toBe(401);
+    expect(queryQuotaMock).not.toHaveBeenCalled();
+  });
+
+  it("returns {formatted, fetchedAt} from queryQuota", async () => {
+    const hub = await startTestHub();
+    queryQuotaMock.mockResolvedValueOnce({
+      kind: "success",
+      level: "pro",
+      items: [
+        { key: "token_5h", label: "5h", usedPercent: 45, leftPercent: 55 },
+        { key: "token_week", label: "Week", usedPercent: 12, leftPercent: 88 },
+      ],
+    });
+    const res = await fetch(dockUrl(hub), { headers: { Authorization: `Bearer ${TOKEN}` } });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    const body = (await res.json()) as { formatted: string | null; fetchedAt: number };
+    expect(body.formatted).toBe("5h 45% · wk 12%");
+    expect(body.fetchedAt).toBeGreaterThan(0);
+  });
+
+  it("serves the cached copy within the TTL", async () => {
+    const hub = await startTestHub();
+    queryQuotaMock.mockResolvedValue({
+      kind: "success",
+      level: "pro",
+      items: [{ key: "token_5h", label: "5h", usedPercent: 1, leftPercent: 99 }],
+    });
+    const headers = { Authorization: `Bearer ${TOKEN}` };
+    const first = await fetch(dockUrl(hub), { headers });
+    const second = await fetch(dockUrl(hub), { headers });
+    expect(queryQuotaMock).toHaveBeenCalledTimes(1);
+    expect(((await first.json()) as { formatted: string }).formatted).toBe("5h 1%");
+    expect(((await second.json()) as { formatted: string }).formatted).toBe("5h 1%");
+  });
+
+  it("caches a null formatted (dock hidden), and answers 502 on query failure", async () => {
+    const hub = await startTestHub();
+    queryQuotaMock.mockResolvedValueOnce({ kind: "unavailable" });
+    const headers = { Authorization: `Bearer ${TOKEN}` };
+    const hidden = await fetch(dockUrl(hub), { headers });
+    expect(hidden.status).toBe(200);
+    expect(((await hidden.json()) as { formatted: unknown }).formatted).toBeNull();
+    // The null result is cached: a repeat within the TTL does not re-query.
+    const again = await fetch(dockUrl(hub), { headers });
+    expect(again.status).toBe(200);
+    expect(((await again.json()) as { formatted: unknown }).formatted).toBeNull();
+    expect(queryQuotaMock).toHaveBeenCalledTimes(1);
+
+    resetDockCacheForTest();
+    queryQuotaMock.mockRejectedValueOnce(new Error("upstream down"));
+    const failed = await fetch(dockUrl(hub), { headers });
+    expect(failed.status).toBe(502);
   });
 });
 

--- a/tests/quota-dock.test.ts
+++ b/tests/quota-dock.test.ts
@@ -1,0 +1,92 @@
+/**
+ * formatQuotaDock tests (ADR-0021): the compact one-line dock string for the
+ * Martty TUI — success shape, omitted MCP, missing windows, reset rendering,
+ * and the null-on-failure contract.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { formatQuotaDock } from "../src/quota/format.js";
+import type { QuotaItem, QuotaResult } from "../src/quota/types.js";
+
+const NOW = 1_800_000_000_000;
+const now = () => NOW;
+
+function item(overrides: Partial<QuotaItem> & { key: string }): QuotaItem {
+  return { label: overrides.key, usedPercent: 0, leftPercent: 100, ...overrides };
+}
+
+describe("formatQuotaDock", () => {
+  it("renders 5h + weekly + reset and omits MCP", () => {
+    const result: QuotaResult = {
+      kind: "success",
+      level: "pro",
+      items: [
+        item({
+          key: "token_5h",
+          usedPercent: 45,
+          nextResetTime: NOW + 2 * 3_600_000 + 13 * 60_000,
+        }),
+        item({ key: "token_week", usedPercent: 12 }),
+        item({ key: "mcp", usedPercent: 80 }),
+      ],
+    };
+    expect(formatQuotaDock(result, now)).toBe("5h 45% · wk 12% · reset 2h13m");
+  });
+
+  it("omits the weekly segment when absent", () => {
+    const result: QuotaResult = {
+      kind: "success",
+      level: "pro",
+      items: [item({ key: "token_5h", usedPercent: 7, nextResetTime: NOW + 43 * 60_000 })],
+    };
+    expect(formatQuotaDock(result, now)).toBe("5h 7% · reset 43m");
+  });
+
+  it("zero-pads minutes when hours are present", () => {
+    const result: QuotaResult = {
+      kind: "success",
+      level: "pro",
+      items: [
+        item({ key: "token_5h", usedPercent: 61, nextResetTime: NOW + 3_600_000 + 2 * 60_000 }),
+      ],
+    };
+    expect(formatQuotaDock(result, now)).toBe("5h 61% · reset 1h02m");
+  });
+
+  it("omits the reset segment when the window carries no reset time", () => {
+    const result: QuotaResult = {
+      kind: "success",
+      level: "pro",
+      items: [
+        item({ key: "token_5h", usedPercent: 30 }),
+        item({ key: "token_week", usedPercent: 5 }),
+      ],
+    };
+    expect(formatQuotaDock(result, now)).toBe("5h 30% · wk 5%");
+  });
+
+  it("returns null without a 5h window even on success", () => {
+    const result: QuotaResult = {
+      kind: "success",
+      level: "pro",
+      items: [item({ key: "token_week", usedPercent: 5 }), item({ key: "mcp", usedPercent: 5 })],
+    };
+    expect(formatQuotaDock(result, now)).toBeNull();
+  });
+
+  it("returns null for every non-success result", () => {
+    expect(formatQuotaDock({ kind: "auth_error" }, now)).toBeNull();
+    expect(formatQuotaDock({ kind: "rate_limited" }, now)).toBeNull();
+    expect(formatQuotaDock({ kind: "unavailable" }, now)).toBeNull();
+  });
+
+  it("clamps a past reset time to 0m instead of going negative", () => {
+    const result: QuotaResult = {
+      kind: "success",
+      level: "pro",
+      items: [item({ key: "token_5h", usedPercent: 99, nextResetTime: NOW - 5_000 })],
+    };
+    expect(formatQuotaDock(result, now)).toBe("5h 99% · reset 0m");
+  });
+});

--- a/tests/quota-live.test.ts
+++ b/tests/quota-live.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Quota dock refresher tests (ADR-0021): lazy singleton lifecycle, interval +
+ * forceRefresh, hub-first with silent direct-query fallback, martty-only
+ * config_option_update targeting, and the null-hides contract.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { queryQuotaMock, buildOptionsMock, remoteConfigMock } = vi.hoisted(() => ({
+  queryQuotaMock: vi.fn(),
+  buildOptionsMock: vi.fn(),
+  remoteConfigMock: vi.fn(),
+}));
+
+vi.mock("../src/quota/index.js", () => ({ queryQuota: queryQuotaMock }));
+vi.mock("../src/config/options.js", () => ({ buildConfigOptions: buildOptionsMock }));
+vi.mock("../src/remote/config.js", () => ({ parseRemoteConfig: remoteConfigMock }));
+
+import {
+  forceRefreshQuota,
+  QUOTA_REFRESH_INTERVAL_MS,
+  resetQuotaRefresherForTest,
+  startQuotaRefresher,
+} from "../src/quota/live.js";
+import type { QuotaResult } from "../src/quota/types.js";
+import type { ZcodeAcpServer } from "../src/server.js";
+
+const SUCCESS: QuotaResult = {
+  kind: "success",
+  level: "pro",
+  items: [
+    { key: "token_5h", label: "5h", usedPercent: 45, leftPercent: 55 },
+    { key: "token_week", label: "Week", usedPercent: 12, leftPercent: 88 },
+  ],
+};
+
+interface NotifyCall {
+  method: string;
+  params: { sessionId: string; update: Record<string, unknown> };
+}
+
+/** Minimal fake server: martty flags, session maps, and a notify-recording client registry. */
+function fakeServer(opts: { martty?: boolean } = {}) {
+  const calls: NotifyCall[] = [];
+  const marttyRoot = { id: "martty-root" };
+  const editorRoot = { id: "editor-root" };
+  const marttyCx = {
+    connectionContext: marttyRoot,
+    notify: async (method: string, params: NotifyCall["params"]) => {
+      calls.push({ method, params });
+    },
+  };
+  const editorCx = {
+    connectionContext: editorRoot,
+    notify: async () => {
+      throw new Error("editor must not be targeted");
+    },
+  };
+  const server = {
+    marttyClientSeen: opts.martty ?? true,
+    quotaDock: null as string | null,
+    marttyConnectionRoots: new Set<unknown>([marttyRoot]),
+    sessionMap: new Map([["acp-1", "z-1"]]),
+    pendingSessions: new Map([["acp-pending", {}]]),
+    resolveSid: (sid: string) =>
+      sid === "acp-1" ? "z-1" : sid === "acp-pending" ? undefined : undefined,
+    clients: {
+      snapshot: () => [marttyCx, editorCx],
+    },
+  };
+  return { server: server as unknown as ZcodeAcpServer, calls };
+}
+
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+beforeEach(() => {
+  queryQuotaMock.mockReset();
+  buildOptionsMock.mockReset();
+  remoteConfigMock.mockReset();
+  remoteConfigMock.mockReturnValue(null);
+  buildOptionsMock.mockResolvedValue([{ id: "model" }]);
+});
+
+afterEach(() => {
+  resetQuotaRefresherForTest();
+  vi.useRealTimers();
+});
+
+describe("startQuotaRefresher", () => {
+  it("no-ops (and never queries) without a martty client", async () => {
+    const { server } = fakeServer({ martty: false });
+    startQuotaRefresher(server);
+    await flushMicrotasks();
+    expect(queryQuotaMock).not.toHaveBeenCalled();
+  });
+
+  it("refreshes immediately on start, stores the dock string, and emits to martty only", async () => {
+    queryQuotaMock.mockResolvedValue(SUCCESS);
+    const { server, calls } = fakeServer();
+    startQuotaRefresher(server);
+    await flushMicrotasks();
+    expect(queryQuotaMock).toHaveBeenCalledTimes(1);
+    expect(server.quotaDock).toBe("5h 45% · wk 12%");
+    // Full-replace options for every known session alias (live + pending).
+    const acpSids = calls.map((c) => c.params.sessionId).sort();
+    expect(acpSids).toEqual(["acp-1", "acp-pending"]);
+    for (const c of calls) {
+      expect(c.method).toBe("session/update");
+      expect(c.params.update.sessionUpdate).toBe("config_option_update");
+      expect(c.params.update.configOptions).toEqual([{ id: "model" }]);
+    }
+  });
+
+  it("refreshes again on the interval", async () => {
+    vi.useFakeTimers();
+    queryQuotaMock.mockResolvedValue(SUCCESS);
+    const { server } = fakeServer();
+    startQuotaRefresher(server);
+    await vi.advanceTimersByTimeAsync(10);
+    expect(queryQuotaMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(QUOTA_REFRESH_INTERVAL_MS);
+    expect(queryQuotaMock).toHaveBeenCalledTimes(2);
+    expect(server.quotaDock).toBe("5h 45% · wk 12%");
+  });
+});
+
+describe("forceRefreshQuota", () => {
+  it("refreshes on demand and collapses concurrent calls into one fetch", async () => {
+    queryQuotaMock.mockResolvedValue(SUCCESS);
+    const { server } = fakeServer();
+    server.marttyClientSeen = true;
+    startQuotaRefresher(server);
+    await flushMicrotasks();
+    queryQuotaMock.mockClear();
+    await Promise.all([forceRefreshQuota(), forceRefreshQuota()]);
+    await flushMicrotasks();
+    expect(queryQuotaMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-emit when the string is unchanged", async () => {
+    queryQuotaMock.mockResolvedValue(SUCCESS);
+    const { server, calls } = fakeServer();
+    startQuotaRefresher(server);
+    await flushMicrotasks();
+    expect(calls.length).toBe(2);
+    await forceRefreshQuota();
+    await flushMicrotasks();
+    expect(calls.length).toBe(2); // no new config_option_update
+  });
+});
+
+describe("hub-first lookup", () => {
+  it("uses the hub payload when reachable and skips the direct query", async () => {
+    remoteConfigMock.mockReturnValue({
+      token: "t",
+      hubHost: "127.0.0.1",
+      hubPort: 8377,
+    });
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ formatted: "5h 50% · wk 9% · reset 1h00m", fetchedAt: 1 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    try {
+      queryQuotaMock.mockResolvedValue(SUCCESS);
+      const { server, calls } = fakeServer();
+      startQuotaRefresher(server);
+      await flushMicrotasks();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock.mock.calls[0]![0]).toBe("http://127.0.0.1:8377/api/quota/dock");
+      expect(fetchMock.mock.calls[0]![1].headers.Authorization).toBe("Bearer t");
+      expect(queryQuotaMock).not.toHaveBeenCalled();
+      expect(server.quotaDock).toBe("5h 50% · wk 9% · reset 1h00m");
+      expect(calls.length).toBe(2);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("falls back to the direct query when the hub is unreachable", async () => {
+    remoteConfigMock.mockReturnValue({ token: "t", hubHost: "127.0.0.1", hubPort: 8377 });
+    const fetchMock = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    vi.stubGlobal("fetch", fetchMock);
+    try {
+      queryQuotaMock.mockResolvedValue(SUCCESS);
+      const { server } = fakeServer();
+      startQuotaRefresher(server);
+      await flushMicrotasks();
+      expect(queryQuotaMock).toHaveBeenCalledTimes(1);
+      expect(server.quotaDock).toBe("5h 45% · wk 12%");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("treats a hub formatted:null as dock-hidden and does not emit", async () => {
+    remoteConfigMock.mockReturnValue({ token: "t", hubHost: "127.0.0.1", hubPort: 8377 });
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ formatted: null, fetchedAt: 1 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    try {
+      queryQuotaMock.mockResolvedValue(SUCCESS);
+      const { server, calls } = fakeServer();
+      startQuotaRefresher(server);
+      await flushMicrotasks();
+      expect(queryQuotaMock).not.toHaveBeenCalled();
+      expect(server.quotaDock).toBeNull();
+      expect(calls.length).toBe(0);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});
+
+describe("failure contract", () => {
+  it("stores null and emits nothing when the direct query fails", async () => {
+    queryQuotaMock.mockResolvedValue({ kind: "unavailable" });
+    const { server, calls } = fakeServer();
+    server.quotaDock = "stale";
+    startQuotaRefresher(server);
+    await flushMicrotasks();
+    expect(server.quotaDock).toBeNull();
+    expect(calls.length).toBe(0);
+  });
+});

--- a/tests/tui-seed.test.ts
+++ b/tests/tui-seed.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Martty quota-dock plugin seeding tests (ADR-0021): planQuotaSeed decision
+ * table (fresh write, ours-current, ours-old update, user-modified, foreign,
+ * unparseable) and the filesystem seeding with a mocked fs.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFiles = new Map<string, string>();
+const mockDirs = new Set<string>();
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    existsSync: (p: string) => mockFiles.has(p) || actual.existsSync(p),
+    readFileSync: (p: string) => {
+      if (mockFiles.has(p)) return mockFiles.get(p)!;
+      return actual.readFileSync(p);
+    },
+    mkdirSync: (p: string) => {
+      mockDirs.add(p);
+    },
+    writeFileSync: (p: string, data: string) => {
+      mockFiles.set(p, data);
+    },
+  };
+});
+
+import { planQuotaSeed, resolveMarttyHome, seedMarttyQuotaPlugin } from "../src/tui.js";
+
+const ASSET = JSON.stringify({
+  schemaVersion: 0,
+  id: "zcode-acp-quota",
+  kind: "ui",
+  name: "zcode-acp quota dock",
+  source: { pluginId: "plugin-zcode-acp-quota", packageId: "pkg-zcode-acp-quota-1" },
+  code: { client: "return {}" },
+});
+
+const ours = (version: number, extra: Record<string, unknown> = {}) =>
+  JSON.stringify({
+    schemaVersion: 0,
+    id: "zcode-acp-quota",
+    kind: "ui",
+    source: { pluginId: "plugin-zcode-acp-quota", packageId: `pkg-zcode-acp-quota-${version}` },
+    code: { client: "return {}" },
+    ...extra,
+  });
+
+const ASSET_PATH = (() => {
+  // dist/tui.js layout: ../assets/martty-plugins/quota-dock/plugin.json
+  return new URL("../assets/martty-plugins/quota-dock/plugin.json", import.meta.url).pathname;
+})();
+
+describe("resolveMarttyHome", () => {
+  it("prefers MARTTY_HOME, then $DSH_HOME/.martty, then ~/.martty", () => {
+    expect(resolveMarttyHome({ MARTTY_HOME: "/mh" })).toBe("/mh");
+    expect(resolveMarttyHome({ DSH_HOME: "/dh" })).toBe("/dh/.martty");
+    expect(resolveMarttyHome({})).toContain(".martty");
+  });
+});
+
+describe("planQuotaSeed", () => {
+  it("writes when the plugin is missing", () => {
+    expect(planQuotaSeed(null, ASSET)).toEqual({ action: "write", reason: "fresh" });
+  });
+
+  it("no-ops on our identical current version", () => {
+    expect(planQuotaSeed(ASSET, ASSET)).toEqual({ action: "none", reason: "current" });
+  });
+
+  it("updates our provably older version", () => {
+    expect(planQuotaSeed(ours(0), ASSET)).toEqual({ action: "write", reason: "update" });
+  });
+
+  it("never touches a user-modified current version", () => {
+    expect(planQuotaSeed(ours(1, { name: "my fork" }), ASSET)).toEqual({
+      action: "skip",
+      reason: "modified",
+    });
+  });
+
+  it("never touches a foreign plugin (other source or newer than us)", () => {
+    const foreign = JSON.stringify({
+      source: { pluginId: "plugin-someone-else", packageId: "pkg-other-1" },
+      code: { client: "return {}" },
+    });
+    expect(planQuotaSeed(foreign, ASSET)).toEqual({ action: "skip", reason: "foreign" });
+    expect(planQuotaSeed(ours(2), ASSET)).toEqual({ action: "skip", reason: "foreign" });
+  });
+
+  it("never touches an unparseable file", () => {
+    expect(planQuotaSeed("{ not json", ASSET)).toEqual({
+      action: "skip",
+      reason: "unparseable",
+    });
+  });
+});
+
+describe("seedMarttyQuotaPlugin", () => {
+  beforeEach(() => {
+    mockFiles.clear();
+    mockDirs.clear();
+    mockFiles.set(ASSET_PATH, ASSET);
+  });
+
+  it("writes the plugin.json into MARTTY_HOME/plugins when absent", () => {
+    const home = "/tmp/mhome-seed";
+    const target = `${home}/plugins/zcode-acp-quota/plugin.json`;
+    expect(seedMarttyQuotaPlugin({ MARTTY_HOME: home })).toBe(true);
+    expect(mockFiles.get(target)).toBe(ASSET);
+    expect(mockDirs.has(`${home}/plugins/zcode-acp-quota`)).toBe(true);
+  });
+
+  it("does not rewrite an already-current plugin", () => {
+    const home = "/tmp/mhome-seed";
+    const target = `${home}/plugins/zcode-acp-quota/plugin.json`;
+    mockFiles.set(target, ASSET);
+    expect(seedMarttyQuotaPlugin({ MARTTY_HOME: home })).toBe(false);
+    expect(mockFiles.get(target)).toBe(ASSET);
+  });
+
+  it("does not overwrite a user-modified plugin", () => {
+    const home = "/tmp/mhome-seed";
+    const target = `${home}/plugins/zcode-acp-quota/plugin.json`;
+    const modified = ours(1, { name: "user fork" });
+    mockFiles.set(target, modified);
+    expect(seedMarttyQuotaPlugin({ MARTTY_HOME: home })).toBe(false);
+    expect(mockFiles.get(target)).toBe(modified);
+  });
+});


### PR DESCRIPTION
## Summary

- **Resident quota dock (ADR-0021)**: martty TUI shows GLM Coding Plan quota (`ctx 3.2%/200K · 5h 45% · wk 12% · reset 2h13m`) live in the composer dock.
  - Bridge: lazy 60s refresher + force-refresh at each turn end; hub-first (`GET /api/quota/dock`, 15s cache) with silent direct-query fallback; read-only `quota` config option emitted **per martty connection only** (recorded at `initialize`, stripped for editors/apps on every emit path).
  - Plugin: seeded into `$MARTTY_HOME/plugins` before spawn (`src/tui.ts`) — written only when absent or provably our own older version (marker + version); user modifications are never overwritten. Dumb renderer: all formatting decisions live bridge-side.
  - Fresh sessions now get an initial `usage_update` so context window size is visible from boot (martty's built-in stats line only appears after real token usage — the dock renders it instead).
- **fix(remote)**: hub-incubated `.command` scripts now live under `<workspace>/.zcode/tmp/` instead of the system temp dir, so terminal tabs bind to the project (Warp source-verified: `open_file` roots the session at the script's parent dir). Falls back to the old tmpdir path on write failure; stale scripts (>1h) cleaned up.

## Verification

- `pnpm typecheck` / `pnpm lint` clean; `pnpm test` 967/967 (72 files, 11 new cases).
- Runtime probes: `.zcode/scratch/martty-quota-probe.md` (plugin contract verified end-to-end on martty 0.2.35); review pass: `.zcode/scratch/review-quota-dock.md`.

## Test plan

- [ ] Bare `zcode-acp`: quota dock line appears within ~1 min and refreshes after each turn; hidden when no credentials.
- [ ] Warp via remote resume/create: new tab lands in the project (diff/git panels work).
- [ ] Editor + phone app attached during TUI lifetime: no `quota` option in their traffic.