### PR TITLE
feat(remote): hub staleness detection via dist content fingerprint with automatic upgrade pokes

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,6 +17,17 @@ export default [
   },
   js.configs.recommended,
   {
+    // Node build scripts (plain .mjs, not compiled): node globals only.
+    files: ["scripts/**/*.mjs"],
+    languageOptions: {
+      globals: {
+        console: "readonly",
+        process: "readonly",
+        URL: "readonly",
+      },
+    },
+  },
+  {
     files: ["src/**/*.ts", "tests/**/*.ts"],
     languageOptions: {
       parser: tsparser,

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "docs"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node scripts/write-code-fingerprint.mjs && node dist/remote/hub-upgrade-notify.js",
     "dev": "tsc --watch",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
@@ -45,7 +45,8 @@
     "lint": "eslint .",
     "smoke": "node dist/index.js < /dev/null",
     "smoke:tui": "node dist/cli.js tui --check",
-    "prepublishOnly": "pnpm run build && pnpm run test"
+    "prepublishOnly": "pnpm run build && pnpm run test",
+    "postinstall": "node dist/remote/hub-upgrade-notify.js 2>/dev/null || true"
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^1.3.0",

--- a/scripts/write-code-fingerprint.mjs
+++ b/scripts/write-code-fingerprint.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+/**
+ * Build step: hash every .js under dist/ (sorted, path+content) into
+ * dist/code-fingerprint.json. The hub-vs-bridge staleness handshake compares
+ * CONTENT, not version numbers or mtimes — a version can lie (a hub started
+ * between a release merge and the dist rebuild reports the new version while
+ * running old code) and an mtime can be preserved or skewed (cp -p, rsync,
+ * clock drift). Content cannot. Run AFTER tsc; part of `pnpm build` so the
+ * npm tarball ships the file (prepublishOnly builds first).
+ */
+
+import { createHash } from "node:crypto";
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const distDir = fileURLToPath(new URL("../dist/", import.meta.url));
+
+async function collectJsFiles(current, out) {
+  for (const entry of await readdir(current, { withFileTypes: true })) {
+    const full = path.join(current, entry.name);
+    if (entry.isDirectory()) await collectJsFiles(full, out);
+    else if (entry.isFile() && entry.name.endsWith(".js")) out.push(full);
+  }
+}
+
+const files = [];
+await collectJsFiles(distDir, files);
+files.sort();
+
+if (files.length === 0) {
+  console.error("write-code-fingerprint: no .js files under dist/ — run tsc first");
+  process.exit(1);
+}
+
+const combined = createHash("sha256");
+for (const file of files) {
+  combined.update(path.relative(distDir, file));
+  combined.update("\0");
+  combined.update(await readFile(file));
+}
+
+const fingerprint = combined.digest("hex");
+const outFile = path.join(distDir, "code-fingerprint.json");
+await mkdir(distDir, { recursive: true });
+await writeFile(outFile, `${JSON.stringify({ fingerprint, fileCount: files.length }, null, 2)}\n`);
+console.log(`write-code-fingerprint: ${fingerprint.slice(0, 12)}… over ${files.length} files`);

--- a/src/remote/code-fingerprint.ts
+++ b/src/remote/code-fingerprint.ts
@@ -1,0 +1,30 @@
+/**
+ * Runtime read of the build-time dist content fingerprint
+ * (scripts/write-code-fingerprint.mjs → dist/code-fingerprint.json).
+ *
+ * Null when absent: running from src (dev), or a dist built before the
+ * fingerprint step existed — callers must fall back to the legacy
+ * version-number comparison then, never treat null as a mismatch.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/** dist/remote/x.js → dist/code-fingerprint.json (dist/ root in tests). */
+export function codeFingerprintPath(distDir?: string): string {
+  return distDir
+    ? `${distDir.replace(/\/$/, "")}/code-fingerprint.json`
+    : fileURLToPath(new URL("../code-fingerprint.json", import.meta.url));
+}
+
+/** Read the fingerprint; null when the file is missing or malformed. */
+export function readCodeFingerprint(distDir?: string): string | null {
+  try {
+    const parsed = JSON.parse(readFileSync(codeFingerprintPath(distDir), "utf8")) as {
+      fingerprint?: unknown;
+    };
+    return typeof parsed.fingerprint === "string" ? parsed.fingerprint : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/remote/endpoint.ts
+++ b/src/remote/endpoint.ts
@@ -34,6 +34,7 @@ import { createSessionCloseHandler } from "./session-close-endpoint.js";
 import { createSessionListHandler } from "./session-list-endpoint.js";
 import { createSessionRenameHandler } from "./session-rename-endpoint.js";
 import { createStatusHandler, runningZcodeSids, type SessionRunStatus } from "./status-endpoint.js";
+import { readCodeFingerprint } from "./code-fingerprint.js";
 import type { RemoteConfig } from "./config.js";
 
 /** One heartbeat/discovery session entry (ADR-0005 adds `status`). */
@@ -282,6 +283,8 @@ export async function startRemoteEndpoint(
   // Last non-2xx/non-401 register status we warned about (once per stretch).
   let unexpectedStatus: number | null = null;
   let spawnThrottledUntil = 0;
+  // Frozen at bridge start: what this process actually runs (see payload).
+  const bridgeFingerprint = readCodeFingerprint();
 
   const payload = (sessions: AdvertisedSession[]) => ({
     token: config.token,
@@ -301,6 +304,10 @@ export async function startRemoteEndpoint(
     // Lets the hub detect that it is older than this bridge and restart
     // itself (we then re-spawn it from this dist — see registerOnce).
     version: AGENT_INFO.version,
+    // Content fingerprint of the dist this bridge runs from — the honest
+    // staleness signal (versions can lie across a release-merge/rebuild
+    // window). Absent when running from src or a pre-fingerprint build.
+    ...(bridgeFingerprint ? { codeFingerprint: bridgeFingerprint } : {}),
   });
 
   const spawnHub = (): void => {

--- a/src/remote/hub-server.ts
+++ b/src/remote/hub-server.ts
@@ -60,6 +60,7 @@ import { WebSocket, WebSocketServer, type RawData } from "ws";
 import { resolveRuntime, runtimeSpawnParts } from "../runtime.js";
 import { AGENT_INFO, compareVersions, log, warn } from "../utils.js";
 import type { TerminalPrefs } from "../config/user-config.js";
+import { readCodeFingerprint } from "./code-fingerprint.js";
 import { remoteEnabledLive, remoteTerminalPrefs } from "./config.js";
 import { accountUsageStats, type UsageStatsResult } from "../handlers/account.js";
 import { BOOT_RESUME_TRIGGER } from "../handlers/session.js";
@@ -96,6 +97,12 @@ export interface HubOptions {
    * directory this module runs from.
    */
   codePaths?: { packageJson: string; distDir: string };
+  /**
+   * Override the frozen content fingerprint this hub compares bridges and
+   * /api/upgrade against (tests inject fixtures). Default: read from the
+   * code-fingerprint.json next to this module's dist root; null in dev/src.
+   */
+  hubFingerprint?: string | null;
   /**
    * Override where the remote session-create endpoints read the known-project
    * whitelist from (tests point this at a fixture sqlite). Default: the App's
@@ -807,20 +814,31 @@ async function newestJsMtime(dir: string): Promise<number | null> {
 
 /**
  * /api/upgrade staleness check: is the code on DISK newer than this running
- * process? Either signal suffices — the on-disk package.json version beats
- * the version frozen into this process at start (a release upgrade), or any
- * .js under dist was written after process start (a rebuild, even without a
- * version bump). A respawned process starts after the newest dist mtime, so
- * the condition self-negates: no restart loops.
+ * process? The content fingerprint is checked FIRST — a hub that knows its
+ * own fingerprint restarts onto any differently-fingerprinted disk build
+ * (deterministic; version numbers can lie across a release-merge/rebuild
+ * window and mtimes can be preserved or skewed). Legacy signals follow for
+ * fingerprint-less processes: the on-disk package.json version beats the
+ * version frozen into this process at start (a release upgrade), or any .js
+ * under dist was written after process start (a rebuild, even without a
+ * version bump). A respawned process re-reads the same disk, so every
+ * condition self-negates: no restart loops.
  */
 async function diskCodeIsNewer(
   paths: { packageJson: string; distDir: string },
   startedAt: number,
+  runningFingerprint: string | null,
 ): Promise<{
   newer: boolean;
-  reason: "version" | "mtime" | "up-to-date";
+  reason: "fingerprint" | "version" | "mtime" | "up-to-date";
   diskVersion: string | null;
 }> {
+  if (runningFingerprint) {
+    const diskFingerprint = readCodeFingerprint(paths.distDir);
+    if (diskFingerprint && diskFingerprint !== runningFingerprint) {
+      return { newer: true, reason: "fingerprint", diskVersion: null };
+    }
+  }
   let diskVersion: string | null = null;
   try {
     const pkg = JSON.parse(await readFile(paths.packageJson, "utf8")) as { version?: unknown };
@@ -861,6 +879,14 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
 
   /** Frozen at hub start — the anchor the /api/upgrade signals compare to. */
   const startedAt = Date.now();
+  /**
+   * Frozen at hub start — the CONTENT anchor both staleness checks compare
+   * against (/api/upgrade vs disk, /api/register vs each bridge). Null when
+   * this process runs from src or a pre-fingerprint build; callers then fall
+   * back to version/mtime signals.
+   */
+  const hubFingerprint =
+    options.hubFingerprint !== undefined ? options.hubFingerprint : readCodeFingerprint();
 
   const instances = new Map<string, InstanceEntry>();
   const proxyPairs = new Set<{ client: WebSocket; bridge: WebSocket }>();
@@ -1504,7 +1530,7 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
         res.end("unauthorized");
         return;
       }
-      const check = await diskCodeIsNewer(codePaths, startedAt);
+      const check = await diskCodeIsNewer(codePaths, startedAt, hubFingerprint);
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(
         JSON.stringify({
@@ -1711,19 +1737,38 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
         instances.delete(id);
         idleSince = null; // re-arm the idle clock on membership change
       }
-      // Version self-upgrade: a bridge NEWER than this hub just registered,
-      // so this process is running stale code. Reply first (the bridge
-      // re-spawns the hub from its own, newer dist when it sees `restarting`),
-      // then exit. Equal/older/absent versions never trigger a restart.
-      const stale =
-        url.pathname === "/api/register" &&
+      // Self-upgrade: a bridge running DIFFERENT code than this hub just
+      // registered, so this process is stale. Reply first (the bridge
+      // re-spawns the hub from its own dist when it sees `restarting`), then
+      // exit. Fingerprints are compared when both sides have one — content
+      // cannot lie the way a version frozen from package.json can (a hub
+      // born between a release merge and the dist rebuild). The lexical
+      // tie-break (bridge fp must sort HIGHER) gives coexisting dists on one
+      // machine a stable winner, so two differently-built bridges can never
+      // ping-pong the hub. Bridges without a fingerprint fall back to the
+      // legacy strictly-newer version check.
+      const bridgeFingerprint =
+        typeof body.codeFingerprint === "string" && body.codeFingerprint
+          ? body.codeFingerprint
+          : null;
+      const fingerprintStale =
+        bridgeFingerprint !== null &&
+        hubFingerprint !== null &&
+        bridgeFingerprint !== hubFingerprint &&
+        bridgeFingerprint > hubFingerprint;
+      const versionStale =
+        bridgeFingerprint === null &&
+        hubFingerprint === null &&
         typeof body.version === "string" &&
         compareVersions(body.version, AGENT_INFO.version) > 0;
+      const stale = url.pathname === "/api/register" && (fingerprintStale || versionStale);
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify(stale ? { ok: true, restarting: true } : { ok: true }));
       if (stale) {
         restartSoon(
-          `hub: bridge ${body.version} is newer than hub ${AGENT_INFO.version} — restarting to upgrade`,
+          fingerprintStale
+            ? `hub: bridge fingerprint ${bridgeFingerprint!.slice(0, 12)} differs from hub ${hubFingerprint!.slice(0, 12)} — restarting to upgrade`
+            : `hub: bridge ${body.version} is newer than hub ${AGENT_INFO.version} — restarting to upgrade`,
         );
       }
       return;

--- a/src/remote/hub-server.ts
+++ b/src/remote/hub-server.ts
@@ -256,6 +256,13 @@ function parseOrigin(raw: unknown): "editor" | "serve" {
 const TUI_REGISTER_TIMEOUT_MS = 20_000;
 /** `open -a <terminal>` must answer fast or the incubation falls back. */
 const TERMINAL_OPEN_TIMEOUT_MS = 3_000;
+/**
+ * The osascript path (Ghostty AppleScript) needs more room: on a locked
+ * screen with display sleep, the AppleEvent round-trip to the app can take
+ * well over 3s while still succeeding — killing it there produced a spurious
+ * timeout (and a duplicate tab once the app processed the event anyway).
+ */
+const TERMINAL_SCRIPT_TIMEOUT_MS = 10_000;
 
 /** Single-quote for sh: ' → '\'' . */
 function shQuote(s: string): string {
@@ -510,6 +517,8 @@ async function spawnTerminalTui(opts: {
   // Async spawn — spawnSync would freeze the hub's event loop (WS proxying,
   // heartbeats for every live bridge) for up to the full timeout while a GUI
   // app cold-starts.
+  const openTimeoutMs =
+    launch.kind === "ghosttyScript" ? TERMINAL_SCRIPT_TIMEOUT_MS : TERMINAL_OPEN_TIMEOUT_MS;
   const errChunks: Buffer[] = [];
   const opened = await new Promise<{ error?: Error; timedOut?: boolean; code?: number | null }>(
     (resolve) => {
@@ -518,7 +527,7 @@ async function spawnTerminalTui(opts: {
       const timer = setTimeout(() => {
         child.kill();
         resolve({ timedOut: true });
-      }, TERMINAL_OPEN_TIMEOUT_MS);
+      }, openTimeoutMs);
       child.once("error", (e: Error) => {
         clearTimeout(timer);
         resolve({ error: e });
@@ -531,7 +540,7 @@ async function spawnTerminalTui(opts: {
   );
   if (opened.error || opened.timedOut || opened.code !== 0) {
     const detail = opened.timedOut
-      ? `timed out after ${TERMINAL_OPEN_TIMEOUT_MS}ms`
+      ? `timed out after ${openTimeoutMs}ms`
       : (opened.error?.message ?? Buffer.concat(errChunks).toString("utf8").trim()) ||
         `exit ${opened.code ?? "?"}`;
     warn(`hub: no terminal window for ${opts.cwd} (${detail}) — falling back to a headless bridge`);

--- a/src/remote/hub-upgrade-notify.ts
+++ b/src/remote/hub-upgrade-notify.ts
@@ -1,0 +1,42 @@
+/**
+ * Best-effort POST /api/upgrade poke at the local hub — the "updater owns
+ * the restart" half of the staleness design (apt postinst convention): the
+ * process that just changed the code on disk tells the running daemon to
+ * re-check itself. The hub still makes its own decision (content fingerprint
+ * / version / mtime comparison) — this script never forces anything.
+ *
+ * Run from `pnpm build` (fresh local rebuild) and the npm postinstall hook
+ * (a consumer upgrading the package). Every failure is silent by design:
+ * no hub running, no token, no remote config — nothing to do, exit 0.
+ */
+
+import process from "node:process";
+
+import { loadUserConfig } from "../config/user-config.js";
+
+function quietHubTarget(env: NodeJS.ProcessEnv): { token: string; port: number } | null {
+  const file = loadUserConfig(env).remote ?? {};
+  const token = file.token ?? (env.ZCODE_ACP_REMOTE_TOKEN ?? "").trim();
+  if (!token) return null;
+  const port = file.hubPort ?? (Number.parseInt(env.ZCODE_ACP_HUB_PORT ?? "", 10) || 8377);
+  return { token, port };
+}
+
+async function main(): Promise<void> {
+  const target = quietHubTarget(process.env);
+  if (!target) return; // no token configured — nothing to poke
+  try {
+    const res = await fetch(`http://127.0.0.1:${target.port}/api/upgrade`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${target.token}` },
+      signal: AbortSignal.timeout(3000),
+    });
+    // Any answer (restart decision or refusal) is the hub's call — even a
+    // 401 just means a token rotation the hub itself will resolve.
+    if (!res.ok) return;
+  } catch {
+    /* hub not running / not reachable — nothing to upgrade */
+  }
+}
+
+void main().finally(() => process.exit(0));

--- a/tests/hub.test.ts
+++ b/tests/hub.test.ts
@@ -829,6 +829,85 @@ describe("hub version self-upgrade", () => {
   });
 });
 
+describe("hub fingerprint self-upgrade", () => {
+  async function register(hub: HubHandle, body: Record<string, unknown>): Promise<Response> {
+    return fetch(`http://127.0.0.1:${hub.port}/api/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(registerBody(body)),
+    });
+  }
+
+  it("restarts when a bridge with a different (lexically higher) fingerprint registers", async () => {
+    let restarted = false;
+    const hub = await startTestHub({
+      hubFingerprint: "aaaa",
+      onRestart: () => {
+        restarted = true;
+      },
+    });
+    const res = await register(hub, { codeFingerprint: "bbbb" });
+    expect(await res.json()).toEqual({ ok: true, restarting: true });
+    await withTimeout(
+      new Promise<void>((resolve) => {
+        const check = setInterval(() => {
+          if (restarted) {
+            clearInterval(check);
+            resolve();
+          }
+        }, 50);
+      }),
+      5000,
+      "hub restart onto higher fingerprint",
+    );
+  });
+
+  it("does not ping-pong for a lexically LOWER fingerprint (stable winner)", async () => {
+    let restarted = false;
+    const hub = await startTestHub({
+      hubFingerprint: "bbbb",
+      onRestart: () => {
+        restarted = true;
+      },
+    });
+    const res = await register(hub, { codeFingerprint: "aaaa" });
+    expect(await res.json()).toEqual({ ok: true });
+    await new Promise((r) => setTimeout(r, 800));
+    expect(restarted).toBe(false);
+  });
+
+  it("does not restart for an identical fingerprint", async () => {
+    let restarted = false;
+    const hub = await startTestHub({
+      hubFingerprint: "aaaa",
+      onRestart: () => {
+        restarted = true;
+      },
+    });
+    const res = await register(hub, { codeFingerprint: "aaaa" });
+    expect(await res.json()).toEqual({ ok: true });
+    await new Promise((r) => setTimeout(r, 800));
+    expect(restarted).toBe(false);
+  });
+
+  it("ignores the version signal once this hub knows its fingerprint", async () => {
+    // A fingerprint-less bridge claiming a huge version must not restart a
+    // fingerprinted hub: the transition case (old bridge vs new hub) is the
+    // /api/upgrade postinstall poke's job, never the register path's.
+    let restarted = false;
+    const hub = await startTestHub({
+      hubFingerprint: "aaaa",
+      onRestart: () => {
+        restarted = true;
+      },
+    });
+    const res = await register(hub, { version: "9999.0.0" });
+    expect(await res.json()).toEqual({ ok: true });
+    await new Promise((r) => setTimeout(r, 800));
+    expect(restarted).toBe(false);
+  });
+});
+
 describe("hub /api/upgrade (self-decided restart)", () => {
   const upgradeUrl = (hub: HubHandle) => `http://127.0.0.1:${hub.port}/api/upgrade`;
   const auth = { Authorization: `Bearer ${TOKEN}` };
@@ -932,6 +1011,46 @@ describe("hub /api/upgrade (self-decided restart)", () => {
       diskVersion: "9999.0.0",
     });
     await until(() => restarted, "hub restart onto newer version");
+  });
+
+  it("restarts onto a different on-disk fingerprint (same version, no mtime change)", async () => {
+    const paths = await writeCodeFixture(AGENT_INFO.version);
+    await writeFile(
+      path.join(paths.distDir, "code-fingerprint.json"),
+      JSON.stringify({ fingerprint: "cccc", fileCount: 1 }),
+    );
+    let restarted = false;
+    const hub = await startTestHub({
+      hubFingerprint: "aaaa",
+      codePaths: paths,
+      onRestart: () => {
+        restarted = true;
+      },
+    });
+    const res = await fetch(upgradeUrl(hub), { method: "POST", headers: auth });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ restarting: true, reason: "fingerprint" });
+    await until(() => restarted, "hub restart onto different fingerprint");
+  });
+
+  it("stays put when the on-disk fingerprint matches (mtime skew irrelevant)", async () => {
+    const paths = await writeCodeFixture(AGENT_INFO.version);
+    await writeFile(
+      path.join(paths.distDir, "code-fingerprint.json"),
+      JSON.stringify({ fingerprint: "aaaa", fileCount: 1 }),
+    );
+    let restarted = false;
+    const hub = await startTestHub({
+      hubFingerprint: "aaaa",
+      codePaths: paths,
+      onRestart: () => {
+        restarted = true;
+      },
+    });
+    const res = await fetch(upgradeUrl(hub), { method: "POST", headers: auth });
+    expect(await res.json()).toMatchObject({ restarting: false, reason: "up-to-date" });
+    await new Promise((r) => setTimeout(r, 800));
+    expect(restarted).toBe(false);
   });
 
   it("restarts when dist was rebuilt without a version bump", async () => {


### PR DESCRIPTION
Two changes that keep a long-running hub honest about the code it runs:

- `fix(remote): widen Ghostty osascript open timeout to survive locked-screen AppleEvents` — the Ghostty AppleScript path only had the 3s `open` budget; on a locked screen with display sleep the AppleEvent round-trip can exceed it while still succeeding, so the hub spuriously fell back to a headless bridge (phone saw a timeout error, tab still opened after unlock). The osascript path now gets its own 10s budget.
- `feat(remote): hub staleness detection via dist content fingerprint with automatic upgrade pokes` — the hub's self-upgrade compared version numbers frozen from package.json, which lie across a release-merge/rebuild window, and mtimes, which can be preserved or skewed. `pnpm build` now hashes dist/*.js into `dist/code-fingerprint.json`; bridges advertise theirs at registration (lexically-higher wins, so coexisting dists cannot ping-pong the hub) and `/api/upgrade` checks it first. `pnpm build` and the npm postinstall hook poke `/api/upgrade` best-effort so the updater owns the restart (apt postinst convention).