### PR TITLE
feat: prefer bun >=1.4 (--smol) for bridge and hub processes with node fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,44 @@ jobs:
         # Headless wiring check (ADR-0020): martty --check-runtime spawns the
         # built bridge and runs the ACP initialize handshake.
         run: pnpm run smoke:tui
+
+  bun-runtime:
+    # Dual-runtime path (src/runtime.ts): with Bun >=1.4 on PATH the bridge
+    # re-execs into `bun --smol` — keep that path covered so Node↔Bun drift
+    # is caught in CI, not in a user's editor.
+    name: Bun runtime
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: pnpm
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Test (vitest hosted by Bun)
+        run: bun x vitest run
+
+      - name: Smoke under Bun (re-exec path)
+        run: |
+          bun --version
+          node dist/cli.js server < /dev/null
+          node dist/cli.js tui --check

--- a/README.md
+++ b/README.md
@@ -82,6 +82,24 @@ Running from source instead? Use `"command": "node"` with
 
 Restart Zed and pick **ZCode** from the agent dropdown.
 
+### Runtime: Bun (optional, lower memory)
+
+The bridge and hub run on Node by default. If a Bun **>= 1.4** install is
+found (`~/.bun/bin/bun`, Homebrew, or `PATH`), they automatically re-exec into
+`bun --smol` — idle RSS drops from ~81 MB to ~48 MB per process, which adds up
+when running many concurrent sessions. Nothing to configure; install Bun and
+restart the editor/CLI. Bun < 1.4 is ignored (no benefit over Node).
+
+Force the old behavior (troubleshooting) with:
+
+```jsonc
+"env": { "ZCODE_ACP_RUNTIME": "node" } // in the editor config, or export it
+```
+
+Note: the `zcode` backend subprocess always needs real Node (it uses
+`node:sea`, which Bun does not implement) — installing Bun changes the
+runtime of the bridge/hub only, and Node >= 22 remains a requirement.
+
 ### `ZCODE_BIN` per platform
 
 The CLI is resolved in this order: `ZCODE_BIN` → a `zcode` found on `PATH` →

--- a/src/bin/hub.ts
+++ b/src/bin/hub.ts
@@ -28,6 +28,7 @@ import { fileURLToPath } from "node:url";
 import { parseHubConfig } from "../remote/config.js";
 import { sandboxBorn, selfRelaunchOutsideSandbox } from "../remote/hub-sandbox.js";
 import { startHub } from "../remote/hub-server.js";
+import { resolveRuntime, runtimeSpawnParts } from "../runtime.js";
 import { log, warn } from "../utils.js";
 
 /**
@@ -41,7 +42,7 @@ function respawnSelf(): void {
   try {
     // bin/hub.js → ../bin/hub.js is itself (this file's compiled location).
     const hubJs = fileURLToPath(new URL("../bin/hub.js", import.meta.url));
-    const child = spawn(process.execPath, [hubJs], {
+    const child = spawn(...runtimeSpawnParts(hubJs), {
       detached: true,
       stdio: ["ignore", "ignore", "ignore"],
     });
@@ -66,7 +67,10 @@ export async function main(): Promise<void> {
   // the visible terminal still works — and say so loudly.
   if (sandboxBorn()) {
     const hubJs = fileURLToPath(new URL("../bin/hub.js", import.meta.url));
-    if (selfRelaunchOutsideSandbox({ nodePath: process.execPath, hubJs })) process.exit(0);
+    const rt = resolveRuntime();
+    if (selfRelaunchOutsideSandbox({ interpreter: [rt.command, ...rt.preArgs], hubJs })) {
+      process.exit(0);
+    }
     warn(
       "hub: running INSIDE a Seatbelt sandbox — macOS will refuse this hub's " +
         "open of the visible session terminal (TCC), so remote session-create " +

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ import process from "node:process";
 import { main as runHub } from "./bin/hub.js";
 import { main as runQuota } from "./bin/quota.js";
 import { main as runServer, runHeadless } from "./index.js";
+import { reexecToBunIfEligible } from "./runtime.js";
 import { checkTuiRuntime, runTui } from "./tui.js";
 import { AGENT_INFO } from "./utils.js";
 
@@ -98,6 +99,12 @@ async function main(): Promise<void> {
     return;
   }
   const invocation = resolveInvocation(basename(process.argv[1] ?? ""), process.argv.slice(2));
+  // Long-running surfaces hand over to `bun --smol` when available (idle RSS
+  // ~47 MB vs ~81 MB on Node); the instant paths (help/version/unknown) skip
+  // the re-exec hop entirely.
+  if (invocation.kind !== "help" && invocation.kind !== "unknown") {
+    if (await reexecToBunIfEligible(process.argv[1] ?? "", process.argv.slice(2))) return;
+  }
   switch (invocation.kind) {
     case "help":
       process.stdout.write(HELP_TEXT + "\n");

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ import { loadSkillCommands } from "./config/skill-discovery.js";
 import { trackConnections } from "./remote/broadcast.js";
 import { parseRemoteConfig } from "./remote/config.js";
 import { startRemoteEndpoint, type RemoteEndpointHandle } from "./remote/endpoint.js";
+import { reexecToBunIfEligible } from "./runtime.js";
 import { messages } from "./i18n.js";
 import { ZcodeAcpServer } from "./server.js";
 import { AGENT_INFO, SLASH_COMMANDS, log, warn } from "./utils.js";
@@ -360,8 +361,13 @@ const invokedDirectly = (() => {
 })();
 
 if (invokedDirectly) {
-  main().catch((err) => {
-    warn(`fatal: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`);
-    process.exit(1);
+  // Editors configured with `node dist/index.js` get the same Bun handover as
+  // the Unified CLI entry (see src/runtime.ts) — no re-exec under Bun itself.
+  reexecToBunIfEligible(process.argv[1] ?? "", process.argv.slice(2)).then((handed) => {
+    if (handed) return;
+    main().catch((err) => {
+      warn(`fatal: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`);
+      process.exit(1);
+    });
   });
 }

--- a/src/remote/endpoint.ts
+++ b/src/remote/endpoint.ts
@@ -27,6 +27,7 @@ import {
 import { WebSocketServer } from "ws";
 
 import type { ZcodeAcpServer } from "../server.js";
+import { runtimeSpawnParts } from "../runtime.js";
 import { AGENT_INFO, log, warn } from "../utils.js";
 import { createFileHandler } from "./file-endpoint.js";
 import { createSessionCloseHandler } from "./session-close-endpoint.js";
@@ -288,7 +289,7 @@ export async function startRemoteEndpoint(
     try {
       // dist/remote/endpoint.js → dist/bin/hub.js (one level up, then bin/).
       const hubJs = fileURLToPath(new URL("../bin/hub.js", import.meta.url));
-      const child = spawn(process.execPath, [hubJs], {
+      const child = spawn(...runtimeSpawnParts(hubJs), {
         detached: true,
         // Surface the daemon's stderr through the bridge's diagnostics — a
         // detached "ignore" pipe silently eats startup failures.

--- a/src/remote/hub-sandbox.ts
+++ b/src/remote/hub-sandbox.ts
@@ -53,7 +53,8 @@ function xmlEscape(s: string): string {
  * machine-singleton behaviour).
  */
 export function buildHubRelaunchPlist(opts: {
-  nodePath: string;
+  /** Interpreter argv prefix (e.g. ["bun", "--smol"] or [nodePath]). */
+  interpreter: string[];
   hubJs: string;
   env: NodeJS.ProcessEnv;
   logPath: string;
@@ -69,9 +70,9 @@ export function buildHubRelaunchPlist(opts: {
     <string>${HUB_LAUNCH_LABEL}</string>
     <key>ProgramArguments</key>
     <array>
-        <string>${xmlEscape(opts.nodePath)}</string>
-        <string>${xmlEscape(opts.hubJs)}</string>
-        <string>hub</string>
+${[...opts.interpreter, opts.hubJs, "hub"]
+  .map((a) => `        <string>${xmlEscape(a)}</string>`)
+  .join("\n")}
     </array>
     <key>EnvironmentVariables</key>
     <dict>
@@ -107,7 +108,8 @@ ${envEntries.map(pair).join("\n")}
  * unreplaced definition is never attempted.
  */
 export function selfRelaunchOutsideSandbox(opts: {
-  nodePath: string;
+  /** Interpreter argv prefix (e.g. ["bun", "--smol"] or [nodePath]). */
+  interpreter: string[];
   hubJs: string;
   logPath?: string;
 }): boolean {

--- a/src/remote/hub-server.ts
+++ b/src/remote/hub-server.ts
@@ -55,6 +55,7 @@ import { fileURLToPath } from "node:url";
 
 import { WebSocket, WebSocketServer, type RawData } from "ws";
 
+import { resolveRuntime, runtimeSpawnParts } from "../runtime.js";
 import { AGENT_INFO, compareVersions, log, warn } from "../utils.js";
 import type { TerminalPrefs } from "../config/user-config.js";
 import { remoteTerminalPrefs } from "./config.js";
@@ -329,6 +330,10 @@ export function terminalTuiScript(cwd: string, cliJs: string, env: NodeJS.Proces
     // banner handshake (martty reads it at its own process start).
     .filter((k) => k.startsWith("ZCODE_ACP_") || k === "DSH_TUI_AUTOPROMPT")
     .map((k) => `export ${k}=${shQuote(String(env[k]))}`);
+  // Prefer bun --smol for the long-lived bridge (src/runtime.ts); the tokens
+  // are quoted individually because the interpreter may carry flags.
+  const rt = resolveRuntime();
+  const execLine = [rt.command, ...rt.preArgs, cliJs].map(shQuote).join(" ");
   return [
     "#!/bin/sh",
     `# Hub-incubated TUI session (ADR-0016): closing this window ends the bridge.`,
@@ -341,7 +346,7 @@ export function terminalTuiScript(cwd: string, cliJs: string, env: NodeJS.Proces
     ...(env.ZCODE_ACP_TAB_TITLE !== undefined
       ? [`printf '\\033]0;%s\\007' "$ZCODE_ACP_TAB_TITLE"`]
       : []),
-    `exec ${shQuote(process.execPath)} ${shQuote(cliJs)}`,
+    `exec ${execLine}`,
     "",
   ].join("\n");
 }
@@ -502,7 +507,7 @@ async function defaultSpawnServe(opts: {
   }
   // dist/remote/hub-server.js → dist/cli.js (one level up).
   const cliJs = fileURLToPath(new URL("../cli.js", import.meta.url));
-  const child = spawn(process.execPath, [cliJs, "serve"], {
+  const child = spawn(...runtimeSpawnParts(cliJs, "serve"), {
     cwd: opts.cwd,
     detached: true,
     stdio: ["ignore", "ignore", "pipe"],

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,0 +1,174 @@
+/**
+ * Dual-runtime launcher support: prefer Bun (>=1.4, `--smol`) for this
+ * package's own long-lived processes (bridge, hub, serve, TUI agent), fall
+ * back to the current Node interpreter. The zcode backend subprocess is NOT
+ * covered — `zcode.cjs` unconditionally loads `node:sea`, which Bun does not
+ * implement, so backend resolution stays on real Node (src/backend/resolve.ts).
+ *
+ * Why Bun 1.4 minimum: measured on this package, 1.3.x had no memory benefit
+ * over Node (~84 MB vs 81 MB idle), while 1.4.x runs the bridge in ~58 MB
+ * (47 MB with --smol) vs Node's 81 MB — decisive for users running many
+ * concurrent sessions.
+ *
+ * ZCODE_ACP_RUNTIME selects the policy: "node" forces Node (troubleshooting
+ * escape hatch), "bun" prefers Bun and warns when unavailable, unset/auto
+ * prefers Bun silently when a >=1.4 install is found. Failures of the probe
+ * itself never block startup — Node is the safe default.
+ */
+
+import { spawn, execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+import process from "node:process";
+
+import { log, warn } from "./utils.js";
+
+/** Interpreter decision for spawning one of this package's JS entries. */
+export interface RuntimeLaunch {
+  command: string;
+  /** Interpreter flags placed before the JS entry (e.g. ["--smol"] for Bun). */
+  preArgs: string[];
+}
+
+/** Minimum Bun version with the Rust-rewrite memory wins (see module doc). */
+const MIN_BUN = { major: 1, minor: 4 };
+
+/** `which bin` — resolve a binary on PATH without external deps. */
+function whichSync(bin: string): string | null {
+  try {
+    const out = execFileSync("which", [bin], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return out || null;
+  } catch {
+    return null;
+  }
+}
+
+/** Well-known Bun install locations, tried around the PATH lookup. */
+function bunCandidates(): string[] {
+  const cands = [
+    path.join(homedir(), ".bun", "bin", "bun"), // official installer default
+    "/opt/homebrew/bin/bun",
+    "/usr/local/bin/bun",
+  ];
+  const onPath = whichSync("bun");
+  if (onPath) cands.unshift(onPath);
+  return cands.filter((c, i, a) => c && a.indexOf(c) === i);
+}
+
+/** Parse "1.4.2" → [1, 4, 2]; null when unparseable. */
+export function parseBunVersion(out: string): [number, number, number] | null {
+  const m = out.trim().match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+/** True when the parsed version meets MIN_BUN. Pure — exported for tests. */
+export function bunVersionOk(v: [number, number, number] | null): boolean {
+  if (!v) return false;
+  return v[0] > MIN_BUN.major || (v[0] === MIN_BUN.major && v[1] >= MIN_BUN.minor);
+}
+
+/** Find a >=MIN_BUN bun binary, or null. Result cached for the process. */
+let bunCache: string | null | undefined;
+
+export function detectBun(): string | null {
+  if (bunCache !== undefined) return bunCache;
+  bunCache = null;
+  for (const cand of bunCandidates()) {
+    if (!existsSync(cand)) continue;
+    try {
+      const out = execFileSync(cand, ["--version"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout: 3000,
+      });
+      if (bunVersionOk(parseBunVersion(out))) {
+        bunCache = cand;
+        break;
+      }
+      log(
+        `runtime: bun at ${cand} is ${out.trim()} (< ${MIN_BUN.major}.${MIN_BUN.minor}) — staying on node`,
+      );
+    } catch (e) {
+      log(`runtime: bun probe failed at ${cand} (${e instanceof Error ? e.message : String(e)})`);
+    }
+  }
+  return bunCache;
+}
+
+/** Reset the probe cache (tests). */
+export function resetRuntimeCache(): void {
+  bunCache = undefined;
+}
+
+/**
+ * The interpreter decision for this process's lifetime. When already running
+ * under Bun, reuses it (execPath) — no nested re-resolution.
+ */
+export function resolveRuntime(): RuntimeLaunch {
+  if (process.versions.bun) return { command: process.execPath, preArgs: ["--smol"] };
+  const policy = (process.env.ZCODE_ACP_RUNTIME ?? "").trim().toLowerCase();
+  if (policy === "node") return { command: process.execPath, preArgs: [] };
+  const bun = detectBun();
+  if (bun) return { command: bun, preArgs: ["--smol"] };
+  if (policy === "bun") {
+    warn(
+      "runtime: ZCODE_ACP_RUNTIME=bun but no bun >= " +
+        `${MIN_BUN.major}.${MIN_BUN.minor} found — falling back to node`,
+    );
+  }
+  return { command: process.execPath, preArgs: [] };
+}
+
+/** Full child argv to run `jsFile` (plus trailing args) under the chosen runtime. */
+export function runtimeArgv(jsFile: string, ...rest: string[]): string[] {
+  const rt = resolveRuntime();
+  return [rt.command, ...rt.preArgs, jsFile, ...rest];
+}
+
+/** Spawn-spread form of runtimeArgv: spawn(...runtimeSpawnParts(js), opts). */
+export function runtimeSpawnParts(jsFile: string, ...rest: string[]): [string, string[]] {
+  const rt = resolveRuntime();
+  return [rt.command, [...rt.preArgs, jsFile, ...rest]];
+}
+
+/**
+ * Hand this process over to Bun when eligible: spawn the same entry under
+ * `bun --smol` with inherited stdio and mirror its exit code. Loop-safe by
+ * construction — under Bun `process.versions.bun` is set and detectBun is
+ * skipped, so the child never re-execs. Resolves true when the handover is in
+ * progress (the caller must return immediately; this process exits with the
+ * child), false when the caller should keep running in-process — Bun is
+ * unavailable, Node was forced via ZCODE_ACP_RUNTIME=node, or the spawn
+ * itself failed (nothing has been written to stdio yet, so the fallback is
+ * safe).
+ */
+export async function reexecToBunIfEligible(
+  entryJs: string,
+  argv: readonly string[],
+): Promise<boolean> {
+  if (process.versions.bun) return false;
+  if ((process.env.ZCODE_ACP_RUNTIME ?? "").trim().toLowerCase() === "node") return false;
+  const bun = detectBun();
+  if (!bun) return false;
+  let settled!: (handed: boolean) => void;
+  const outcome = new Promise<boolean>((resolve) => {
+    settled = resolve;
+  });
+  log(`runtime: handing over to ${bun} --smol for ${entryJs}`);
+  const child = spawn(bun, ["--smol", entryJs, ...argv], { stdio: "inherit" });
+  child.once("error", (e) => {
+    warn(`runtime: bun re-exec failed (${e.message}) — continuing on node`);
+    settled(false);
+  });
+  child.once("close", (code, signal) => {
+    settled(true);
+    if (signal) process.kill(process.pid, signal);
+    else process.exit(code ?? 1);
+  });
+  return outcome;
+}

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -22,6 +22,7 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
+import { resolveRuntime } from "./runtime.js";
 import { log, warn } from "./utils.js";
 
 /** Path to Martty's Node wrapper (bin/martty.js), or null when not installed. */
@@ -43,11 +44,23 @@ export function agentEntryJs(): string {
 
 /**
  * Martty argv (after the wrapper script) wiring the bridge in as its agent.
- * `process.execPath` avoids PATH/shebang differences across platforms.
+ * The interpreter defaults to the dual-runtime choice (bun --smol when
+ * available, else the current Node binary) — absolute paths avoid PATH/shebang
+ * differences across platforms, and each --agent-arg is exactly one argv
+ * token, so interpreter flags ride as their own tokens before the entry.
  * Pure — exported for unit tests.
  */
-export function buildTuiArgs(agentJs: string): string[] {
-  return ["--agent", process.execPath, "--agent-arg", agentJs];
+export function buildTuiArgs(
+  agentJs: string,
+  interp: { command: string; preArgs: string[] } = resolveRuntime(),
+): string[] {
+  return [
+    "--agent",
+    interp.command,
+    ...interp.preArgs.map((a) => ["--agent-arg", a]).flat(),
+    "--agent-arg",
+    agentJs,
+  ];
 }
 
 /**

--- a/tests/hub-sandbox.test.ts
+++ b/tests/hub-sandbox.test.ts
@@ -35,7 +35,7 @@ describe("hub sandbox self-relaunch", () => {
 
   it("builds a plist with the hub argv, the env (marker stripped), and XML escaping", () => {
     const plist = buildHubRelaunchPlist({
-      nodePath: "/usr/bin/node",
+      interpreter: ["/usr/bin/node"],
       hubJs: "/opt/acp/dist/bin/hub.js",
       env: {
         ZCODE_ACP_REMOTE_TOKEN: "to&k<'s>",
@@ -60,7 +60,7 @@ describe("hub sandbox self-relaunch", () => {
   it("self-relaunches: bootstrap then kickstart, plist in a fresh temp dir", () => {
     execFileSyncMock.mockReturnValue(Buffer.alloc(0));
     const ok = selfRelaunchOutsideSandbox({
-      nodePath: "/usr/bin/node",
+      interpreter: ["/usr/bin/node"],
       hubJs: "/opt/acp/dist/bin/hub.js",
     });
     expect(ok).toBe(true);
@@ -89,7 +89,7 @@ describe("hub sandbox self-relaunch", () => {
       return Buffer.alloc(0);
     });
     expect(
-      selfRelaunchOutsideSandbox({ nodePath: "/usr/bin/node", hubJs: "/opt/acp/dist/bin/hub.js" }),
+      selfRelaunchOutsideSandbox({ interpreter: ["/usr/bin/node"], hubJs: "/opt/acp/dist/bin/hub.js" }),
     ).toBe(true);
     expect(execFileSyncMock.mock.calls.map((c) => c[1][0])).toEqual([
       "bootstrap",
@@ -105,7 +105,7 @@ describe("hub sandbox self-relaunch", () => {
       return Buffer.alloc(0);
     });
     expect(
-      selfRelaunchOutsideSandbox({ nodePath: "/usr/bin/node", hubJs: "/opt/acp/dist/bin/hub.js" }),
+      selfRelaunchOutsideSandbox({ interpreter: ["/usr/bin/node"], hubJs: "/opt/acp/dist/bin/hub.js" }),
     ).toBe(false);
     // 3 bootstrap attempts (with bootout between), never a blind kickstart —
     // that would revive the stale job definition.

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for the dual-runtime launcher (src/runtime.ts).
+ *
+ * The Bun probe shells out (`which`, `bun --version`) and stats candidate
+ * paths, so both node:child_process and node:fs are mocked with a synthetic
+ * binary table; the pure pieces (version parsing/gating) are pinned directly.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  bunVersionOk,
+  parseBunVersion,
+  resetRuntimeCache,
+  resolveRuntime,
+  runtimeArgv,
+} from "../src/runtime.js";
+
+// --- mocks: which/version probe + candidate existence ---
+
+const execMocks = new Map<string, string>();
+const existingPaths = new Set<string>();
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    execFileSync: vi.fn((cmd: string, args: string[]) => {
+      if (cmd === "which") {
+        return (
+          execMocks.get(`which ${args[0]}`) ??
+          (() => {
+            throw new Error("not found");
+          })()
+        );
+      }
+      return (
+        execMocks.get(`${cmd} ${args.join(" ")}`) ??
+        (() => {
+          throw new Error("no mock");
+        })()
+      );
+    }),
+  };
+});
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    existsSync: (p: string) => existingPaths.has(p) || actual.existsSync(p),
+  };
+});
+
+/** Plant one bun install: path exists, `bun --version` answers `version`. */
+function plantBun(bin: string, version: string): void {
+  existingPaths.add(bin);
+  execMocks.set(`which bun`, bin);
+  execMocks.set(`${bin} --version`, version);
+}
+
+beforeEach(() => {
+  execMocks.clear();
+  existingPaths.clear();
+  resetRuntimeCache();
+  delete process.env.ZCODE_ACP_RUNTIME;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("bun version parsing", () => {
+  it("parses plain semver and rejects junk", () => {
+    expect(parseBunVersion("1.4.2")).toEqual([1, 4, 2]);
+    expect(parseBunVersion(" 1.5.0\n")).toEqual([1, 5, 0]);
+    expect(parseBunVersion("bun 1.4")).toBeNull();
+    expect(parseBunVersion("")).toBeNull();
+  });
+
+  it("gates on the 1.4 minimum", () => {
+    expect(bunVersionOk([1, 4, 0])).toBe(true);
+    expect(bunVersionOk([2, 0, 0])).toBe(true);
+    expect(bunVersionOk([1, 3, 9])).toBe(false);
+    expect(bunVersionOk(null)).toBe(false);
+  });
+});
+
+describe("resolveRuntime policy", () => {
+  it("stays on node with no bun installed", () => {
+    const rt = resolveRuntime();
+    expect(rt.command).toBe(process.execPath);
+    expect(rt.preArgs).toEqual([]);
+  });
+
+  it("prefers a >=1.4 bun with --smol", () => {
+    plantBun("/usr/local/bin/bun", "1.4.2");
+    const rt = resolveRuntime();
+    expect(rt.command).toBe("/usr/local/bin/bun");
+    expect(rt.preArgs).toEqual(["--smol"]);
+  });
+
+  it("rejects an old bun (1.3.x had no memory benefit over node)", () => {
+    plantBun("/usr/local/bin/bun", "1.3.9");
+    const rt = resolveRuntime();
+    expect(rt.command).toBe(process.execPath);
+  });
+
+  it("ZCODE_ACP_RUNTIME=node forces node even with bun present", () => {
+    plantBun("/usr/local/bin/bun", "1.4.2");
+    process.env.ZCODE_ACP_RUNTIME = "node";
+    expect(resolveRuntime().command).toBe(process.execPath);
+  });
+
+  it("builds the full child argv including trailing args", () => {
+    plantBun("/usr/local/bin/bun", "1.4.2");
+    expect(runtimeArgv("/x/dist/bin/hub.js")).toEqual([
+      "/usr/local/bin/bun",
+      "--smol",
+      "/x/dist/bin/hub.js",
+    ]);
+    expect(runtimeArgv("/x/dist/cli.js", "serve")).toEqual([
+      "/usr/local/bin/bun",
+      "--smol",
+      "/x/dist/cli.js",
+      "serve",
+    ]);
+  });
+});

--- a/tests/tui.test.ts
+++ b/tests/tui.test.ts
@@ -19,9 +19,22 @@ describe("martty launcher", () => {
     // A single --agent + one --agent-arg pair: martty treats each --agent-arg
     // as one argv token, so the agent command is exactly `node <dist/index.js>`
     // — no PATH lookup, no shell, same on Windows.
-    expect(buildTuiArgs("/x/dist/index.js")).toEqual([
+    expect(buildTuiArgs("/x/dist/index.js", { command: "/usr/bin/node", preArgs: [] })).toEqual([
       "--agent",
-      process.execPath,
+      "/usr/bin/node",
+      "--agent-arg",
+      "/x/dist/index.js",
+    ]);
+  });
+
+  it("spreads interpreter flags as their own --agent-arg tokens (bun --smol)", () => {
+    expect(
+      buildTuiArgs("/x/dist/index.js", { command: "/usr/local/bin/bun", preArgs: ["--smol"] }),
+    ).toEqual([
+      "--agent",
+      "/usr/local/bin/bun",
+      "--agent-arg",
+      "--smol",
       "--agent-arg",
       "/x/dist/index.js",
     ]);


### PR DESCRIPTION
## Summary

Dual-runtime launch: this package's own long-lived processes (bridge, hub, serve bridge, TUI agent) now run under `bun --smol` when a Bun **>= 1.4** install is found, falling back to the current Node interpreter otherwise. No user configuration changes; `ZCODE_ACP_RUNTIME=node` forces Node as a troubleshooting escape hatch.

Measured motivation (idle RSS of the loaded bridge): Node 81 MB · Bun 1.3.9 84 MB (no benefit) · Bun 1.4.2 58 MB / 48 MB with `--smol`. With many concurrent sessions this adds up linearly. Bun < 1.4 is therefore detected and rejected.

The zcode backend subprocess is intentionally NOT switched: `zcode.cjs` unconditionally loads `node:sea`, which Bun marks "Not implemented" (verified live: startup dies with `No such built-in module: node:sea`). Backend resolution (`src/backend/resolve.ts`) stays on real Node.

## Changes

- **`src/runtime.ts` (new)** — runtime decision helper: Bun probe (`~/.bun/bin`, Homebrew, PATH; version-gated >= 1.4, cached per process), `ZCODE_ACP_RUNTIME` policy (`node` forces Node), spawn-argv builders, and `reexecToBunIfEligible()` (stdio-inherit handover, loop-safe because under Bun the probe is skipped; spawn failure falls back to in-process Node).
- **Entries** — `src/cli.ts` and `src/index.ts` hand over to Bun at startup (instant paths like `--version`/help skip the re-exec hop). Editors keep launching `node dist/index.js` / the npm bin unchanged.
- **Hub chain** — hub respawn + launchd sandbox relaunch (`bin/hub.ts`, `hub-sandbox.ts` plist now carries an interpreter argv), hub incubation (`endpoint.ts`), serve-bridge spawn and the terminal `.command` script (`hub-server.ts`) all use the shared helper.
- **TUI** — martty's agent interpreter is dual-mode (`--agent-arg --smol` tokens before the entry).
- **Tests** — new `tests/runtime.test.ts` (version gate, policy, argv); `tui`/`hub-sandbox` tests updated for the new shapes. Full suite passes under Node and under Bun 1.4 (vitest hosted by Bun).
- **CI** — new `bun-runtime` job: Bun-hosted vitest + the re-exec smoke path.
- **README** — "Runtime: Bun (optional, lower memory)" section.

## Verification

- `typecheck` / `lint` / `build` clean; 73 files / 978 tests pass under Node and under Bun 1.4.2.
- Live: 1.3.9 correctly rejected (stays Node), 1.4.2 handover confirmed via debug log, `ZCODE_ACP_RUNTIME=node` disables it, `smoke` + `tui --check` green on both runtimes.
- On a real machine, a hub-incubated resumed session was observed running as `bun --smol dist/cli.js`.