### PR TITLE
fix(handlers): session-scoped /resume elicitation and atomic lazy-alias store

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,19 @@ ZCode protocol types into ACP notifications directly — always translate.
   — short turns can complete before a late subscribe catches them.
 - **Preempt lock**: concurrent prompts for the same session are serialized via
   `withPreemptLock`. Don't bypass it — two simultaneous turns corrupt the listener.
+- **The lazy-alias store (`~/.zcode/v2/acp-lazy-sessions.json`) is shared by
+  EVERY bridge process and must never be written non-atomically**: it maps lazy
+  placeholder ids → cwd/backend id and is the only recovery for an idle editor
+  thread after a bridge restart. A torn/interleaved whole-file write corrupts
+  it, the next reader treats corruption as `{}` and the overwrite wipes all
+  aliases — the thread then fails with the backend's cryptic "Session ID
+  不存在" (observed 2026-09; a vitest run racing a live Zed bridge did exactly
+  this). Writes go through `persist()` (temp file + rename + stale-tmp sweep +
+  merge-at-write) — never `writeFileSync` the store path directly. Tests run
+  under a hermetic temp HOME (`tests/setup/hermetic-home.ts`, set by direct
+  `process.env.HOME` assignment so `vi.unstubAllEnvs()` cannot leak back to
+  the real HOME); keep new tests store-safe by default and don't bypass the
+  setup file.
 - **AGENTS.md is workspace-scoped**: the global `~/.zcode/AGENTS.md` also exists;
   this file takes precedence for this repo.
 - **WS proxy frame type**: the SDK's WS server drops non-text frames, and

--- a/src/handlers/server-requests.ts
+++ b/src/handlers/server-requests.ts
@@ -717,6 +717,10 @@ export async function askSessionPick(
       "elicitation/create",
       {
         mode: "form",
+        // Session scope is mandatory: schema-strict clients (Zed 1.18+) fail
+        // the whole request with -32602 when neither sessionId nor requestId
+        // is present, which surfaced as a silent "resume cancelled".
+        sessionId: acpSid,
         message: messages().slashResumePickTitle,
         requestedSchema: {
           type: "object",

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -636,13 +636,17 @@ async function adoptStoredTitle(
 async function resolveResumeTarget(
   server: ZcodeAcpServer,
   acpSid: string,
-): Promise<{ zcodeSid: string; alreadyLive: boolean }> {
+): Promise<{ zcodeSid: string; alreadyLive: boolean; origin: "mapped" | "placeholder" | "raw" }> {
   const mapped = server.resolveSid(acpSid);
   if (mapped) {
-    return { zcodeSid: mapped, alreadyLive: server.isBackendSessionLive(acpSid) };
+    return { zcodeSid: mapped, alreadyLive: server.isBackendSessionLive(acpSid), origin: "mapped" };
   }
   if (server.pendingSessions.has(acpSid)) {
-    return { zcodeSid: await ensureRealSession(server, acpSid), alreadyLive: true };
+    return {
+      zcodeSid: await ensureRealSession(server, acpSid),
+      alreadyLive: true,
+      origin: "placeholder",
+    };
   }
   const record = lookupLazySession(acpSid);
   if (record) {
@@ -651,9 +655,14 @@ async function resolveResumeTarget(
     return {
       zcodeSid: await ensureRealSession(server, acpSid),
       alreadyLive: !record.zcodeSid,
+      origin: "placeholder",
     };
   }
-  return { zcodeSid: acpSid, alreadyLive: false };
+  // Raw passthrough: the id may be a real backend session id (imported
+  // threads). It may equally be a placeholder whose durable alias was lost —
+  // callers wrap raw-origin resume failures with an actionable message
+  // instead of the backend's cryptic "session not found".
+  return { zcodeSid: acpSid, alreadyLive: false, origin: "raw" };
 }
 
 /**
@@ -711,7 +720,7 @@ export async function resumeSession(
   // Lazy placeholders (session/new) resolve to their real backend session
   // here; alreadyLive targets skip the resume RPC because the session is live
   // in this backend subprocess.
-  const { zcodeSid, alreadyLive } = await resolveResumeTarget(server, acpSid);
+  const { zcodeSid, alreadyLive, origin } = await resolveResumeTarget(server, acpSid);
 
   if (!alreadyLive) {
     // No runtimeModel pinning here: the session keeps its own persisted
@@ -733,7 +742,19 @@ export async function resumeSession(
     // third-party model in its history, and the backend needs the provider
     // registered to even process the resume turn.
     await syncProviderRegistry(server, cwd);
-    const resumeResult = await resumePreservingModel(server, zcParams);
+    let resumeResult: unknown;
+    try {
+      resumeResult = await resumePreservingModel(server, zcParams);
+    } catch (e) {
+      if (origin === "raw") {
+        warn(
+          `session/resume: ${acpSid} unknown to bridge and alias store ` +
+            `(backend said: ${e instanceof Error ? e.message : String(e)})`,
+        );
+        throw new Error(messages().loadUnknownAlias(acpSid));
+      }
+      throw e;
+    }
     // The resume RPC succeeded — the session is now loaded in this backend.
     server.markBackendLoaded(acpSid);
     // The session kept its own model — repair it only if it's no longer enabled.
@@ -914,7 +935,7 @@ export async function loadSession(
 
   // Same placeholder resolution as resumeSession; alreadyLive targets skip the
   // backend resume RPC (the session is live in this subprocess).
-  const { zcodeSid, alreadyLive } = await resolveResumeTarget(server, acpSid);
+  const { zcodeSid, alreadyLive, origin } = await resolveResumeTarget(server, acpSid);
 
   if (!alreadyLive) {
     const zcParams: Record<string, unknown> = {
@@ -925,7 +946,19 @@ export async function loadSession(
     // third-party model in its history, and the backend needs the provider
     // registered to process it.
     await syncProviderRegistry(server, cwd);
-    const resumeResult = await resumePreservingModel(server, zcParams);
+    let resumeResult: unknown;
+    try {
+      resumeResult = await resumePreservingModel(server, zcParams);
+    } catch (e) {
+      if (origin === "raw") {
+        warn(
+          `session/load: ${acpSid} unknown to bridge and alias store ` +
+            `(backend said: ${e instanceof Error ? e.message : String(e)})`,
+        );
+        throw new Error(messages().loadUnknownAlias(acpSid));
+      }
+      throw e;
+    }
     // The resume RPC succeeded — the session is now loaded in this backend.
     server.markBackendLoaded(acpSid);
     // The session kept its own model — repair it only if it's no longer enabled.
@@ -947,15 +980,17 @@ export async function loadSession(
   server.ensureBackgroundListener(zcodeSid);
   await adoptStoredTitle(server, acpSid, zcodeSid);
 
-  const messages = await fetchMessages(server, zcodeSid);
+  // Named `history` — a local `messages` would shadow the i18n `messages()`
+  // helper used in the error paths above (TDZ crash from the catch block).
+  const history = await fetchMessages(server, zcodeSid);
   // History on disk = real interaction (covers untitled sessions resumed from
   // a previous bridge lifetime) — make the session discoverable remotely.
-  if (messages.length > 0) server.markSessionActive(acpSid);
+  if (history.length > 0) server.markSessionActive(acpSid);
   // Tail replay (Proposal 0001): a `_meta.zcode.limit` replays only the last
   // N messages aligned to turn boundaries — the full replay stays the default
   // for editors that send no `_meta` (Zed path unchanged).
   const limit = readTailLimit(params);
-  const slice = limit === null ? fullSlice(messages) : sliceTail(messages, limit);
+  const slice = limit === null ? fullSlice(history) : sliceTail(history, limit);
   if (opts.replayHistory === false) {
     // Boot-resume interception (session/new): the terminal TUI client does not
     // render replayed updates (its transcript lives in its own local store)

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -701,6 +701,28 @@ async function replayResumeHistory(
   );
 }
 
+/**
+ * Surface a raw-origin resume failure honestly. A backend id unknown to the
+ * bridge AND the alias store, which the backend itself rejects as missing, is
+ * a dead/expired session — swap the cryptic backend message for the
+ * actionable alias-lost text. Any OTHER failure on a raw id (transient
+ * timeout, lock, network) keeps its original error: blaming a lost alias for
+ * it would misreport the cause. Always throws.
+ */
+function translateResumeFailure(
+  methodLabel: "session/resume" | "session/load",
+  acpSid: string,
+  origin: "mapped" | "placeholder" | "raw",
+  e: unknown,
+): never {
+  const raw = e instanceof Error ? e.message : String(e);
+  if (origin === "raw" && /不存在|not\s*found/i.test(raw)) {
+    warn(`${methodLabel}: ${acpSid} unknown to bridge and alias store (backend said: ${raw})`);
+    throw new Error(messages().loadUnknownAlias(acpSid));
+  }
+  throw e;
+}
+
 /** `session/resume` → zcode `session/resume` (with runtimeModel overlay). */
 export async function resumeSession(
   server: ZcodeAcpServer,
@@ -746,14 +768,7 @@ export async function resumeSession(
     try {
       resumeResult = await resumePreservingModel(server, zcParams);
     } catch (e) {
-      if (origin === "raw") {
-        warn(
-          `session/resume: ${acpSid} unknown to bridge and alias store ` +
-            `(backend said: ${e instanceof Error ? e.message : String(e)})`,
-        );
-        throw new Error(messages().loadUnknownAlias(acpSid));
-      }
-      throw e;
+      translateResumeFailure("session/resume", acpSid, origin, e);
     }
     // The resume RPC succeeded — the session is now loaded in this backend.
     server.markBackendLoaded(acpSid);
@@ -950,14 +965,7 @@ export async function loadSession(
     try {
       resumeResult = await resumePreservingModel(server, zcParams);
     } catch (e) {
-      if (origin === "raw") {
-        warn(
-          `session/load: ${acpSid} unknown to bridge and alias store ` +
-            `(backend said: ${e instanceof Error ? e.message : String(e)})`,
-        );
-        throw new Error(messages().loadUnknownAlias(acpSid));
-      }
-      throw e;
+      translateResumeFailure("session/load", acpSid, origin, e);
     }
     // The resume RPC succeeded — the session is now loaded in this backend.
     server.markBackendLoaded(acpSid);

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -137,6 +137,8 @@ export interface Messages {
   slashResumeFailed: string;
   slashResumed: (title: string) => string;
   slashErrResumeArg: (arg: string) => string;
+  /** Placeholder alias lost/expired — the thread id is unresolvable. */
+  loadUnknownAlias: (sid: string) => string;
   /** Collapsed tool-call titles during session/load replay. */
   replayCompactSummary: string;
   replayContextHandoff: string;
@@ -234,6 +236,8 @@ const zh: Messages = {
   slashResumeFailed: "⚠ 接续失败（后端 resume 出错）——会话保持原状",
   slashResumed: (t) => `✓ 已接续会话：${t}`,
   slashErrResumeArg: (a) => `⚠ 找不到会话 ${a}——用 /resume 查看可选列表`,
+  loadUnknownAlias: (s) =>
+    `⚠ 会话 ${s} 的占位别名已丢失或过期，无法恢复该线程——请新建会话；如需继续历史对话，可用 /resume 接续`,
   replayCompactSummary: "压缩摘要",
   replayContextHandoff: "上下文交接",
   replayToolFallback: (tool) => `${tool} 工具`,
@@ -338,6 +342,8 @@ const en: Messages = {
   slashResumeFailed: "⚠ resume failed (backend error) — the thread is unchanged",
   slashResumed: (t) => `✓ resumed session: ${t}`,
   slashErrResumeArg: (a) => `⚠ session ${a} not found — run /resume to list candidates`,
+  loadUnknownAlias: (s) =>
+    `⚠ placeholder alias for ${s} was lost or expired — start a new thread, or /resume a listed session`,
   replayCompactSummary: "Compact summary",
   replayContextHandoff: "Context handoff",
   replayToolFallback: (tool) => `${tool} tool`,

--- a/src/lazy-sessions.ts
+++ b/src/lazy-sessions.ts
@@ -20,7 +20,16 @@
  * session/list after that, only the placeholder alias expires.
  */
 
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import process from "node:process";
 
@@ -84,12 +93,40 @@ function readTable(): { kept: Record<string, LazySessionRecord>; pruned: boolean
 function persist(table: Record<string, LazySessionRecord>): void {
   try {
     const p = storePath();
-    mkdirSync(path.dirname(p), { recursive: true });
+    const dir = path.dirname(p);
+    mkdirSync(dir, { recursive: true });
     const tmp = `${p}.tmp-${process.pid}`;
     writeFileSync(tmp, JSON.stringify(table, null, 2));
     renameSync(tmp, p);
+    sweepStaleTmp(dir, p);
   } catch (e) {
     log(`lazy-sessions: store write failed (${e instanceof Error ? e.message : String(e)})`);
+  }
+}
+
+/** Stale atomic-write leftovers older than this are swept on the next persist. */
+const TMP_MAX_AGE_MS = 60 * 60 * 1000;
+
+/**
+ * Remove leftover `.tmp-*` siblings a crashed writer never renamed away. The
+ * 1h age guard keeps a concurrently-writing process's microsecond-lived tmp
+ * untouched; the sweep runs only from persist, so readers pay nothing.
+ */
+function sweepStaleTmp(dir: string, storeFile: string): void {
+  try {
+    const prefix = `${path.basename(storeFile)}.tmp-`;
+    const cutoff = Date.now() - TMP_MAX_AGE_MS;
+    for (const entry of readdirSync(dir)) {
+      if (!entry.startsWith(prefix)) continue;
+      const full = path.join(dir, entry);
+      try {
+        if (statSync(full).mtimeMs < cutoff) unlinkSync(full);
+      } catch {
+        // a racing removal or vanished file is fine — best-effort
+      }
+    }
+  } catch {
+    // best-effort — the sweep must never fail a persist
   }
 }
 

--- a/src/lazy-sessions.ts
+++ b/src/lazy-sessions.ts
@@ -33,7 +33,7 @@ import {
 import path from "node:path";
 import process from "node:process";
 
-import { log, warn } from "./utils.js";
+import { warn } from "./utils.js";
 
 /** Placeholder alias record persisted in the store. */
 export interface LazySessionRecord {
@@ -100,7 +100,9 @@ function persist(table: Record<string, LazySessionRecord>): void {
     renameSync(tmp, p);
     sweepStaleTmp(dir, p);
   } catch (e) {
-    log(`lazy-sessions: store write failed (${e instanceof Error ? e.message : String(e)})`);
+    // warn, not gated log: this store is an idle thread's only recovery path,
+    // so a silent write failure must be visible in stderr.
+    warn(`lazy-sessions: store write failed (${e instanceof Error ? e.message : String(e)})`);
   }
 }
 

--- a/src/lazy-sessions.ts
+++ b/src/lazy-sessions.ts
@@ -20,7 +20,7 @@
  * session/list after that, only the placeholder alias expires.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
 
@@ -46,63 +46,81 @@ function storePath(): string {
   return path.join(home, ".zcode", "v2", STORE_FILENAME);
 }
 
-/** Read the store, pruning expired/corrupt records. Returns {} on any failure. */
-function loadRecords(): Record<string, LazySessionRecord> {
+/** Parse and validate the table. No side effects — never rewrites the file. */
+function readTable(): { kept: Record<string, LazySessionRecord>; pruned: boolean } {
   try {
     const p = storePath();
-    if (!existsSync(p)) return {};
+    if (!existsSync(p)) return { kept: {}, pruned: false };
     const raw = JSON.parse(readFileSync(p, "utf8")) as Record<string, LazySessionRecord>;
-    if (typeof raw !== "object" || raw === null) return {};
+    if (typeof raw !== "object" || raw === null) return { kept: {}, pruned: false };
     const now = Date.now();
     let pruned = false;
-    const out: Record<string, LazySessionRecord> = {};
+    const kept: Record<string, LazySessionRecord> = {};
     for (const [acpSid, rec] of Object.entries(raw)) {
       if (typeof rec?.createdAt !== "number" || now - rec.createdAt > TTL_MS) {
         pruned = true;
         continue;
       }
-      out[acpSid] = rec;
+      kept[acpSid] = rec;
     }
-    if (pruned) writeRecords(out);
-    return out;
+    return { kept, pruned };
   } catch (e) {
     warn(
       `lazy-sessions: store read failed ` +
         `(${e instanceof Error ? e.message : String(e)}) — placeholder aliases unavailable`,
     );
-    return {};
+    return { kept: {}, pruned: false };
   }
 }
 
-/** Overwrite the store file. Failures are logged, never thrown. */
-function writeRecords(records: Record<string, LazySessionRecord>): void {
+/**
+ * Overwrite the store file atomically. Failures are logged, never thrown.
+ *
+ * Several bridge processes (editor + serve/TUI + tests) share this file with
+ * no lock; a torn direct write corrupts the JSON, and the next reader treats
+ * corruption as an empty table — permanently wiping every alias. The
+ * write-then-rename leaves readers with either the old or the new file.
+ */
+function persist(table: Record<string, LazySessionRecord>): void {
   try {
     const p = storePath();
     mkdirSync(path.dirname(p), { recursive: true });
-    writeFileSync(p, JSON.stringify(records, null, 2));
+    const tmp = `${p}.tmp-${process.pid}`;
+    writeFileSync(tmp, JSON.stringify(table, null, 2));
+    renameSync(tmp, p);
   } catch (e) {
     log(`lazy-sessions: store write failed (${e instanceof Error ? e.message : String(e)})`);
   }
 }
 
+/** Read the store, pruning expired records (persisting the survivors). */
+function loadRecords(): Record<string, LazySessionRecord> {
+  const { kept, pruned } = readTable();
+  if (pruned) persist(kept);
+  return kept;
+}
+
 /** Record a new placeholder at session/new (no backend session yet). */
 export function rememberLazySession(acpSid: string, cwd: string): void {
-  const records = loadRecords();
-  records[acpSid] = { cwd, createdAt: Date.now() };
-  writeRecords(records);
+  // Merge over a FRESH disk read at write time: persisting a stale snapshot
+  // silently drops records a concurrent bridge process just added.
+  const { kept } = readTable();
+  persist({ ...kept, [acpSid]: { cwd, createdAt: Date.now() } });
 }
 
 /** Attach the backend session id once the placeholder materializes. */
 export function recordMaterializedSession(acpSid: string, zcodeSid: string, cwd: string): void {
-  const records = loadRecords();
-  const existing = records[acpSid];
+  const { kept } = readTable();
+  const existing = kept[acpSid];
   if (existing?.zcodeSid === zcodeSid) return;
-  records[acpSid] = {
-    cwd: existing?.cwd ?? cwd,
-    zcodeSid,
-    createdAt: existing?.createdAt ?? Date.now(),
-  };
-  writeRecords(records);
+  persist({
+    ...kept,
+    [acpSid]: {
+      cwd: existing?.cwd ?? cwd,
+      zcodeSid,
+      createdAt: existing?.createdAt ?? Date.now(),
+    },
+  });
 }
 
 /** Look up a placeholder alias (undefined = unknown to this bridge and store). */

--- a/tests/lazy-sessions.test.ts
+++ b/tests/lazy-sessions.test.ts
@@ -33,6 +33,10 @@ vi.mock("node:fs", async () => {
       mockDirs.add(path.dirname(p));
       mockFiles.set(p, String(data));
     },
+    renameSync: (from: string, to: string) => {
+      mockFiles.set(to, mockFiles.get(from) ?? "");
+      mockFiles.delete(from);
+    },
     mkdirSync: (p: string) => {
       mockDirs.add(String(p));
     },
@@ -79,5 +83,28 @@ describe("lazy session alias store", () => {
     mockFiles.set(STORE, "{not json");
 
     expect(lookupLazySession("acp_1")).toBeUndefined();
+  });
+
+  it("writes atomically — no .tmp leftovers at the store path", () => {
+    rememberLazySession("acp_1", "/tmp/ws");
+    recordMaterializedSession("acp_1", "sess_1", "/tmp/ws");
+
+    const paths = [...mockFiles.keys()];
+    expect(paths).toEqual([STORE]);
+    // The final content is complete, parseable JSON.
+    expect(() => JSON.parse(mockFiles.get(STORE)!)).not.toThrow();
+  });
+
+  it("merges over the on-disk table, preserving a concurrent writer's record", () => {
+    // Process A's placeholder…
+    rememberLazySession("acp_a", "/tmp/ws");
+    // …then process B replaces the file wholesale (its own snapshot). Process
+    // A's next write must re-read and keep B's record, not clobber it.
+    mockFiles.set(STORE, JSON.stringify({ acp_b: { cwd: "/tmp/other", createdAt: Date.now() } }));
+
+    rememberLazySession("acp_c", "/tmp/third");
+
+    const table = JSON.parse(mockFiles.get(STORE)!) as Record<string, { cwd: string }>;
+    expect(Object.keys(table).sort()).toEqual(["acp_b", "acp_c"]);
   });
 });

--- a/tests/lazy-sessions.test.ts
+++ b/tests/lazy-sessions.test.ts
@@ -18,6 +18,8 @@ import {
 
 const mockFiles = new Map<string, string>();
 const mockDirs = new Set<string>();
+/** Explicit mtimes for files the sweep's statSync consults (absent = now). */
+const mockMtimes = new Map<string, number>();
 const STORE = "/fake-home/.zcode/v2/acp-lazy-sessions.json";
 
 vi.mock("node:fs", async () => {
@@ -37,6 +39,13 @@ vi.mock("node:fs", async () => {
       mockFiles.set(to, mockFiles.get(from) ?? "");
       mockFiles.delete(from);
     },
+    readdirSync: (d: string) =>
+      [...mockFiles.keys()].filter((k) => path.dirname(k) === d).map((k) => path.basename(k)),
+    statSync: (p: string) => ({ mtimeMs: mockMtimes.get(p) ?? Date.now() }),
+    unlinkSync: (p: string) => {
+      mockFiles.delete(p);
+      mockMtimes.delete(p);
+    },
     mkdirSync: (p: string) => {
       mockDirs.add(String(p));
     },
@@ -46,6 +55,7 @@ vi.mock("node:fs", async () => {
 beforeEach(() => {
   mockFiles.clear();
   mockDirs.clear();
+  mockMtimes.clear();
   vi.stubEnv("HOME", "/fake-home");
 });
 
@@ -106,5 +116,19 @@ describe("lazy session alias store", () => {
 
     const table = JSON.parse(mockFiles.get(STORE)!) as Record<string, { cwd: string }>;
     expect(Object.keys(table).sort()).toEqual(["acp_b", "acp_c"]);
+  });
+
+  it("sweeps stale atomic-write tmp leftovers on the next persist", () => {
+    const stale = `${STORE}.tmp-999`;
+    const fresh = `${STORE}.tmp-123`;
+    mockFiles.set(stale, "{}");
+    mockFiles.set(fresh, "{}");
+    mockMtimes.set(stale, Date.now() - 2 * 60 * 60 * 1000); // 2h old — sweep
+    mockMtimes.set(fresh, Date.now()); // a live writer's tmp — keep
+
+    rememberLazySession("acp_1", "/tmp/ws");
+
+    expect(mockFiles.has(stale)).toBe(false);
+    expect(mockFiles.has(fresh)).toBe(true);
   });
 });

--- a/tests/resume-pick-elicitation.test.ts
+++ b/tests/resume-pick-elicitation.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Regression: the `/resume` picker's `elicitation/create` params must carry a
+ * session scope. Zed (1.18.1) validates the request against the ACP schema
+ * and answers -32602 ("data did not match any variant of untagged enum
+ * ElicitationMode") when neither sessionId nor requestId is present — the
+ * failed request surfaced to the user as a bare "resume cancelled".
+ *
+ * The client mock below re-validates the exact wire params with the SDK's own
+ * generated zod schema, mirroring the Rust deserializer that rejected them.
+ */
+
+import type * as acp from "@agentclientprotocol/sdk";
+import { describe, expect, it } from "vitest";
+
+import { zCreateElicitationRequest } from "../node_modules/@agentclientprotocol/sdk/dist/schema/zod.gen.js";
+import { askSessionPick } from "../src/handlers/server-requests.js";
+import { ZcodeAcpServer } from "../src/server.js";
+
+/**
+ * A schema-strict client: `elicitation/create` params that do not parse are
+ * answered with a rejection (the JSON-RPC error path requestWithTimeout maps
+ * to null). Everything else succeeds.
+ */
+function strictElicitationClient(onParams: (params: unknown) => void): acp.AgentContext {
+  return {
+    notify: async () => {},
+    request: async (method: string, params: never) => {
+      if (method !== "elicitation/create") return {};
+      onParams(params);
+      const parsed = zCreateElicitationRequest.safeParse(params);
+      if (!parsed.success) throw new Error("Invalid params");
+      return { action: "accept", content: { session: "ztarget" } };
+    },
+  } as unknown as acp.AgentContext;
+}
+
+describe("askSessionPick elicitation wire format", () => {
+  it("sends a session-scoped form a schema-strict client accepts", async () => {
+    const server = new ZcodeAcpServer();
+    server.mergeClientCapabilities({ elicitation: { form: {} } });
+    const seen: unknown[] = [];
+    const cx = strictElicitationClient((p) => seen.push(p));
+
+    const picked = await askSessionPick(server, cx, "acp_thread_1", [
+      { sessionId: "ztarget", label: "a session · 2026-09-07 00:00" },
+      { sessionId: "zother", label: "another · 2026-09-06 12:00" },
+    ]);
+
+    expect(seen).toHaveLength(1);
+    expect(picked).toBe("ztarget");
+    // The scope must name the editor thread the picker was opened from.
+    expect(seen[0]).toMatchObject({ mode: "form", sessionId: "acp_thread_1" });
+  });
+
+  it("returns null (no adoption) when the client rejects the params", async () => {
+    const server = new ZcodeAcpServer();
+    server.mergeClientCapabilities({ elicitation: { form: {} } });
+    const cx = {
+      notify: async () => {},
+      request: async () => {
+        throw new Error("Invalid params");
+      },
+    } as unknown as acp.AgentContext;
+
+    const picked = await askSessionPick(server, cx, "acp_thread_1", [
+      { sessionId: "ztarget", label: "a session" },
+    ]);
+    expect(picked).toBeNull();
+  });
+});

--- a/tests/resume-unknown-session.test.ts
+++ b/tests/resume-unknown-session.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unknown-thread resolution: an editor thread id the bridge has never seen
+ * (no mapping, no pending placeholder, no durable alias) must fail with an
+ * actionable bridge-side error. The raw-id passthrough exists for REAL
+ * backend session ids (imported threads) — but when the backend rejects a
+ * raw id, the cryptic "Session ID 不存在" left users stuck (observed after
+ * the shared alias store lost records to concurrent writers).
+ */
+
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import type * as acp from "@agentclientprotocol/sdk";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ZcodeBackend } from "../src/backend/client.js";
+import { loadSession, resumeSession } from "../src/handlers/session.js";
+import { ZcodeAcpServer } from "../src/server.js";
+
+vi.mock("../src/tasks-index.js", () => ({
+  upsertSessionTask: async () => true,
+  updateSessionTitle: async () => true,
+  renameSessionTask: async () => true,
+  listKnownWorkspaces: async () => [],
+}));
+
+/** Backend whose session/resume rejects unknown ids like the real one. */
+function fakeBackend(): {
+  backend: ZcodeBackend;
+  sent: Array<{ method: string; params: unknown }>;
+} {
+  const sent: Array<{ method: string; params: unknown }> = [];
+  const backend = {
+    isDead: false,
+    request: async (_id: number, method: string, params: Record<string, unknown>) => {
+      sent.push({ method, params });
+      if (method === "session/resume") {
+        return { error: { message: "Session ID 不存在" } };
+      }
+      return { result: {} };
+    },
+    send: () => {},
+    pollServerRequests: () => [],
+    registerEventListener: () => {},
+    unregisterEventListener: () => {},
+  } as unknown as ZcodeBackend;
+  return { backend, sent };
+}
+
+const cx = { notify: async () => {}, request: async () => ({}) } as unknown as acp.AgentContext;
+const LOST_SID = "996b7c79-219b-4b89-8df1-b1313a2c2007";
+
+beforeEach(() => {
+  vi.stubEnv("HOME", mkdtempSync(path.join(tmpdir(), "zacp-unknown-sid-")));
+});
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("unknown thread id (alias lost)", () => {
+  it("session/load fails with the actionable alias-lost error", async () => {
+    const server = new ZcodeAcpServer();
+    const { backend } = fakeBackend();
+    server.backend = backend;
+
+    const err = await loadSession(server, { sessionId: LOST_SID }, cx).catch((e: Error) => e);
+    expect(err).toBeInstanceOf(Error);
+    const text = String((err as Error).message);
+    // Locale-independent: names the id, and is NOT the raw backend failure.
+    expect(text).toContain(LOST_SID);
+    expect(text).not.toContain("zcode resume failed");
+  });
+
+  it("session/resume fails with the same actionable error", async () => {
+    const server = new ZcodeAcpServer();
+    const { backend } = fakeBackend();
+    server.backend = backend;
+
+    const err = await resumeSession(server, { sessionId: LOST_SID }, cx).catch((e: Error) => e);
+    expect(err).toBeInstanceOf(Error);
+    const text = String((err as Error).message);
+    expect(text).toContain(LOST_SID);
+    expect(text).not.toContain("zcode resume failed");
+  });
+
+  it("still passes raw backend-shaped ids through to the backend resume", async () => {
+    const server = new ZcodeAcpServer();
+    const { backend, sent } = fakeBackend();
+    server.backend = backend;
+
+    await loadSession(server, { sessionId: "sess_real_backend_id" }, cx).catch(() => undefined);
+    // The passthrough attempt happened (imported-thread support) — only the
+    // failure MESSAGE changed, not the wire behavior.
+    expect(sent).toContainEqual({
+      method: "session/resume",
+      params: expect.objectContaining({ sessionId: "sess_real_backend_id" }),
+    });
+  });
+});

--- a/tests/resume-unknown-session.test.ts
+++ b/tests/resume-unknown-session.test.ts
@@ -3,16 +3,17 @@
  * (no mapping, no pending placeholder, no durable alias) must fail with an
  * actionable bridge-side error. The raw-id passthrough exists for REAL
  * backend session ids (imported threads) — but when the backend rejects a
- * raw id, the cryptic "Session ID 不存在" left users stuck (observed after
- * the shared alias store lost records to concurrent writers).
+ * raw id as MISSING, the cryptic "Session ID 不存在" left users stuck
+ * (observed after the shared alias store lost records to concurrent
+ * writers). Any other raw-id failure keeps the backend's own error: only a
+ * not-found rejection means a dead session.
+ *
+ * The suite-wide hermetic HOME (tests/setup/hermetic-home.ts) keeps the
+ * alias store lookups off the real one.
  */
 
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
-import path from "node:path";
-
 import type * as acp from "@agentclientprotocol/sdk";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { ZcodeBackend } from "../src/backend/client.js";
 import { loadSession, resumeSession } from "../src/handlers/session.js";
@@ -25,8 +26,8 @@ vi.mock("../src/tasks-index.js", () => ({
   listKnownWorkspaces: async () => [],
 }));
 
-/** Backend whose session/resume rejects unknown ids like the real one. */
-function fakeBackend(): {
+/** Backend whose session/resume fails with the given error message. */
+function fakeBackend(resumeError = "Session ID 不存在"): {
   backend: ZcodeBackend;
   sent: Array<{ method: string; params: unknown }>;
 } {
@@ -36,7 +37,7 @@ function fakeBackend(): {
     request: async (_id: number, method: string, params: Record<string, unknown>) => {
       sent.push({ method, params });
       if (method === "session/resume") {
-        return { error: { message: "Session ID 不存在" } };
+        return { error: { message: resumeError } };
       }
       return { result: {} };
     },
@@ -50,13 +51,6 @@ function fakeBackend(): {
 
 const cx = { notify: async () => {}, request: async () => ({}) } as unknown as acp.AgentContext;
 const LOST_SID = "996b7c79-219b-4b89-8df1-b1313a2c2007";
-
-beforeEach(() => {
-  vi.stubEnv("HOME", mkdtempSync(path.join(tmpdir(), "zacp-unknown-sid-")));
-});
-afterEach(() => {
-  vi.unstubAllEnvs();
-});
 
 describe("unknown thread id (alias lost)", () => {
   it("session/load fails with the actionable alias-lost error", async () => {
@@ -96,5 +90,21 @@ describe("unknown thread id (alias lost)", () => {
       method: "session/resume",
       params: expect.objectContaining({ sessionId: "sess_real_backend_id" }),
     });
+  });
+});
+
+describe("raw id with a transient backend failure", () => {
+  it("keeps the backend's own error instead of blaming a lost alias", async () => {
+    const server = new ZcodeAcpServer();
+    const { backend } = fakeBackend("session locked by another process");
+    server.backend = backend;
+
+    const err = await loadSession(server, { sessionId: "sess_real_backend_id" }, cx).catch(
+      (e: Error) => e,
+    );
+    // The original error flows through untouched — a transient lock on a real
+    // id must NOT be reported as an unrecoverable placeholder alias.
+    expect(String((err as Error).message)).toContain("session locked by another process");
+    expect(String((err as Error).message)).not.toContain(LOST_SID);
   });
 });

--- a/tests/setup/hermetic-home.ts
+++ b/tests/setup/hermetic-home.ts
@@ -1,0 +1,19 @@
+/**
+ * Default hermetic HOME for every test file: a fresh temp dir per file.
+ *
+ * The lazy-alias store (~/.zcode/v2/acp-lazy-sessions.json) is shared with
+ * LIVE bridge processes on the dev machine — a test run writing the real
+ * store once raced a live bridge and wiped a user's placeholder records
+ * (observed 2026-09: an idle editor thread then failed with the backend's
+ * "Session ID 不存在" because its alias was gone). Pointing HOME at a temp
+ * dir by default keeps every fixture, credential lookup, and store write
+ * inside the sandbox; a test that needs a different HOME can still
+ * vi.stubEnv("HOME", …) — the later stub wins for that test.
+ */
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { vi } from "vitest";
+
+vi.stubEnv("HOME", mkdtempSync(path.join(tmpdir(), "zacp-test-home-")));

--- a/tests/setup/hermetic-home.ts
+++ b/tests/setup/hermetic-home.ts
@@ -5,15 +5,25 @@
  * LIVE bridge processes on the dev machine — a test run writing the real
  * store once raced a live bridge and wiped a user's placeholder records
  * (observed 2026-09: an idle editor thread then failed with the backend's
- * "Session ID 不存在" because its alias was gone). Pointing HOME at a temp
- * dir by default keeps every fixture, credential lookup, and store write
- * inside the sandbox; a test that needs a different HOME can still
- * vi.stubEnv("HOME", …) — the later stub wins for that test.
+ * "Session ID 不存在" because its alias was gone).
+ *
+ * HOME is set by DIRECT assignment, not vi.stubEnv: vi.unstubAllEnvs() only
+ * restores values recorded through stubEnv, so a test file calling it
+ * mid-run cannot drop the suite back onto the real HOME. A per-test
+ * vi.stubEnv("HOME", …) still overrides this default for that test.
  */
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { vi } from "vitest";
+import { afterAll } from "vitest";
 
-vi.stubEnv("HOME", mkdtempSync(path.join(tmpdir(), "zacp-test-home-")));
+const home = mkdtempSync(path.join(tmpdir(), "zacp-test-home-"));
+process.env.HOME = home;
+
+afterAll(() => {
+  // The dir is only used synchronously by store/config reads; by afterAll the
+  // file's tests are done. Crashed workers leak a dir — the OS tmp cleaner
+  // handles those.
+  rmSync(home, { recursive: true, force: true });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // Hermetic HOME for all tests — see tests/setup/hermetic-home.ts. Guards
+    // the shared lazy-alias store (and any other $HOME-derived state) from
+    // test writes on dev machines.
+    setupFiles: ["./tests/setup/hermetic-home.ts"],
+  },
+});


### PR DESCRIPTION
Two user-facing fixes plus a review follow-up.

## Bug 1 — `/resume` in Zed showed "resume cancelled"

The `askSessionPick` elicitation carried no session or request scope; Zed (1.18+) validates `elicitation/create` against the ACP schema and rejects scope-less requests with -32602, surfacing as a bare "resume cancelled". Attach the session scope. The regression test re-validates outgoing params with the SDK's own zod schema (imported by relative path — the exports map blocks the subpath), because a plain fake client doesn't validate and missed the bug.

## Bug 2 — long-idle empty editor threads fail with "Session ID 不存在"

`session/new` mints a lazy placeholder uuid persisted in `~/.zcode/v2/acp-lazy-sessions.json`, shared by every bridge process with no locking. A torn or interleaved write corrupts the JSON; the next reader treats it as `{}` and overwrites, wiping all aliases. The thread then resumes its placeholder against the backend and dies on the cryptic error (corruption was confirmed caused by this repo's own vitest runs writing the real store).

- atomic writes (temp file + rename), mutators merge over a fresh disk read
- stale `.tmp-<pid>` leftovers (>1h) swept on persist
- the whole suite runs under a hermetic temp HOME (vitest setupFiles) — suite runs can never race live bridges on the real store
- a lost/expired placeholder alias now fails with an actionable message (start a new session / use /resume); REAL backend ids keep their passthrough and their own errors

## Review follow-up (post-review hardening)

- only not-found raw resume failures (不存在 / not found) are translated to the alias-lost message; transient failures (lock, timeout, network) keep the backend's own error — the duplicated try/catch collapses into one `translateResumeFailure` helper
- alias-store write failure logs via `warn()` (was gated `log()`) — the store is an idle thread's only recovery path
- hermetic HOME survives `vi.unstubAllEnvs()` (direct `process.env.HOME` assignment) with afterAll cleanup

## Test evidence

- 1014/1014 tests, typecheck, lint, build, smoke all green
- a known load-induced timeout flake in `tests/hub.test.ts` (`hub instance shutdown`) reproduces on `main` without this branch — pre-existing, not introduced here

🤖 Generated with ZCode