### PR TITLE
fix(sandbox): centralize profile dirs under ~/.zcode-acp/sandbox with pid-aware sweeping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,9 +252,13 @@ ZCode protocol types into ACP notifications directly — always translate.
   `applySandboxFlip()` at prompt entry; flipping back only drops the wrap on
   the next respawn). Hardening invariants from adversarial review — do not
   regress: profiles go through `armSandboxArgv()` (fresh mkdtemp dir under
-  HOME + O_EXCL + the profile denies its own dir last; the HOME base is the
-  point — every agent-writable path is writable by prior sandboxed
-  generations too, so a $TMPDIR profile is raceable across generations), and
+  the managed root `~/.zcode-acp/sandbox/`, pid-encoded `p-<pid>-*`, + O_EXCL
+  + the profile denies its own dir AND the whole root last; the root must
+  stay off every write-allow list — every agent-writable path is writable by
+  prior sandboxed generations too, so a $TMPDIR profile is raceable across
+  generations; each arm sweeps dead-pid dirs and legacy `~/.zcode-acp-sbx-*`
+  HOME siblings, which the per-bridge chain-cleanup used to leak one per
+  restart), and
     the config must pass the integrity check before the bridge persists
     through it (symlink/hardlink pierces the deny island; a config read as
     armed then EACCES/ENOTDIR/vanished also reads as armed — falling back to

--- a/src/backend/sandbox.ts
+++ b/src/backend/sandbox.ts
@@ -40,8 +40,10 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   realpathSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import os from "node:os";
@@ -348,6 +350,13 @@ export interface SandboxArmInput {
    * profile path would be attacker-reachable.
    */
   profileDir?: string;
+  /**
+   * Managed root under which every profile dir lives (`~/.zcode-acp/sandbox/`).
+   * Denied in full: no sandboxed generation may touch ANY profile, its own or
+   * another bridge's — same placement invariant the profileDir deny provides,
+   * covering the whole centralized tree.
+   */
+  profilesRoot?: string;
 }
 
 /**
@@ -403,6 +412,9 @@ export function buildSandboxProfile(input: SandboxArmInput): string {
   );
   if (input.profileDir) {
     denies.push(`(deny file-write* (subpath ${sb(input.profileDir)}))`);
+  }
+  if (input.profilesRoot) {
+    denies.push(`(deny file-write* (subpath ${sb(resolveReal(input.profilesRoot))}))`);
   }
   return (
     ["(version 1)", "(allow default)", "(deny file-write*)", ...allows, ...denies].join("\n") + "\n"
@@ -496,27 +508,114 @@ export function resetSandboxDecisionForTest(): void {
 /** Previous respawn's profile dir — removed once superseded (its backend is dead). */
 let lastProfileDir: string | null = null;
 
+/** Managed root for all sandbox profile dirs — centralized, sweepable. */
+export function sandboxProfilesRoot(): string {
+  return path.join(os.homedir(), ".zcode-acp", "sandbox");
+}
+
+/** Age at which a profile dir is sweepable even if its pid looks alive. */
+const SWEEP_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Old-name `~/.zcode-acp-sbx-*` sibling from a pre-centralization bridge. */
+const LEGACY_SBX_PREFIX = ".zcode-acp-sbx-";
+
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    // EPERM = the process exists but belongs to another user — still alive.
+    return (e as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
 /**
- * Arm a backend argv: build the profile into a FRESH unpredictable dir and
- * wrap with sandbox-exec. The dir sits DIRECTLY under $HOME with a
- * `.zcode-acp-sbx-` prefix — OUTSIDE every whitelisted path (it is a SIBLING
- * of `~/.zcode`, not inside it). That location is the load-bearing defense:
- * $TMPDIR and the cache dirs are agent-writable, and a PRIOR sandboxed
- * generation (a setsid survivor of the old process group) keeps its own
- * profile's allows — so a profile placed there could be raced, symlinked,
+ * Remove profile dirs of DEAD bridges. Each dir is pid-encoded (`p-<pid>-*`):
+ * a live pid (another running bridge) keeps its dir, a dead pid is a crash
+ * leak. The 7-day age guard also reaps dirs held "alive" by a recycled or
+ * zombie pid. Runs only from armSandboxArgv, best-effort throughout.
+ */
+function sweepProfileDirs(root: string): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(root);
+  } catch {
+    return; // no root yet or unreadable — nothing to sweep
+  }
+  const now = Date.now();
+  for (const entry of entries) {
+    const full = path.join(root, entry);
+    if (full === lastProfileDir) continue;
+    const m = /^p-(\d+)-/.exec(entry);
+    try {
+      const stale = now - statSync(full).mtimeMs > SWEEP_MAX_AGE_MS;
+      // Own pid + not lastProfileDir = a chain-cleanup leftover of THIS
+      // process — dead by construction. Unparsable name: age-expire only.
+      const dead = m ? Number(m[1]) === process.pid || !pidAlive(Number(m[1])) : stale;
+      if (stale || dead) rmSync(full, { recursive: true, force: true });
+    } catch {
+      // best-effort — a vanished/racing dir is fine
+    }
+  }
+}
+
+/**
+ * Migration sweep: remove the per-arm `~/.zcode-acp-sbx-*` HOME siblings
+ * this bridge's ancestors leaked (each bridge cleaned only its own previous
+ * dir; crashes and restarts accumulated — 121 observed on one machine). Runs
+ * on every arm (idempotent): old bridges may still be alive and leaking. The
+ * 1h mtime guard leaves alone anything a still-running OLD bridge may be
+ * reading mid-exec; a profile is only ever read at exec time, and every arm
+ * creates a fresh dir, so older siblings are dead by construction.
+ */
+function sweepLegacySbxDirs(): void {
+  const home = os.homedir();
+  let entries: string[];
+  try {
+    entries = readdirSync(home);
+  } catch {
+    return;
+  }
+  const cutoff = Date.now() - 60 * 60 * 1000;
+  for (const entry of entries) {
+    if (!entry.startsWith(LEGACY_SBX_PREFIX)) continue;
+    const full = path.join(home, entry);
+    try {
+      if (statSync(full).mtimeMs < cutoff) rmSync(full, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  }
+}
+
+/**
+ * Arm a backend argv: build the profile into a FRESH unpredictable dir under
+ * `~/.zcode-acp/sandbox/` and wrap with sandbox-exec. The managed root is
+ * OUTSIDE every whitelisted path (the profile allows ~/.zcode* state dirs,
+ * caches, and temp trees — never ~/.zcode-acp), which is the load-bearing
+ * defense: $TMPDIR and the cache dirs are agent-writable, and a PRIOR
+ * sandboxed generation (a setsid survivor of the old process group) keeps its
+ * own profile's allows — so a profile placed there could be raced, symlinked,
  * FIFO'd, or occupied no matter how fresh its name (reproduced across
  * generations even with mkdtemp + O_EXCL + a self-deny, which each generation
  * only applies to its own dir). The agent can also kill the backend at will
  * (signals are not file-writes) to control respawn timing; with the profile
  * unreachable from ANY generation, that primitive buys nothing. O_EXCL ("wx")
- * additionally refuses pre-placed symlinks from a pre-arming process, and
- * the profile still self-denies its own dir last (defense in depth for the
- * workspace-root-is-$HOME edge, where home itself is writable).
+ * additionally refuses pre-placed symlinks from a pre-arming process, the
+ * profile denies the whole profiles root last, and the self-deny of its own
+ * dir remains as defense in depth for the workspace-root-is-$HOME edge (where
+ * home itself is writable).
  */
 export function armSandboxArgv(argv: string[], input: SandboxArmInput): string[] {
-  const dir = mkdtempSync(path.join(os.homedir(), ".zcode-acp-sbx-"));
+  const root = sandboxProfilesRoot();
+  mkdirSync(root, { recursive: true });
+  // pid-encoded name: the arm-time sweep can tell a live bridge's profile
+  // from a crashed bridge's leak and remove only the latter.
+  const dir = mkdtempSync(path.join(root, `p-${process.pid}-`));
   const file = path.join(dir, "profile.sb");
-  writeFileSync(file, buildSandboxProfile({ ...input, profileDir: dir }), { flag: "wx" });
+  writeFileSync(file, buildSandboxProfile({ ...input, profileDir: dir, profilesRoot: root }), {
+    flag: "wx",
+  });
   if (lastProfileDir && lastProfileDir !== dir) {
     try {
       rmSync(lastProfileDir, { recursive: true, force: true });
@@ -525,6 +624,8 @@ export function armSandboxArgv(argv: string[], input: SandboxArmInput): string[]
     }
   }
   lastProfileDir = dir;
+  sweepProfileDirs(root);
+  sweepLegacySbxDirs();
   log(`sandbox: backend wrapped with sandbox-exec (profile: ${file})`);
   return ["sandbox-exec", "-f", file, ...argv];
 }

--- a/tests/sandbox.test.ts
+++ b/tests/sandbox.test.ts
@@ -9,6 +9,7 @@
  * assertion runs under a stubbed darwin platform.
  */
 
+import { spawn, spawnSync } from "node:child_process";
 import {
   chmodSync,
   existsSync,
@@ -19,6 +20,7 @@ import {
   realpathSync,
   rmSync,
   symlinkSync,
+  utimesSync,
   writeFileSync,
 } from "node:fs";
 import os from "node:os";
@@ -38,6 +40,7 @@ import {
   resetSandboxDecisionForTest,
   sandboxActive,
   sandboxConfigPath,
+  sandboxProfilesRoot,
 } from "../src/backend/sandbox.js";
 
 // The arm tests redirect os.homedir() to a repo-local fixture (sandboxed
@@ -467,12 +470,15 @@ describe("armSandboxArgv", () => {
     ]);
     const file = argv[2]!;
     const dir = path.dirname(file);
-    // Home base, NOT $TMPDIR/caches: a prior sandboxed generation keeps the
-    // old allows, so only a path no generation can write is race-proof.
-    expect(dir.startsWith(path.join(os.homedir(), ".zcode-acp-sbx-"))).toBe(true);
+    // Managed root under HOME, NOT $TMPDIR/caches: a prior sandboxed
+    // generation keeps the old allows, so only a path no generation can
+    // write is race-proof. The dir name carries the owning pid for sweeping.
+    const root = path.join(os.homedir(), ".zcode-acp", "sandbox");
+    expect(dir.startsWith(path.join(root, `p-${process.pid}-`))).toBe(true);
     expect(dir.startsWith(realpathSync(os.tmpdir()))).toBe(false);
     const profile = readFileSync(file, "utf8");
     expect(profile).toContain(`(deny file-write* (subpath "${dir}"))`);
+    expect(profile).toContain(`(deny file-write* (subpath "${realpathSync(root)}"))`);
     rmSync(dir, { recursive: true, force: true });
   });
 
@@ -485,5 +491,68 @@ describe("armSandboxArgv", () => {
     expect(dir2).not.toBe(dir1);
     expect(existsSync(dir1)).toBe(false); // cleaned up once superseded
     rmSync(dir2, { recursive: true, force: true });
+  });
+
+  it("sweeps a DEAD bridge's pid-encoded dir on the next arm", () => {
+    const root = sandboxProfilesRoot();
+    const dead = spawnSync("sleep", ["0.01"]); // completes → its pid is gone
+    const leftover = path.join(root, `p-${dead.pid}-leak`);
+    mkdirSync(leftover, { recursive: true });
+    writeFileSync(path.join(leftover, "profile.sb"), "(version 1)");
+
+    const file = arm()[2]!;
+    expect(existsSync(leftover)).toBe(false); // dead pid → swept
+    rmSync(path.dirname(file), { recursive: true, force: true });
+  });
+
+  it("keeps another LIVE bridge's profile dir", () => {
+    const root = sandboxProfilesRoot();
+    const peer = spawn("sleep", ["10"]);
+    try {
+      const liveDir = path.join(root, `p-${peer.pid}-live`);
+      mkdirSync(liveDir, { recursive: true });
+      writeFileSync(path.join(liveDir, "profile.sb"), "(version 1)");
+
+      const file = arm()[2]!;
+      expect(existsSync(liveDir)).toBe(true); // live pid → untouched
+      rmSync(liveDir, { recursive: true, force: true });
+      rmSync(path.dirname(file), { recursive: true, force: true });
+    } finally {
+      peer.kill();
+    }
+  });
+
+  it("reaps stale dirs past the age guard even if the pid looks alive", () => {
+    const root = sandboxProfilesRoot();
+    const peer = spawn("sleep", ["10"]);
+    try {
+      const old = path.join(root, `p-${peer.pid}-ancient`);
+      mkdirSync(old, { recursive: true });
+      writeFileSync(path.join(old, "profile.sb"), "(version 1)");
+      const weekAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000);
+      utimesSync(old, weekAgo, weekAgo);
+
+      const file = arm()[2]!;
+      expect(existsSync(old)).toBe(false); // >7d → swept despite live pid
+      rmSync(path.dirname(file), { recursive: true, force: true });
+    } finally {
+      peer.kill();
+    }
+  });
+
+  it("migrates legacy ~/.zcode-acp-sbx-* HOME siblings (old swept, fresh kept)", () => {
+    const home = os.homedir();
+    const oldLegacy = path.join(home, ".zcode-acp-sbx-oldleak");
+    const freshLegacy = path.join(home, ".zcode-acp-sbx-fresh");
+    mkdirSync(oldLegacy, { recursive: true });
+    mkdirSync(freshLegacy, { recursive: true });
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    utimesSync(oldLegacy, twoHoursAgo, twoHoursAgo);
+
+    const file = arm()[2]!;
+    expect(existsSync(oldLegacy)).toBe(false); // stale legacy → swept
+    expect(existsSync(freshLegacy)).toBe(true); // fresh → may be mid-exec
+    rmSync(freshLegacy, { recursive: true, force: true });
+    rmSync(path.dirname(file), { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
Every sandbox arm created a fresh `~/.zcode-acp-sbx-*` dir directly under $HOME and only the chain-cleanup of the previous dir existed, so each bridge lifetime leaked at least one dir and crashes leaked all (121 observed on one machine).

- Profiles now live in the managed root `~/.zcode-acp/sandbox/` in pid-encoded `p-<pid>-<rand>` dirs. The root is deliberately off every write-allow list, so the race-proofing invariant from ADR-0011 (no sandboxed generation may reach any profile) is unchanged; the profile now denies the whole root in addition to its own dir.
- Each arm sweeps DEAD-pid dirs (a live bridge's profile is untouched) with a 7-day age guard against pid recycling/zombies; unparsable names age-expire only.
- A migration sweep removes the legacy `~/.zcode-acp-sbx-*` HOME siblings on every arm (1h mtime guard — a profile is only ever read at exec time, so older siblings are dead by construction).
- Tests: dead-pid sweep, live-pid keep, age guard, legacy migration, placement + whole-root deny assertions.

## Review evidence

Two-axis review (standards + spec) passed: allow-collision check, SBPL deny-ordering, sweep containment and best-effort error handling all verified. 1020/1020 tests, typecheck, lint, build green.

🤖 Generated with ZCode