### PR TITLE
fix(handlers): never TTL-prune materialized lazy aliases; distinct evicted-session error

### DIFF
--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -702,12 +702,14 @@ async function replayResumeHistory(
 }
 
 /**
- * Surface a raw-origin resume failure honestly. A backend id unknown to the
- * bridge AND the alias store, which the backend itself rejects as missing, is
- * a dead/expired session — swap the cryptic backend message for the
- * actionable alias-lost text. Any OTHER failure on a raw id (transient
- * timeout, lock, network) keeps its original error: blaming a lost alias for
- * it would misreport the cause. Always throws.
+ * Surface a resume failure honestly, keyed on WHY the id is known. Always
+ * throws. Two not-found shapes get an actionable message:
+ * - raw (id unknown to bridge AND alias store): a placeholder whose durable
+ *   alias was lost/expired — or a deleted imported session.
+ * - mapped/placeholder (alias points at a zcodeSid): the backend session
+ *   itself was deleted/evicted — the link is fine, the target is gone.
+ * Any OTHER failure (transient timeout, lock, network) keeps the backend's
+ * own error: guessing a cause for it would misreport it.
  */
 function translateResumeFailure(
   methodLabel: "session/resume" | "session/load",
@@ -716,11 +718,13 @@ function translateResumeFailure(
   e: unknown,
 ): never {
   const raw = e instanceof Error ? e.message : String(e);
-  if (origin === "raw" && /不存在|not\s*found/i.test(raw)) {
+  if (!/不存在|not\s*found/i.test(raw)) throw e;
+  if (origin === "raw") {
     warn(`${methodLabel}: ${acpSid} unknown to bridge and alias store (backend said: ${raw})`);
     throw new Error(messages().loadUnknownAlias(acpSid));
   }
-  throw e;
+  warn(`${methodLabel}: ${acpSid} → backend session no longer exists (backend said: ${raw})`);
+  throw new Error(messages().sessionEvicted(acpSid));
 }
 
 /** `session/resume` → zcode `session/resume` (with runtimeModel overlay). */

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -139,6 +139,8 @@ export interface Messages {
   slashErrResumeArg: (arg: string) => string;
   /** Placeholder alias lost/expired — the thread id is unresolvable. */
   loadUnknownAlias: (sid: string) => string;
+  /** Alias resolves but the backend session itself was deleted/evicted. */
+  sessionEvicted: (sid: string) => string;
   /** Collapsed tool-call titles during session/load replay. */
   replayCompactSummary: string;
   replayContextHandoff: string;
@@ -238,6 +240,7 @@ const zh: Messages = {
   slashErrResumeArg: (a) => `⚠ 找不到会话 ${a}——用 /resume 查看可选列表`,
   loadUnknownAlias: (s) =>
     `⚠ 会话 ${s} 的占位别名已丢失或过期，无法恢复该线程——请新建会话；如需继续历史对话，可用 /resume 接续`,
+  sessionEvicted: (s) => `⚠ 会话 ${s} 已被后端清理，该线程无法恢复——请新建会话`,
   replayCompactSummary: "压缩摘要",
   replayContextHandoff: "上下文交接",
   replayToolFallback: (tool) => `${tool} 工具`,
@@ -344,6 +347,8 @@ const en: Messages = {
   slashErrResumeArg: (a) => `⚠ session ${a} not found — run /resume to list candidates`,
   loadUnknownAlias: (s) =>
     `⚠ placeholder alias for ${s} was lost or expired — start a new thread, or /resume a listed session`,
+  sessionEvicted: (s) =>
+    `⚠ session ${s} no longer exists in the backend — this thread cannot be recovered; start a new thread`,
   replayCompactSummary: "Compact summary",
   replayContextHandoff: "Context handoff",
   replayToolFallback: (tool) => `${tool} tool`,

--- a/src/lazy-sessions.ts
+++ b/src/lazy-sessions.ts
@@ -15,9 +15,11 @@
  *     placeholder from a previous bridge lifetime.
  *
  * Best-effort side-channel like tasks-index: failures are logged and swallowed
- * so a store problem never breaks session/new or first use. Records older than
- * 30 days are pruned on load — the real session stays reachable via
- * session/list after that, only the placeholder alias expires.
+ * so a store problem never breaks session/new or first use. NEVER-USED
+ * placeholders older than 30 days are pruned on load — the real session stays
+ * reachable via session/list after that, only the unused alias expires.
+ * Materialized records never expire: their alias is the only link from the
+ * editor's thread id to the backend session.
  */
 
 import {
@@ -46,7 +48,7 @@ export interface LazySessionRecord {
 /** Store file lives next to config.json / tasks-index.sqlite under ~/.zcode/v2/. */
 const STORE_FILENAME = "acp-lazy-sessions.json";
 
-/** Placeholder aliases expire after 30 days; the real session remains listable. */
+/** NEVER-USED placeholders expire after 30 days; materialized records never do. */
 const TTL_MS = 30 * 24 * 60 * 60 * 1000;
 
 /** Resolved at call time so tests can stub HOME without re-importing. */
@@ -66,7 +68,13 @@ function readTable(): { kept: Record<string, LazySessionRecord>; pruned: boolean
     let pruned = false;
     const kept: Record<string, LazySessionRecord> = {};
     for (const [acpSid, rec] of Object.entries(raw)) {
-      if (typeof rec?.createdAt !== "number" || now - rec.createdAt > TTL_MS) {
+      // TTL applies to NEVER-USED placeholders only. A materialized record
+      // (zcodeSid set) is the sole durable link between the editor's thread
+      // id and the backend session — pruning it orphans a session the
+      // backend still happily resumes, and the prune-on-read persist below
+      // makes that loss permanent on first touch (observed: every thread
+      // older than the 30-day TTL failed with "alias lost" in Zed).
+      if (!rec.zcodeSid && (typeof rec?.createdAt !== "number" || now - rec.createdAt > TTL_MS)) {
         pruned = true;
         continue;
       }

--- a/tests/lazy-sessions.test.ts
+++ b/tests/lazy-sessions.test.ts
@@ -81,12 +81,27 @@ describe("lazy session alias store", () => {
     expect(rec?.createdAt).toBeTypeOf("number");
   });
 
-  it("drops expired records on load and rewrites the file", () => {
+  it("drops expired NEVER-USED placeholders on load and rewrites the file", () => {
     const old = Date.now() - 31 * 24 * 60 * 60 * 1000; // older than the 30-day TTL
     mockFiles.set(STORE, JSON.stringify({ stale: { cwd: "/tmp/ws", createdAt: old } }));
 
     expect(lookupLazySession("stale")).toBeUndefined();
     expect(JSON.parse(mockFiles.get(STORE)!)).toEqual({});
+  });
+
+  it("keeps an expired record that MATERIALIZED — the alias is the thread's only link", () => {
+    const old = Date.now() - 31 * 24 * 60 * 60 * 1000; // older than the 30-day TTL
+    mockFiles.set(
+      STORE,
+      JSON.stringify({
+        used_old: { cwd: "/tmp/ws", createdAt: old, zcodeSid: "sess_live" },
+        unused_old: { cwd: "/tmp/ws", createdAt: old },
+      }),
+    );
+
+    expect(lookupLazySession("used_old")?.zcodeSid).toBe("sess_live");
+    const table = JSON.parse(mockFiles.get(STORE)!) as Record<string, unknown>;
+    expect(Object.keys(table)).toEqual(["used_old"]); // the placeholder was pruned
   });
 
   it("tolerates a corrupt store file", () => {

--- a/tests/resume-unknown-session.test.ts
+++ b/tests/resume-unknown-session.test.ts
@@ -17,6 +17,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { ZcodeBackend } from "../src/backend/client.js";
 import { loadSession, resumeSession } from "../src/handlers/session.js";
+import { recordMaterializedSession, rememberLazySession } from "../src/lazy-sessions.js";
 import { ZcodeAcpServer } from "../src/server.js";
 
 vi.mock("../src/tasks-index.js", () => ({
@@ -106,5 +107,25 @@ describe("raw id with a transient backend failure", () => {
     // id must NOT be reported as an unrecoverable placeholder alias.
     expect(String((err as Error).message)).toContain("session locked by another process");
     expect(String((err as Error).message)).not.toContain(LOST_SID);
+  });
+});
+
+describe("alias whose backend session was deleted", () => {
+  it("reports the evicted-session error, not the lost-alias one", async () => {
+    // Realistic eviction shape: bridge restarted, the alias (with zcodeSid)
+    // survived in the store, but the backend deleted the session itself.
+    rememberLazySession("acp_alias", "/tmp/ws");
+    recordMaterializedSession("acp_alias", "sess_deleted_long_ago", "/tmp/ws");
+    const server = new ZcodeAcpServer();
+    const { backend } = fakeBackend(); // "Session ID 不存在"
+    server.backend = backend;
+
+    const err = await loadSession(server, { sessionId: "acp_alias" }, cx).catch((e: Error) => e);
+    const text = String((err as Error).message);
+    // The alias is fine — the backend session itself is gone. The message must
+    // say so (and must not confuse it with the lost-alias case).
+    expect(text).toContain("acp_alias");
+    expect(text).not.toContain("zcode resume failed");
+    expect(text).not.toContain("占位别名");
   });
 });


### PR DESCRIPTION
Follow-up to #148, from a live report: opening old threads in Zed failed with the alias-lost error.

## Root cause (two independent)

1. **TTL pruned materialized aliases.** The 30-day TTL applied to every record, but a materialized alias (zcodeSid set) is the only durable link between an editor thread id and its backend session. Pruning it orphaned sessions the backend still happily resumes — and because `lookupLazySession` prunes-on-read + persists, the loss became permanent on the first touch. The feature shipped Aug 3; every thread from its first week crossed the cliff starting Sep 2. The TTL now applies to never-used placeholders only; materialized records never expire.
2. **Lost aliases from the pre-#148 store races** kept surfacing the same error for newer threads (separate data repair done locally; nothing in this PR).

## Also

- A not-found resume failure is now reported by cause: an alias that resolves but whose backend session was deleted/evicted says "session evicted" instead of the misleading "placeholder alias lost" (`sessionEvicted` in i18n, zh + en).
- Regression tests: an expired-but-materialized record survives; the evicted path produces the new message.

## Test evidence

- 1016/1016 tests, typecheck, lint, build green
- full-suite run leaves the real alias store byte-identical (hermetic HOME guard)

🤖 Generated with ZCode