### PR TITLE
feat(remote): terminate serve-origin CLI on last close and list skill commands per client

### DIFF
--- a/docs/REMOTE-CLIENTS.md
+++ b/docs/REMOTE-CLIENTS.md
@@ -442,6 +442,26 @@ Cross-instance note: if the same conversation is also registered by another
 bridge of the project, the hub's dedupe re-attaches it under that instance —
 close it there too.
 
+### Serve-origin instances: closing ends the CLI
+
+Everything above describes **editor-origin** bridges (retire-only). For
+`origin: "serve"` instances — the ones the hub incubated for remote
+session-create/resume — closing the LAST advertised conversation also
+TERMINATES the CLI that hosts it:
+
+- A **terminal TUI** bridge is taken down with one group signal to its whole
+  process tree (cli → martty → bridge); martty restores the TTY and exits
+  cleanly, and each terminal's own close-on-exit preference then takes the
+  window (default: closes in Terminal, iTerm2, Ghostty, Warp).
+- A **headless serve** bridge exits immediately (its idle timeout pulled
+  forward to zero).
+
+The instance disappears from `/api/instances` within one heartbeat. The
+conversation itself is still resumable later via
+`POST /api/instances` / `GET /api/projects/sessions` — closing ends the
+process, not the history. If other advertised conversations (or remote-created
+empty sessions) remain on the instance, it stays up.
+
 ## Renaming a session
 
 ```text
@@ -535,10 +555,16 @@ size, mtime}], truncated }`. Dotfiles are included — filter client-side.
 ## Slash-command handling
 
 Only the commands the bridge advertises via `available_commands_update` (plus
-`skill`/`init` and `$`-skills) are treated as commands. Any other `/`-leading
+`skill`/`init` and skills) are treated as commands. Any other `/`-leading
 prompt — e.g. a pasted directory path — is delivered to the model as plain
 text with an invisible zero-width-space prefix; clients see the text verbatim
 in replay and echoes. Clients should not special-case this.
+
+Skill names are PER-CLIENT in the advertised list: editors that group
+visually (Zed) receive `$name` (e.g. `$tdd`), while martty and clients that
+send no `clientInfo` receive the bare `name` so their `/` completion menu
+surfaces skills at all. Both spellings route identically — `/tdd` and `/$tdd`
+are the same command.
 
 ## Tail replay and history pagination
 

--- a/src/handlers/io.ts
+++ b/src/handlers/io.ts
@@ -12,6 +12,7 @@ import { randomUUID } from "node:crypto";
 import type * as acp from "@agentclientprotocol/sdk";
 import { RequestError } from "@agentclientprotocol/sdk";
 
+import type { ClientRegistry } from "../remote/broadcast.js";
 import type { ZcodeAcpServer } from "../server.js";
 import { warn } from "../utils.js";
 
@@ -180,6 +181,48 @@ export function sendAvailableCommands(
 }
 
 /**
+ * Does this client see the `$` skill-name grouping? The prefix is a DISPLAY
+ * convention for editors (Zed groups skills visually under `$`); martty and
+ * unnamed clients (the remote App sends no clientInfo) surface commands by
+ * typing `/` — a `$`-prefixed name never matches there, hiding every skill.
+ * Both spellings route identically (slash.ts accepts bare and `$`-prefixed
+ * skill names), so per-client display is safe.
+ */
+export function skillPrefixForClient(name: string | null): string {
+  if (name === null || name.toLowerCase().includes("martty")) return "";
+  return "$";
+}
+
+/**
+ * Send `available_commands_update` with a PER-CLIENT command list: skill names
+ * keep their `$` prefix for grouping-capable editors and lose it for martty /
+ * unnamed clients (see `skillPrefixForClient`).
+ */
+export function sendAvailableCommandsPerClient(
+  registry: ClientRegistry,
+  sessionId: string,
+  commands: ReadonlyArray<SlashCommandEntry>,
+): Promise<void> {
+  return registry.notifyEach("session/update", (name) => {
+    const prefix = skillPrefixForClient(name);
+    return {
+      sessionId,
+      update: {
+        sessionUpdate: "available_commands_update",
+        availableCommands: commands.map((c) => {
+          const out: { name: string; description: string; input?: { hint: string } } = {
+            name: prefix === "" && c.name.startsWith("$") ? c.name.slice(1) : c.name,
+            description: c.description,
+          };
+          if (c.input) out.input = c.input;
+          return out;
+        }),
+      },
+    };
+  });
+}
+
+/**
  * Per-session pending deferred-notification timeouts. Tracks the timers from
  * repeated `sendAvailableCommandsDeferred` calls so a newer call can cancel
  * the older call's still-pending timers. Without this, a slow timer (e.g.
@@ -205,7 +248,7 @@ const activeDeferredTimeouts = new Map<string, Set<ReturnType<typeof setTimeout>
  * timer overwrite the newest command list.
  */
 export function sendAvailableCommandsDeferred(
-  cx: acp.AgentContext,
+  registry: ClientRegistry,
   sessionId: string,
   commands: ReadonlyArray<SlashCommandEntry>,
 ): void {
@@ -221,7 +264,7 @@ export function sendAvailableCommandsDeferred(
 
   for (const delay of [50, 300, 1000]) {
     const t = setTimeout(() => {
-      sendAvailableCommands(cx, sessionId, commands)
+      sendAvailableCommandsPerClient(registry, sessionId, commands)
         .catch((e) => {
           warn(
             `available_commands_update failed (sid=${sessionId}, delay=${delay}): ` +

--- a/src/handlers/slash.ts
+++ b/src/handlers/slash.ts
@@ -39,6 +39,7 @@ import { applyModelSwitch } from "../config/runtime-model.js";
 import { emitConfigOptionUpdate } from "../config/options.js";
 import { formatMcpServers, loadMcpServers } from "../config/mcp-discovery.js";
 import { loadPluginCommands } from "../config/plugin-commands.js";
+import { loadSkillCommands } from "../config/skill-discovery.js";
 import { messages } from "../i18n.js";
 import { formatQuota, queryQuota } from "../quota/index.js";
 import { CONFIG_DISPATCH, SLASH_COMMANDS, warn } from "../utils.js";
@@ -102,12 +103,19 @@ const PASSTHROUGH_COMMANDS = new Set([
 let knownCommands: Set<string> | null = null;
 function knownCommandSet(): Set<string> {
   if (!knownCommands) {
-    knownCommands = new Set<string>([
+    const names = [
       ...SLASH_COMMANDS.map((c) => c.name),
       ...PASSTHROUGH_COMMANDS,
       ...UNSUPPORTED_TUI_COMMANDS,
       ...loadPluginCommands().map((c) => c.name),
-    ]);
+      // Skills travel BOTH spellings: `$name` for grouping-capable editors
+      // (Zed) and bare `name` for martty / the remote App (whose `/` menus
+      // cannot match a `$`-prefixed name). Both are passthrough to the model.
+      ...loadSkillCommands().flatMap((c) =>
+        c.name.startsWith("$") ? [c.name, c.name.slice(1)] : [c.name],
+      ),
+    ];
+    knownCommands = new Set<string>(names);
   }
   return knownCommands;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,7 +158,7 @@ function buildAgentApp(server: ZcodeAcpServer, allCommands: ReturnType<typeof bu
       .onRequest("session/new", async (ctx) => {
         const result = await newSession(server, ctx.params, ctx.client);
         for (const sid of server.sessionAliases(result.sessionId)) {
-          sendAvailableCommandsDeferred(server.clients.broadcast(), sid, allCommands);
+          sendAvailableCommandsDeferred(server.clients, sid, allCommands);
         }
         return result;
       })
@@ -166,7 +166,7 @@ function buildAgentApp(server: ZcodeAcpServer, allCommands: ReturnType<typeof bu
       .onRequest("session/resume", async (ctx) => {
         const result = await resumeSession(server, ctx.params, server.clients.broadcast());
         for (const sid of server.sessionAliases(ctx.params.sessionId)) {
-          sendAvailableCommandsDeferred(server.clients.broadcast(), sid, allCommands);
+          sendAvailableCommandsDeferred(server.clients, sid, allCommands);
         }
         // A client that (re)connects catches up via resume/load; any interaction
         // request still waiting for an answer is re-sent to it so a question
@@ -177,7 +177,7 @@ function buildAgentApp(server: ZcodeAcpServer, allCommands: ReturnType<typeof bu
       .onRequest("session/load", async (ctx) => {
         const result = await loadSession(server, ctx.params, server.clients.broadcast());
         for (const sid of server.sessionAliases(ctx.params.sessionId)) {
-          sendAvailableCommandsDeferred(server.clients.broadcast(), sid, allCommands);
+          sendAvailableCommandsDeferred(server.clients, sid, allCommands);
         }
         resendPendingInteractions(server, ctx.client, ctx.params.sessionId);
         return result;

--- a/src/remote/broadcast.ts
+++ b/src/remote/broadcast.ts
@@ -20,7 +20,7 @@
 
 import type * as acp from "@agentclientprotocol/sdk";
 
-import { warn } from "../utils.js";
+import { clientConnectionRoot, warn } from "../utils.js";
 
 /** The AgentContext surface the bridge actually calls. */
 export interface ClientLike {
@@ -54,6 +54,8 @@ interface RaceWinner {
 export class ClientRegistry {
   private readonly clients = new Set<ClientLike>();
   private proxy: acp.AgentContext | null = null;
+  /** clientInfo name per connection root (see `nameConnection`). */
+  private readonly names = new WeakMap<object, string>();
 
   add(cx: ClientLike): void {
     this.clients.add(cx);
@@ -65,6 +67,52 @@ export class ClientRegistry {
 
   get size(): number {
     return this.clients.size;
+  }
+
+  /**
+   * Record a connection's `initialize` clientInfo name, keyed by the SDK's
+   * per-connection root (same identity `notifyOthers` filters on) so payloads
+   * can be tailored per client (`notifyEach`). Unnamed clients (the remote
+   * App sends no clientInfo) read as null — distinct from "" only in that an
+   * initialize was never seen for the connection.
+   */
+  nameConnection(cx: ClientLike, name: string): void {
+    const root = clientConnectionRoot(cx);
+    if (typeof root === "object" && root !== null) this.names.set(root, name);
+  }
+
+  /** Name recorded at initialize for this connection, null when none. */
+  nameOf(cx: ClientLike): string | null {
+    const root = clientConnectionRoot(cx);
+    if (typeof root !== "object" || root === null) return null;
+    // "" (initialize seen, no clientInfo — the remote App) reads as null too.
+    return this.names.get(root) || null;
+  }
+
+  /**
+   * Fan out a notification whose payload is built PER CLIENT from its recorded
+   * name (null payload = skip that client). Used for `available_commands_update`:
+   * editors keep the `$` skill grouping, martty and unnamed clients get the
+   * bare names so their `/` completion menu shows skills at all.
+   */
+  async notifyEach(
+    method: string,
+    build: (name: string | null) => Record<string, unknown> | null,
+  ): Promise<void> {
+    const results = await Promise.allSettled(
+      this.snapshot().map((cx) => {
+        const params = build(this.nameOf(cx));
+        return params ? cx.notify(method, params) : Promise.resolve();
+      }),
+    );
+    for (const r of results) {
+      if (r.status === "rejected") {
+        warn(
+          `broadcast: notifyEach ${method} failed on one client: ` +
+            `${r.reason instanceof Error ? r.reason.message : String(r.reason)}`,
+        );
+      }
+    }
   }
 
   /** Stable broadcast proxy satisfying the `AgentContext` call surface. */

--- a/src/remote/hub-server.ts
+++ b/src/remote/hub-server.ts
@@ -384,6 +384,11 @@ export function terminalTuiScript(cwd: string, cliJs: string, env: NodeJS.Proces
     ...(env.ZCODE_ACP_TAB_TITLE !== undefined
       ? [`printf '\\033]0;%s\\007' "$ZCODE_ACP_TAB_TITLE"`]
       : []),
+    // $$ survives exec as the cli's pid — and as the terminal's foreground
+    // process-group leader it names the whole TUI tree (cli → martty → bridge).
+    // Remote session-close SIGTERMs this GROUP to tear the window's CLI down
+    // (see session-close-endpoint.ts); a bare pid would orphan the Rust host.
+    `export ZCODE_ACP_TUI_CLI_PID=$$`,
     `exec ${execLine}`,
     "",
   ].join("\n");
@@ -967,6 +972,12 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
       ZCODE_ACP_REMOTE_ORIGIN: "serve",
       ZCODE_ACP_REMOTE_PIN_CWD: "1",
     };
+    // The TUI CLI pid names ONE process tree and must never leak across
+    // trees: a hub born inside a TUI (or re-spawned by one of its bridges)
+    // carries it in process.env, and a bridge it later incubates headless
+    // would SIGTERM that UNRELATED tree's process group on its last close.
+    // The terminal script re-exports its own live $$ for real TUI spawns.
+    delete env.ZCODE_ACP_TUI_CLI_PID;
     if (kind === "resume") {
       // ADR-0017: the requested session rides the env — terminalTuiScript
       // exports every ZCODE_ACP_* var into the terminal's fresh shell, so the

--- a/src/remote/session-close-endpoint.ts
+++ b/src/remote/session-close-endpoint.ts
@@ -20,6 +20,7 @@
  */
 
 import type { IncomingMessage, ServerResponse } from "node:http";
+import process from "node:process";
 
 import type { ZcodeAcpServer } from "../server.js";
 import { log } from "../utils.js";
@@ -39,6 +40,79 @@ function sendJson(res: ServerResponse, code: number, body: Record<string, unknow
   res.end(payload);
 }
 
+/** Grace before the bridge exits itself when the TUI group signal missed. */
+const SELF_EXIT_MS = 1_500;
+
+export interface ServeTerminateDecision {
+  /** Terminate this bridge once the close response has flushed. */
+  terminate: boolean;
+  /** Foreground process-group id of the incubated TUI tree; absent = headless. */
+  tuiPgid?: number;
+}
+
+/**
+ * Should closing a session TERMINATE this bridge? Only for remote-incubated
+ * instances (ZCODE_ACP_REMOTE_ORIGIN=serve, ADR-0016): their CLI was spawned
+ * for exactly this conversation, so the last close ends it — the TUI window's
+ * whole process tree (cli → martty → bridge) via one group signal, or a plain
+ * self-exit for the headless serve bridge (pulling its idle exit forward).
+ * Editor-origin bridges return null and keep the retire-only semantics.
+ * Pure — exported for unit tests.
+ */
+export function serveTerminateDecision(
+  advertisedCount: number,
+  env: { ZCODE_ACP_REMOTE_ORIGIN?: string; ZCODE_ACP_TUI_CLI_PID?: string } = process.env,
+): ServeTerminateDecision | null {
+  if ((env.ZCODE_ACP_REMOTE_ORIGIN ?? "").trim() !== "serve") return null;
+  if (advertisedCount > 0) return { terminate: false };
+  const pid = Number.parseInt((env.ZCODE_ACP_TUI_CLI_PID ?? "").trim(), 10);
+  return {
+    terminate: true,
+    ...(Number.isInteger(pid) && pid > 0 ? { tuiPgid: pid } : {}),
+  };
+}
+
+/**
+ * Advertised-session count after a close: summaries with activity plus
+ * REMOTE-created empty placeholders (mirrors the /status membership rule).
+ */
+function advertisedSessionCount(server: ZcodeAcpServer): number {
+  let count = server.remoteCreatedSessions.size;
+  for (const [sid, summary] of server.sessionSummaries) {
+    if (summary.hasActivity && !server.remoteCreatedSessions.has(sid)) count++;
+  }
+  return count;
+}
+
+/**
+ * Tear the incubated CLI down AFTER the close response flushed (the phone
+ * must get its 200 before the bridge dies). The group SIGTERM covers the
+ * martty Rust host too — a bare kill of one pid orphans it; martty's client
+ * converts the signal to an orderly exit and restores the TTY, the tree ends
+ * with exit code 0, and each terminal's own close-on-exit pref takes the
+ * window. The self-exit timer is the fallback for the headless serve bridge
+ * and for a terminal whose launch path broke process-group membership.
+ */
+function terminateAfterFlush(decision: ServeTerminateDecision, res: ServerResponse): void {
+  const run = () => {
+    if (decision.tuiPgid !== undefined) {
+      try {
+        process.kill(-decision.tuiPgid, "SIGTERM");
+        log(`remote: last session closed — SIGTERM to TUI process group ${decision.tuiPgid}`);
+      } catch (e) {
+        log(
+          `remote: TUI group signal failed ` +
+            `(${e instanceof Error ? e.message : String(e)}) — exiting this bridge instead`,
+        );
+      }
+    }
+    setTimeout(() => process.exit(0), SELF_EXIT_MS);
+  };
+  // 'finish' fires asynchronously after end(), so attaching here never misses.
+  if (res.writableEnded) res.once("finish", run);
+  else run();
+}
+
 async function handleClose(
   server: ZcodeAcpServer,
   req: IncomingMessage,
@@ -48,7 +122,10 @@ async function handleClose(
   // Consume any request body so the client's connection drains cleanly.
   req.resume();
 
-  if (!server.sessionSummaries.has(sessionId)) {
+  // An empty REMOTE-created placeholder (no turn yet) has no summary but IS
+  // advertised by discovery — it must be closable too, or it blocks the
+  // last-close CLI termination forever (advertisedSessionCount never drops).
+  if (!server.sessionSummaries.has(sessionId) && !server.remoteCreatedSessions.has(sessionId)) {
     sendText(res, 404, "unknown session");
     return;
   }
@@ -58,6 +135,7 @@ async function handleClose(
     return;
   }
   server.sessionSummaries.delete(sessionId);
+  server.remoteCreatedSessions.delete(sessionId);
   // Evict the backend's resident runtime so the conversation truly stops (no
   // background turn keeps it alive); the session file stays on disk and
   // session/list / a later resume still work. Best-effort — a bridge with no
@@ -77,7 +155,9 @@ async function handleClose(
     }
   }
   log(`remote: session ${sessionId.slice(0, 8)} closed from remote (discovery retired)`);
+  const terminate = serveTerminateDecision(advertisedSessionCount(server));
   sendJson(res, 200, { ok: true });
+  if (terminate?.terminate) terminateAfterFlush(terminate, res);
 }
 
 /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -614,6 +614,7 @@ export class ZcodeAcpServer {
   ): Promise<acp.InitializeResponse> {
     const clientInfo = (params.clientInfo as { name?: string; version?: string } | null) ?? null;
     this.clientName = clientInfo?.name ?? null;
+    if (client) this.clients.nameConnection(client, this.clientName ?? "");
     if ((this.clientName ?? "").toLowerCase().includes("martty")) {
       this.marttyClientSeen = true;
       const root = clientConnectionRoot(client);

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -190,13 +190,20 @@ export function seedMarttyQuotaPlugin(env: NodeJS.ProcessEnv = process.env): boo
 /** Resolve on child exit; forward terminal signals while it runs. */
 function settle(child: ChildProcess): Promise<number | null> {
   return new Promise((resolve) => {
-    const forward = (sig: NodeJS.Signals) => child.kill(sig);
+    let forwardedTerminate = false;
+    const forward = (sig: NodeJS.Signals) => {
+      if (sig === "SIGTERM") forwardedTerminate = true;
+      child.kill(sig);
+    };
     process.on("SIGINT", forward);
     process.on("SIGTERM", forward);
-    child.once("exit", (code) => {
+    child.once("exit", (code, signal) => {
       process.off("SIGINT", forward);
       process.off("SIGTERM", forward);
-      resolve(code);
+      // A SIGTERM we forwarded (remote session-close hits the whole process
+      // group) is an intentional shutdown: resolve clean so the exec'd shell
+      // exits 0 and terminals with "close on clean exit" take the window.
+      resolve(code ?? (forwardedTerminate && signal === "SIGTERM" ? 0 : 1));
     });
     child.once("error", (err) => {
       process.off("SIGINT", forward);

--- a/tests/hub.test.ts
+++ b/tests/hub.test.ts
@@ -1169,7 +1169,11 @@ describe("hub remote session-create (ADR-0014)", () => {
   });
 
   it("spawns a serve bridge in the project cwd and returns its instance once registered", async () => {
+    // Simulate a hub born inside a TUI tree: the foreign CLI pid rides
+    // process.env and the incubation must strip it (see assertion below).
+    process.env.ZCODE_ACP_TUI_CLI_PID = "999999";
     const hub = await startTestHub({ spawnServe: spawnServeSpy() });
+    delete process.env.ZCODE_ACP_TUI_CLI_PID;
     const pending = fetch(`http://127.0.0.1:${hub.port}/api/instances`, {
       method: "POST",
       headers: { ...auth, "Content-Type": "application/json" },
@@ -1190,6 +1194,10 @@ describe("hub remote session-create (ADR-0014)", () => {
     expect(spawnCalls[0]!.env.ZCODE_ACP_REMOTE_PIN_CWD).toBe("1");
     // Tab title default: no conversation to name, so the project names it.
     expect(spawnCalls[0]!.env.ZCODE_ACP_TAB_TITLE).toBe("demo");
+    // The TUI CLI pid is process-tree-local: a hub born inside one TUI tree
+    // must not pass a foreign pid to bridges it incubates (a headless serve
+    // bridge would SIGTERM that unrelated tree on its last session close).
+    expect(spawnCalls[0]!.env.ZCODE_ACP_TUI_CLI_PID).toBeUndefined();
     await registerServeBridge(hub, PROJECT);
     const res = await pending;
     expect(res.status).toBe(200);
@@ -1710,6 +1718,15 @@ describe("hub terminal-TUI session resume (ADR-0017)", () => {
     expect(withTitle).toContain("export ZCODE_ACP_TAB_TITLE='Fix the login bug'");
     expect(withTitle).toContain(`printf '\\033]0;%s\\007' "$ZCODE_ACP_TAB_TITLE"`);
     expect(terminalTuiScript(PROJECT, "/opt/cli.js", {})).not.toContain("033]0");
+  });
+
+  it("embeds the shell's pid as the TUI CLI pid for remote-close termination", () => {
+    // $$ survives exec as the cli's pid — the terminal's foreground process-
+    // group leader. Remote session-close SIGTERMs that group to end the whole
+    // TUI tree (cli → martty → bridge) when the last conversation closes.
+    const body = terminalTuiScript(PROJECT, "/opt/cli.js", {});
+    expect(body).toContain("export ZCODE_ACP_TUI_CLI_PID=$$");
+    expect(body.indexOf("ZCODE_ACP_TUI_CLI_PID")).toBeLessThan(body.indexOf("exec "));
   });
 
   it("titles the resume tab with the conversation title from the live serve bridge", async () => {

--- a/tests/remote-broadcast.test.ts
+++ b/tests/remote-broadcast.test.ts
@@ -239,3 +239,54 @@ describe("echoUserPromptToOthers", () => {
     expect(phone.notifies).toHaveLength(0);
   });
 });
+
+describe("per-client naming and notifyEach", () => {
+  it("builds a distinct payload per recorded client name (null payload skips)", async () => {
+    const registry = new ClientRegistry();
+    const zed = fakeClient();
+    const app = fakeClient();
+    const martty = fakeClient();
+    registry.add(zed.cx);
+    registry.add(app.cx);
+    registry.add(martty.cx);
+    registry.nameConnection(zed.cx, "Zed");
+    registry.nameConnection(app.cx, ""); // remote App: initialize with no clientInfo
+    registry.nameConnection(martty.cx, "martty");
+
+    await registry.notifyEach("session/update", (name) => ({
+      sessionId: "s1",
+      update: { grouped: name !== null && !name.toLowerCase().includes("martty") },
+    }));
+
+    expect((zed.notifies[0]![1] as { update: { grouped: boolean } }).update.grouped).toBe(true);
+    expect((app.notifies[0]![1] as { update: { grouped: boolean } }).update.grouped).toBe(false);
+    expect((martty.notifies[0]![1] as { update: { grouped: boolean } }).update.grouped).toBe(false);
+  });
+
+  it("nameOf reads null for unnamed or unseen connections", () => {
+    const registry = new ClientRegistry();
+    const named = fakeClient();
+    const unnamed = fakeClient();
+    const unseen = fakeClient();
+    registry.add(named.cx);
+    registry.add(unnamed.cx);
+    registry.add(unseen.cx);
+    registry.nameConnection(named.cx, "Zed");
+    registry.nameConnection(unnamed.cx, "");
+
+    expect(registry.nameOf(named.cx)).toBe("Zed");
+    expect(registry.nameOf(unnamed.cx)).toBeNull();
+    expect(registry.nameOf(unseen.cx)).toBeNull();
+  });
+});
+
+describe("skillPrefixForClient", () => {
+  it("keeps $ grouping for editors, strips it for martty and unnamed clients", async () => {
+    const { skillPrefixForClient } = await import("../src/handlers/io.js");
+    expect(skillPrefixForClient("Zed")).toBe("$");
+    expect(skillPrefixForClient("JetBrains")).toBe("$");
+    expect(skillPrefixForClient("martty")).toBe("");
+    expect(skillPrefixForClient("Martty TUI")).toBe("");
+    expect(skillPrefixForClient(null)).toBe("");
+  });
+});

--- a/tests/remote-session-close.test.ts
+++ b/tests/remote-session-close.test.ts
@@ -11,7 +11,10 @@ import { createServer, type Server } from "node:http";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { createSessionCloseHandler } from "../src/remote/session-close-endpoint.js";
+import {
+  createSessionCloseHandler,
+  serveTerminateDecision,
+} from "../src/remote/session-close-endpoint.js";
 import { collectStatus } from "../src/remote/status-endpoint.js";
 import { collectSessions } from "../src/remote/endpoint.js";
 import { ZcodeAcpServer } from "../src/server.js";
@@ -125,6 +128,23 @@ describe("session close endpoint", () => {
     expect(server.backend).toBeNull(); // close never spawned one
   });
 
+  it("closes an empty remote-created placeholder (no summary, still advertised)", async () => {
+    // Regression: the 404 guard only checked sessionSummaries, so a
+    // phone-minted placeholder could never be closed — it stayed advertised
+    // forever and blocked the serve-origin last-close CLI termination.
+    const server = new ZcodeAcpServer();
+    const acpSid = randomUUID();
+    server.remoteCreatedSessions.add(acpSid);
+    const base = await bootClose(server);
+
+    expect((await fetch(`${base}/sessions/${acpSid}/close`, { method: "POST" })).status).toBe(200);
+    expect(server.remoteCreatedSessions.has(acpSid)).toBe(false);
+    // With nothing else advertised, a serve-origin bridge WOULD now terminate.
+    expect(serveTerminateDecision(0, { ZCODE_ACP_REMOTE_ORIGIN: "serve" })).toEqual({
+      terminate: true,
+    });
+  });
+
   it("a closed session reappears once the editor touches it again (self-healing)", async () => {
     const server = new ZcodeAcpServer();
     const { acpSid, zcodeSid } = seedSession(server, { title: "still open in editor" });
@@ -153,5 +173,57 @@ describe("session close endpoint", () => {
     // hasActivity unset) — the session must stay hidden until real use.
     server.registerSession(acpSid, zcodeSid);
     expect(collectStatus(server).sessions).toHaveLength(0);
+  });
+});
+
+describe("serve-origin termination decision (remote close ends the CLI)", () => {
+  it("editor-origin bridges never terminate — retire-only semantics hold", () => {
+    expect(serveTerminateDecision(0, { ZCODE_ACP_TUI_CLI_PID: "4242" })).toBeNull();
+  });
+
+  it("a TUI bridge terminates on the LAST close, targeting its process group", () => {
+    expect(
+      serveTerminateDecision(1, {
+        ZCODE_ACP_REMOTE_ORIGIN: "serve",
+        ZCODE_ACP_TUI_CLI_PID: "4242",
+      }),
+    ).toEqual({ terminate: false });
+
+    expect(
+      serveTerminateDecision(0, {
+        ZCODE_ACP_REMOTE_ORIGIN: "serve",
+        ZCODE_ACP_TUI_CLI_PID: "4242",
+      }),
+    ).toEqual({ terminate: true, tuiPgid: 4242 });
+  });
+
+  it("a headless serve bridge self-exits (no TUI pid) and a stale pid is ignored", () => {
+    expect(serveTerminateDecision(0, { ZCODE_ACP_REMOTE_ORIGIN: "serve" })).toEqual({
+      terminate: true,
+    });
+    expect(
+      serveTerminateDecision(0, {
+        ZCODE_ACP_REMOTE_ORIGIN: "serve",
+        ZCODE_ACP_TUI_CLI_PID: "not-a-pid",
+      }),
+    ).toEqual({ terminate: true });
+  });
+
+  it("remote-created empty placeholders count as advertised — close keeps the CLI alive", async () => {
+    const server = new ZcodeAcpServer();
+    // One live TUI conversation + one phone-created empty session.
+    const live = seedSession(server);
+    const empty = randomUUID();
+    server.remoteCreatedSessions.add(empty);
+    const base = await bootClose(server);
+
+    expect((await fetch(`${base}/sessions/${live.acpSid}/close`, { method: "POST" })).status).toBe(
+      200,
+    );
+    // The empty placeholder still holds the CLI up.
+    expect(serveTerminateDecision(1, { ZCODE_ACP_REMOTE_ORIGIN: "serve" })).toEqual({
+      terminate: false,
+    });
+    expect(server.remoteCreatedSessions.has(empty)).toBe(true);
   });
 });

--- a/tests/slash-text.test.ts
+++ b/tests/slash-text.test.ts
@@ -120,6 +120,21 @@ describe("neutralizeSlashText", () => {
     expect(f("/$tdd args")).toBe("/$tdd args");
   });
 
+  it("leaves bare skill names unchanged (martty / remote App spelling)", async () => {
+    // Seed one skill in the mocked fs so its bare name enters the known set
+    // (loadSkillCommands reads the same mock as loadPluginCommands).
+    mockDirs.add(path.join(homedir(), ".zcode", "skills"));
+    mockDirs.add(path.join(homedir(), ".zcode", "skills", "tdd"));
+    mockFiles.set(
+      path.join(homedir(), ".zcode", "skills", "tdd", "SKILL.md"),
+      "---\nname: tdd\ndescription: Test-driven development\n---\nbody",
+    );
+    const f = await load();
+    expect(f("/tdd fix the bug")).toBe("/tdd fix the bug");
+    // And the $-spelling still routes identically.
+    expect(f("/$tdd fix the bug")).toBe("/$tdd fix the bug");
+  });
+
   it("leaves discovered plugin commands unchanged", async () => {
     const f = await load();
     expect(f("/demo-cmd x")).toBe("/demo-cmd x");


### PR DESCRIPTION
## Summary

Two user-facing fixes for the remote/CLI surfaces:

### 1. Remote close actually terminates the CLI (serve-origin bridges)
- Closing the **last advertised session** on a hub-incubated bridge now ends its CLI: the terminal TUI tree (cli → martty → bridge) via one process-group SIGTERM (martty restores the TTY, the chain exits 0, each terminal's own close-on-exit preference takes the window); the headless serve bridge exits immediately (idle timeout pulled forward).
- Editor-origin bridges are unchanged — retire-only semantics (ADR-0006).
- The TUI CLI pid rides the incubation script (`$$` survives exec as the foreground process-group leader) and is **stripped from the hub incubation env** — a hub born inside one TUI tree must never hand a foreign pid to a headless bridge (adversarial-review finding).
- Empty remote-created placeholders are now closable (they previously 404'd and blocked last-close termination forever).

### 2. Skill commands are visible in CLI/phone menus
- `available_commands_update` now carries a **per-client** list: editors (Zed) keep the `$` grouping; martty and unnamed clients (the remote App sends no `clientInfo`) get bare names — a `$`-prefixed name never matched their `/` completion, hiding every skill.
- Both spellings (`/tdd` and `/$tdd`) route identically; old cached command lists keep working.

## Test plan
- 1043 tests pass (76 files), incl. new cases: placeholder close, pid strip, notifyEach per-client payloads, bare-name routing
- End-to-end probe against a live serve bridge: Zed-shaped client received 58 `$`-prefixed skills, unnamed client received the same 58 bare-named
- Full typecheck/lint/build clean
