### PR TITLE
feat(remote): ordered terminal preference list with chained fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,8 +117,12 @@ ZCode protocol types into ACP notifications directly — always translate.
   merge-at-write) — never `writeFileSync` the store path directly. Tests run
   under a hermetic temp HOME (`tests/setup/hermetic-home.ts`, set by direct
   `process.env.HOME` assignment so `vi.unstubAllEnvs()` cannot leak back to
-  the real HOME); keep new tests store-safe by default and don't bypass the
-  setup file.
+  the real HOME); the same setup DELETES `ZCODE_ACP_REMOTE_ORIGIN` /
+  `ZCODE_ACP_TUI_CLI_PID`, because a vitest run started from inside an
+  incubated TUI inherits them and the session-close endpoint would signal the
+  REAL window's process tree from a test (observed live 2026-09-08 — the run
+  killed its own host window). Keep new tests store-safe by default and don't
+  bypass the setup file.
 - **AGENTS.md is workspace-scoped**: the global `~/.zcode/AGENTS.md` also exists;
   this file takes precedence for this repo.
 - **WS proxy frame type**: the SDK's WS server drops non-text frames, and
@@ -242,23 +246,23 @@ ZCode protocol types into ACP notifications directly — always translate.
     the old permanent mute left the model on a bare EPERM with no way out. Well-known system temp trees (/tmp → /private/tmp,
     /var/tmp, /private/var/folders) are DEFAULT-ALLOWED — tools hardcode /tmp
     and $TMPDIR names only the per-user /var/folders leaf; don't "tighten"
-  them back into popup storms (verify-sandbox.sh fixtures moved to HOME for
-  the same reason). Arming is dual-switch: `ZCODE_ACP_SANDBOX=1` globally
-  or `enabled: true` in that config per project (auto-created template ships
-  `false`; a malformed or non-object config reads as enabled — fail closed,
-  never rewrite the user's bytes). `server.backendSandboxed` is the process
-  fact the EPERM flow gates on — not `sandboxActive()`, which is the config
-  wish re-checked per call (a mid-run flip to `true` is applied by
-  `applySandboxFlip()` at prompt entry; flipping back only drops the wrap on
-  the next respawn). Hardening invariants from adversarial review — do not
-  regress: profiles go through `armSandboxArgv()` (fresh mkdtemp dir under
-  the managed root `~/.zcode-acp/sandbox/`, pid-encoded `p-<pid>-*`, + O_EXCL
-  + the profile denies its own dir AND the whole root last; the root must
-  stay off every write-allow list — every agent-writable path is writable by
-  prior sandboxed generations too, so a $TMPDIR profile is raceable across
-  generations; each arm sweeps dead-pid dirs and legacy `~/.zcode-acp-sbx-*`
-  HOME siblings, which the per-bridge chain-cleanup used to leak one per
-  restart), and
+    them back into popup storms (verify-sandbox.sh fixtures moved to HOME for
+    the same reason). Arming is dual-switch: `ZCODE_ACP_SANDBOX=1` globally
+    or `enabled: true` in that config per project (auto-created template ships
+    `false`; a malformed or non-object config reads as enabled — fail closed,
+    never rewrite the user's bytes). `server.backendSandboxed` is the process
+    fact the EPERM flow gates on — not `sandboxActive()`, which is the config
+    wish re-checked per call (a mid-run flip to `true` is applied by
+    `applySandboxFlip()` at prompt entry; flipping back only drops the wrap on
+    the next respawn). Hardening invariants from adversarial review — do not
+    regress: profiles go through `armSandboxArgv()` (fresh mkdtemp dir under
+    the managed root `~/.zcode-acp/sandbox/`, pid-encoded `p-<pid>-*`, + O_EXCL
+  * the profile denies its own dir AND the whole root last; the root must
+    stay off every write-allow list — every agent-writable path is writable by
+    prior sandboxed generations too, so a $TMPDIR profile is raceable across
+    generations; each arm sweeps dead-pid dirs and legacy `~/.zcode-acp-sbx-*`
+    HOME siblings, which the per-bridge chain-cleanup used to leak one per
+    restart), and
     the config must pass the integrity check before the bridge persists
     through it (symlink/hardlink pierces the deny island; a config read as
     armed then EACCES/ENOTDIR/vanished also reads as armed — falling back to

--- a/src/config/options.ts
+++ b/src/config/options.ts
@@ -22,7 +22,7 @@ import {
   ZCODE_CREDS_PATH,
 } from "../utils.js";
 import type { ZcodeAcpServer } from "../server.js";
-import { sendSessionUpdate } from "../handlers/io.js";
+import { sendSessionUpdate, sendSessionUpdateToOthers } from "../handlers/io.js";
 
 interface ProviderModelsJson {
   [modelId: string]: { limit?: { context?: number } } | undefined;
@@ -421,6 +421,10 @@ export async function setConfigOption(
 /** Emit a config_option_update (+ current_mode_update for mode) after a change.
  *  Returns the rebuilt options so the caller can include them in the response.
  *
+ *  Every payload is ALSO broadcast to the other attached clients (the CLI
+ *  window when the switch came from the phone, and vice versa) — a settings
+ *  change is per-session state, not per-connection.
+ *
  *  For model switches, also emit a usage_update with the NEW model's context
  *  window (from config.json) so the editor's context bar refreshes immediately
  *  instead of waiting for the next turn's UsageDelta. */
@@ -432,16 +436,20 @@ export async function emitConfigOptionUpdate(
   kind: "model" | "mode" | "thought",
 ): Promise<acp.SessionConfigOption[]> {
   const options = await buildConfigOptions(server, zcodeSid, clientConnectionRoot(cx));
-  await sendSessionUpdate(cx, acpSid, {
+  const configUpdate: acp.SessionUpdate = {
     sessionUpdate: "config_option_update",
     configOptions: options,
-  });
+  };
+  await sendSessionUpdate(cx, acpSid, configUpdate);
+  sendSessionUpdateToOthers(server, cx, acpSid, configUpdate);
   if (kind === "mode") {
     const modes = await buildModes(server, zcodeSid);
-    await sendSessionUpdate(cx, acpSid, {
+    const modeUpdate: acp.SessionUpdate = {
       sessionUpdate: "current_mode_update",
       currentModeId: modes.currentModeId,
-    });
+    };
+    await sendSessionUpdate(cx, acpSid, modeUpdate);
+    sendSessionUpdateToOthers(server, cx, acpSid, modeUpdate);
   }
   if (kind === "model") {
     // Refresh the context bar: the backend's projection.contextWindow lags
@@ -457,11 +465,13 @@ export async function emitConfigOptionUpdate(
       const modelOpt = options.find((o) => o.id === "model");
       const { providerId, modelId } = parseModelValue(String(modelOpt?.currentValue ?? ""));
       const size = modelContextWindow(providerId, modelId);
-      await sendSessionUpdate(cx, acpSid, {
+      const usageUpdate: acp.SessionUpdate = {
         sessionUpdate: "usage_update",
         used,
         size,
-      });
+      };
+      await sendSessionUpdate(cx, acpSid, usageUpdate);
+      sendSessionUpdateToOthers(server, cx, acpSid, usageUpdate);
     } catch (e) {
       log(
         `options: usage_update after model switch failed (${e instanceof Error ? e.message : String(e)})`,

--- a/src/config/user-config.ts
+++ b/src/config/user-config.ts
@@ -27,6 +27,12 @@ import { warn } from "../utils.js";
 export interface TerminalPrefs {
   /** false → remote session-create stays headless (no visible window). */
   enabled?: boolean;
+  /**
+   * Ordered terminal preference list — the hub tries them in order (a launch
+   * failure or a window that never registers moves down the list) and only
+   * goes headless once every entry failed. Names resolve like `app`.
+   */
+  terminals?: string[];
   /** Terminal app name (Terminal, iTerm, wezterm, kitty, alacritty, ghostty, …). */
   app?: string;
   /** Shell command template; `{script}` is replaced with the quoted script path. */
@@ -74,7 +80,9 @@ export function loadUserConfig(env: NodeJS.ProcessEnv = process.env): UserConfig
   try {
     parsed = JSON.parse(raw);
   } catch (e) {
-    warn(`config: ${file} is not valid JSON — ignoring (${e instanceof Error ? e.message : String(e)})`);
+    warn(
+      `config: ${file} is not valid JSON — ignoring (${e instanceof Error ? e.message : String(e)})`,
+    );
     return {};
   }
   if (!isPlainObject(parsed)) {
@@ -89,7 +97,8 @@ export function loadUserConfig(env: NodeJS.ProcessEnv = process.env): UserConfig
   }
   const out: RemoteUserConfig = {};
   if (typeof remote["enabled"] === "boolean") out.enabled = remote["enabled"];
-  if (typeof remote["token"] === "string" && remote["token"].trim()) out.token = remote["token"].trim();
+  if (typeof remote["token"] === "string" && remote["token"].trim())
+    out.token = remote["token"].trim();
   for (const key of ["hubPort", "bridgePort"] as const) {
     const v = remote[key];
     if (v === undefined) continue;
@@ -106,7 +115,16 @@ export function loadUserConfig(env: NodeJS.ProcessEnv = process.env): UserConfig
   if (isPlainObject(terminal)) {
     const t: TerminalPrefs = {};
     if (typeof terminal["enabled"] === "boolean") t.enabled = terminal["enabled"];
-    if (typeof terminal["app"] === "string" && terminal["app"].trim()) t.app = terminal["app"].trim();
+    if (Array.isArray(terminal["terminals"])) {
+      const list = terminal["terminals"]
+        .filter((v): v is string => typeof v === "string" && !!v.trim())
+        .map((v) => v.trim());
+      if (list.length > 0) t.terminals = list;
+    } else if (terminal["terminals"] !== undefined) {
+      warn(`config: remote.terminal.terminals in ${file} is not an array of names — ignoring`);
+    }
+    if (typeof terminal["app"] === "string" && terminal["app"].trim())
+      t.app = terminal["app"].trim();
     if (typeof terminal["command"] === "string" && terminal["command"].trim()) {
       t.command = terminal["command"].trim();
     }

--- a/src/handlers/dispatch.ts
+++ b/src/handlers/dispatch.ts
@@ -27,7 +27,7 @@ import { messages } from "../i18n.js";
 import type { InternalEvent } from "../translators/types.js";
 import type { ZcodeAcpServer } from "../server.js";
 import { clientConnectionRoot, warn } from "../utils.js";
-import { sendSessionUpdate } from "./io.js";
+import { sendSessionUpdate, sendSessionUpdateToOthers } from "./io.js";
 
 /** True once the EPERM hint fired for this process — throttled to one shot. */
 let sandboxEpermHinted = false;
@@ -148,18 +148,24 @@ async function dispatchConfigChanged(
     }
     if (ev.mode !== undefined) setById("mode", ev.mode);
     if (ev.thought !== undefined) setById("thought", ev.thought);
-    await sendSessionUpdate(cx, acpSid, {
+    const configUpdate: acp.SessionUpdate = {
       sessionUpdate: "config_option_update",
       configOptions: options,
-    });
+    };
+    await sendSessionUpdate(cx, acpSid, configUpdate);
+    // Settings are per-session: the CLI's /model or the phone's dropdown must
+    // reach every OTHER attached client too.
+    sendSessionUpdateToOthers(server, cx, acpSid, configUpdate);
     if (ev.mode !== undefined) {
       // Mirror the advertised mode so turn-completion reconciliation
       // (emitModeIfChanged) doesn't re-emit the same value.
       server.lastMode.set(acpSid, ev.mode);
-      await sendSessionUpdate(cx, acpSid, {
+      const modeUpdate: acp.SessionUpdate = {
         sessionUpdate: "current_mode_update",
         currentModeId: ev.mode,
-      });
+      };
+      await sendSessionUpdate(cx, acpSid, modeUpdate);
+      sendSessionUpdateToOthers(server, cx, acpSid, modeUpdate);
     }
   } catch (e) {
     warn(`dispatch: ConfigChanged failed (${e instanceof Error ? e.message : String(e)})`);

--- a/src/handlers/io.ts
+++ b/src/handlers/io.ts
@@ -154,6 +154,39 @@ export function echoUserPromptToOthers(
   });
 }
 
+/**
+ * Push a `session/update` to every OTHER attached client (the prompter's
+ * connection excluded). Session settings are per-SESSION, not per-connection:
+ * a model/mode switch made from the phone must reach the CLI window and vice
+ * versa — a cx-addressed send alone leaves every other view stale. Same
+ * alias fan-out as the prompt echo (clients may hold the conversation under
+ * different ids). Fire-and-forget; failures warn, never throw.
+ */
+export function sendSessionUpdateToOthers(
+  server: ZcodeAcpServer,
+  source: acp.AgentContext,
+  sessionId: string,
+  update: acp.SessionUpdate,
+): void {
+  void enqueueSessionSend(sessionId, async () => {
+    const results = await Promise.allSettled(
+      server
+        .sessionAliases(sessionId)
+        .map((sid) =>
+          server.clients.notifyOthers(source, "session/update", { sessionId: sid, update }),
+        ),
+    );
+    for (const r of results) {
+      if (r.status === "rejected") {
+        warn(
+          `update broadcast failed (sid=${sessionId}): ` +
+            `${r.reason instanceof Error ? r.reason.message : String(r.reason)}`,
+        );
+      }
+    }
+  });
+}
+
 /** Shape of a slash command entry (matches ACP's AvailableCommand). */
 interface SlashCommandEntry {
   name: string;

--- a/src/remote/config.ts
+++ b/src/remote/config.ts
@@ -23,6 +23,9 @@
  *                                   when taken; loopback only)
  *     ZCODE_ACP_HUB_TERMINAL=0      disable the visible-terminal incubation
  *     ZCODE_ACP_HUB_TERMINAL_APP=<name>   terminal app for the TUI window
+ *     ZCODE_ACP_HUB_TERMINAL_APPS=<a,b,…>  ordered terminal fallback list
+ *                                   (file `remote.terminal.terminals` wins;
+ *                                   tried in order before going headless)
  *     ZCODE_ACP_HUB_TERMINAL_COMMAND=<sh> shell command template ({script})
  *   3. Built-in defaults.
  *
@@ -148,10 +151,27 @@ export function parseHubConfig(env: NodeJS.ProcessEnv = process.env): RemoteConf
  */
 export function remoteTerminalPrefs(env: NodeJS.ProcessEnv = process.env): TerminalPrefs {
   const file = loadUserConfig(env).remote?.terminal ?? {};
+  const fileTerminals = Array.isArray(file.terminals)
+    ? file.terminals.filter((v) => typeof v === "string" && v.trim())
+    : undefined;
+  const envTerminals = (env.ZCODE_ACP_HUB_TERMINAL_APPS ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const terminals = fileTerminals?.length
+    ? fileTerminals
+    : envTerminals.length
+      ? envTerminals
+      : undefined;
   const app = file.app ?? ((env.ZCODE_ACP_HUB_TERMINAL_APP ?? "").trim() || undefined);
   const command = file.command ?? ((env.ZCODE_ACP_HUB_TERMINAL_COMMAND ?? "").trim() || undefined);
   const enabled =
     file.enabled ??
     !["0", "false", "off"].includes((env.ZCODE_ACP_HUB_TERMINAL ?? "").trim().toLowerCase());
-  return { enabled, ...(app ? { app } : {}), ...(command ? { command } : {}) };
+  return {
+    enabled,
+    ...(terminals ? { terminals } : {}),
+    ...(app ? { app } : {}),
+    ...(command ? { command } : {}),
+  };
 }

--- a/src/remote/endpoint.ts
+++ b/src/remote/endpoint.ts
@@ -34,7 +34,6 @@ import { createSessionCloseHandler } from "./session-close-endpoint.js";
 import { createSessionListHandler } from "./session-list-endpoint.js";
 import { createSessionRenameHandler } from "./session-rename-endpoint.js";
 import { createStatusHandler, runningZcodeSids, type SessionRunStatus } from "./status-endpoint.js";
-import { readCodeFingerprint } from "./code-fingerprint.js";
 import type { RemoteConfig } from "./config.js";
 
 /** One heartbeat/discovery session entry (ADR-0005 adds `status`). */
@@ -283,8 +282,6 @@ export async function startRemoteEndpoint(
   // Last non-2xx/non-401 register status we warned about (once per stretch).
   let unexpectedStatus: number | null = null;
   let spawnThrottledUntil = 0;
-  // Frozen at bridge start: what this process actually runs (see payload).
-  const bridgeFingerprint = readCodeFingerprint();
 
   const payload = (sessions: AdvertisedSession[]) => ({
     token: config.token,
@@ -304,10 +301,6 @@ export async function startRemoteEndpoint(
     // Lets the hub detect that it is older than this bridge and restart
     // itself (we then re-spawn it from this dist — see registerOnce).
     version: AGENT_INFO.version,
-    // Content fingerprint of the dist this bridge runs from — the honest
-    // staleness signal (versions can lie across a release-merge/rebuild
-    // window). Absent when running from src or a pre-fingerprint build.
-    ...(bridgeFingerprint ? { codeFingerprint: bridgeFingerprint } : {}),
   });
 
   const spawnHub = (): void => {

--- a/src/remote/hub-server.ts
+++ b/src/remote/hub-server.ts
@@ -122,14 +122,25 @@ export interface HubOptions {
    * dist/cli.js — an interactive TUI in a visible terminal for
    * session-create and session-resume ("tui"; resume carries the requested
    * session in ZCODE_ACP_RESUME_SESSION), a detached headless serve bridge
-   * for background queries ("serve").
+   * for background queries ("serve"). A "tui" attempt returns null when the
+   * launch fails; the caller then walks down the terminal preference list
+   * (terminalLaunches) and only spawns "serve" once every entry failed.
    */
   spawnServe?: (opts: {
     cwd: string;
     env: NodeJS.ProcessEnv;
     /** "tui" = visible terminal (session-create/-resume); "serve" = detached headless. */
     kind: "tui" | "serve";
-  }) => ChildProcess | Promise<ChildProcess>;
+    /** The resolved launch for a "tui" attempt (one list entry). */
+    launch?: TerminalLaunch;
+  }) => ChildProcess | null | Promise<ChildProcess | null>;
+  /**
+   * Override the ordered terminal preference list the create/resume
+   * incubation walks (tests inject fixed entries). Default: resolved LIVE
+   * per incubation from remoteTerminalPrefs (config file > env), so editing
+   * the file takes effect without a hub restart.
+   */
+  terminalLaunches?: TerminalLaunch[];
 }
 
 export interface HubHandle {
@@ -343,15 +354,31 @@ export function resolveTerminalLaunch(
   launch: TerminalLaunch;
   warning?: string;
 } {
-  if (prefs.command) return { launch: { kind: "shell", command: prefs.command } };
-  const raw = prefs.app ?? "";
-  const name = raw
-    .toLowerCase()
-    .replace(/\.app$/, "")
-    .replace(/\s+/g, "-");
-  const launcher = TERMINAL_APP_LAUNCHERS[name];
-  if (launcher) return { launch: launcher };
-  return { launch: { kind: "openApp", app: raw || "Terminal" } };
+  const launches = resolveTerminalLaunches(prefs);
+  return { launch: launches[0] ?? { kind: "openApp", app: "Terminal" } };
+}
+
+/**
+ * The ORDERED terminal preference list (ADR-0016 amendment): the hub walks
+ * it when a window fails — a launch that errors moves down the list at
+ * once, a window that never registers moves down at its registration
+ * timeout — and only the exhaustion of every entry falls back to headless.
+ * Resolution per entry mirrors resolveTerminalLaunch: the explicit command
+ * template (the universal escape hatch) replaces the whole list; otherwise
+ * a built-in launcher by normalized app name, else `open -a` passthrough.
+ * Disabled prefs resolve to [] (no visible-terminal attempts at all).
+ */
+export function resolveTerminalLaunches(prefs: TerminalPrefs): TerminalLaunch[] {
+  if (prefs.enabled === false) return [];
+  if (prefs.command) return [{ kind: "shell", command: prefs.command }];
+  const names = prefs.terminals?.length ? prefs.terminals : prefs.app ? [prefs.app] : ["Terminal"];
+  return names.map((raw) => {
+    const name = raw
+      .toLowerCase()
+      .replace(/\.app$/, "")
+      .replace(/\s+/g, "-");
+    return TERMINAL_APP_LAUNCHERS[name] ?? { kind: "openApp", app: raw };
+  });
 }
 
 /**
@@ -478,30 +505,25 @@ export function writeTuiScript(workspace: string, cliJs: string, env: NodeJS.Pro
 /**
  * Spawn session-create as a VISIBLE interactive TUI (ADR-0016): write a
  * throwaway .command script (`cd <project> && exec node cli.js`) and hand it
- * to a terminal (resolveTerminalLaunch) — the user gets a real terminal
- * window running the local CLI instead of an invisible daemon. The TUI's
- * bridge child inherits the remote ENV, so the incubation registers exactly
- * like a serve bridge; closing the window ends the bridge (its lifetime
- * follows the terminal, the ADR-0001 anchor). Returns null when a terminal
- * can't be used — platform, gated off via ZCODE_ACP_HUB_TERMINAL, or the
- * open failing (headless/SSH) — and the caller falls back to the detached
- * serve spawn.
+ * to ONE resolved terminal launch — the user gets a real terminal window
+ * running the local CLI instead of an invisible daemon. The TUI's bridge
+ * child inherits the remote ENV, so the incubation registers exactly like a
+ * serve bridge; closing the window ends the bridge (its lifetime follows
+ * the terminal, the ADR-0001 anchor). Returns null when the launch fails —
+ * platform without GUI support or the open erroring (pre-1.3 Ghostty,
+ * denied Automation permission) — and the CALLER walks down the terminal
+ * preference list, falling back to the detached serve spawn only after the
+ * list is exhausted.
  */
 async function spawnTerminalTui(opts: {
   cwd: string;
   env: NodeJS.ProcessEnv;
+  launch: TerminalLaunch;
 }): Promise<ChildProcess | null> {
   if (process.platform !== "darwin") return null;
-  // Terminal prefs are read LIVE here (config file first, env fallback): the
-  // hub outlives the shells that configured it, and its birth env rotates
-  // between GUI editors and interactive shells — only the file is stable.
-  // Set remote.terminal.enabled=false in ~/.config/zcode-acp/config.json (or
-  // ZCODE_ACP_HUB_TERMINAL=0) to keep remote session-create headless.
-  if (!remoteTerminalPrefs(process.env).enabled) return null;
   const cliJs = fileURLToPath(new URL("../cli.js", import.meta.url));
   const script = writeTuiScript(opts.cwd, cliJs, opts.env);
-  const { launch, warning } = resolveTerminalLaunch(process.env);
-  if (warning) warn(`hub: ${warning}`);
+  const { launch } = opts;
   let argv: string[];
   if (launch.kind === "shell") {
     const rendered = launch.command.includes("{script}")
@@ -579,14 +601,20 @@ async function spawnTerminalTui(opts: {
  * detached headless serve bridge otherwise (the ADR-0014 original — also the
  * fallback whenever the terminal window can't be opened).
  */
+/**
+ * One spawn attempt. "tui" = one resolved terminal launch (returns null when
+ * the launch fails — the caller walks the preference list); "serve" = the
+ * detached headless bridge (the documented no-GUI fallback, ADR-0014).
+ */
 async function defaultSpawnServe(opts: {
   cwd: string;
   env: NodeJS.ProcessEnv;
   kind: "tui" | "serve";
-}): Promise<ChildProcess> {
+  launch?: TerminalLaunch;
+}): Promise<ChildProcess | null> {
   if (opts.kind === "tui") {
-    const viaTerminal = await spawnTerminalTui(opts);
-    if (viaTerminal) return viaTerminal;
+    if (!opts.launch) return null;
+    return spawnTerminalTui(opts as typeof opts & { launch: TerminalLaunch });
   }
   // dist/remote/hub-server.js → dist/cli.js (one level up).
   const cliJs = fileURLToPath(new URL("../cli.js", import.meta.url));
@@ -880,6 +908,7 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
     projectsDbPath,
     stayAliveCheck = () => remoteEnabledLive(),
     spawnServe = defaultSpawnServe,
+    terminalLaunches,
   } = options;
 
   /** Frozen at hub start — the anchor the /api/upgrade signals compare to. */
@@ -1013,29 +1042,89 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
       // (terminals otherwise name the tab after the process, "node").
       env.ZCODE_ACP_TAB_TITLE = tabTitle ?? path.basename(workspacePath);
     }
+    // Terminal preference list (ADR-0016 amendment): visible-terminal kinds
+    // walk it — a failed launch moves down at once, a window that never
+    // registers moves down at its timeout — and only the exhausted list
+    // falls back to the detached headless spawn. "serve" never pops a window.
+    const launches =
+      kind === "serve"
+        ? []
+        : (terminalLaunches ?? resolveTerminalLaunches(remoteTerminalPrefs(process.env)));
+    let li = 0;
+    /**
+     * Try launches[li..] until one OPENS; advance li past every failure and
+     * leave it parked on the first opened attempt's successor. null = the
+     * remaining list failed/exhausted (caller falls back to headless).
+     */
+    const openNextTerminal = async (): Promise<ChildProcess | null> => {
+      while (li < launches.length) {
+        const attempt = launches[li]!;
+        li++;
+        try {
+          const opened = await spawnServe({
+            cwd: workspacePath,
+            kind: "tui",
+            env,
+            launch: attempt,
+          });
+          if (opened) {
+            opened.once("error", (e: Error) => {
+              spawnError = e;
+            });
+            spawnError = null;
+            log(
+              `hub: spawned terminal TUI via ${
+                attempt.kind === "shell"
+                  ? "command template"
+                  : attempt.kind === "ghosttyScript"
+                    ? `Ghostty (${attempt.app})`
+                    : attempt.kind === "warpUri"
+                      ? `Warp (${attempt.app})`
+                      : `open -a ${attempt.app}`
+              } for ${workspacePath} (pid ${opened.pid})`,
+            );
+            return opened;
+          }
+          warn(
+            `hub: terminal launch ${li}/${launches.length} failed to open — trying the next preference`,
+          );
+        } catch (e) {
+          warn(`hub: terminal launch threw: ${e instanceof Error ? e.message : String(e)}`);
+        }
+      }
+      return null;
+    };
     try {
-      // Resume shares session-create's visible-terminal surface (and its
-      // detached-serve fallback for headless machines); only a background
-      // listing spawns the headless form — it must never pop a window.
-      child = await spawnServe({
-        cwd: workspacePath,
-        kind: kind === "serve" ? "serve" : "tui",
-        env,
-      });
-      child.once("error", (e: Error) => {
-        spawnError = e;
-      });
+      const opened = await openNextTerminal();
+      if (opened) {
+        child = opened;
+      } else {
+        // Resume shares session-create's visible-terminal surface (and its
+        // detached-serve fallback for headless machines); only a background
+        // listing spawns the headless form — it must never pop a window.
+        const spawned = await spawnServe({
+          cwd: workspacePath,
+          kind: "serve",
+          env,
+        });
+        if (!spawned) throw new Error("headless spawn returned null");
+        child = spawned;
+        child.once("error", (e: Error) => {
+          spawnError = e;
+        });
+      }
     } catch (e) {
       warn(`hub: serve spawn failed: ${e instanceof Error ? e.message : String(e)}`);
       throw new Error("serve bridge spawn failed");
     }
     log(
-      `hub: spawned ${
-        kind === "resume" ? "resume TUI" : kind === "tui" ? "terminal TUI" : "serve bridge"
-      } for ${workspacePath} (pid ${child.pid})`,
+      `hub: incubating ${kind === "resume" ? "resume TUI" : kind === "tui" ? "terminal TUI" : "serve bridge"} for ${workspacePath} (pid ${child.pid})`,
     );
     const budget = kind === "serve" ? SERVE_REGISTER_TIMEOUT_MS : tuiRegisterTimeoutMs;
-    const deadline = Date.now() + budget;
+    let deadline = Date.now() + budget;
+    // One headless rescue per incubation — a second timeout means the rescue
+    // bridge also failed to register, and retrying again just burns time.
+    let rescued = false;
     // A visible-terminal incubation (create OR resume) runs NEXT TO the serve
     // bridge the listing already incubated, and several incubations can race
     // for one workspace: the poll matches only a registration that is neither
@@ -1079,6 +1168,50 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
             );
             return { id: fallback.id, reused: true };
           }
+        }
+        // Next terminal preference: the window opened but never registered —
+        // on a locked/display-asleep screen Ghostty's AppleScript tab opens
+        // fine but its surface init fails (error.OutOfMemory, ghostty
+        // #10712), leaving the tab dead on its error page (the fake child
+        // never exits, so the fast-fail above can't fire). Walk down the
+        // user's list with a fresh budget before giving up on windows.
+        if (kind !== "serve" && li < launches.length) {
+          warn(
+            `hub: terminal TUI for ${workspacePath} never registered — trying the next terminal preference`,
+          );
+          const next = await openNextTerminal();
+          if (next) {
+            deadline = Date.now() + budget;
+            continue;
+          }
+        }
+        // Headless rescue (once, after the terminal list is exhausted):
+        // spawn the SAME incubation headlessly — the session-bind env rides
+        // along (create's pre-generated id, resume's target) and the nonce is
+        // unchanged, so this very loop matches the rescue bridge's
+        // registration and answers with a working session either way.
+        if (kind !== "serve" && !rescued) {
+          rescued = true;
+          warn(
+            `hub: ${kind === "resume" ? "resume TUI" : "terminal TUI"} for ${workspacePath} ` +
+              `never registered — rescuing the request with a headless serve bridge`,
+          );
+          try {
+            const rescuedChild = await spawnServe({ cwd: workspacePath, kind: "serve", env });
+            if (!rescuedChild) throw new Error("rescue spawn returned null");
+            child = rescuedChild;
+            child.once("error", (e: Error) => {
+              spawnError = e;
+            });
+            spawnError = null;
+          } catch (e) {
+            warn(
+              `hub: headless rescue spawn failed: ${e instanceof Error ? e.message : String(e)}`,
+            );
+            throw new Error("serve bridge did not register in time");
+          }
+          deadline = Date.now() + budget;
+          continue;
         }
         warn(`hub: serve bridge for ${workspacePath} never registered`);
         throw new Error("serve bridge did not register in time");

--- a/src/remote/hub-server.ts
+++ b/src/remote/hub-server.ts
@@ -141,6 +141,12 @@ export interface HubOptions {
    * the file takes effect without a hub restart.
    */
   terminalLaunches?: TerminalLaunch[];
+  /**
+   * How long after startup the hub ignores newer-bridge stale votes (tests
+   * shrink to 0). Default STALE_VOTE_COOLDOWN_MS — the loop breaker so a
+   * same-age respawn can never be voted into a restart churn.
+   */
+  staleVoteCooldownMs?: number;
 }
 
 export interface HubHandle {
@@ -260,6 +266,13 @@ function validSessions(raw: unknown): SessionSummary[] | null {
 /** How long POST /api/instances waits for the spawned bridge to register. */
 const SERVE_REGISTER_TIMEOUT_MS = 10_000;
 const SERVE_REGISTER_POLL_MS = 300;
+/**
+ * A freshly started hub ignores newer-bridge stale votes for this long —
+ * the loop breaker for a restart that re-spawned a hub of the same age
+ * (the vote would otherwise fire again immediately; at most one restart
+ * per cooldown window).
+ */
+const STALE_VOTE_COOLDOWN_MS = 60_000;
 
 /** Register-origin parser: only "serve" is special; anything else is "editor". */
 function parseOrigin(raw: unknown): "editor" | "serve" {
@@ -909,6 +922,7 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
     stayAliveCheck = () => remoteEnabledLive(),
     spawnServe = defaultSpawnServe,
     terminalLaunches,
+    staleVoteCooldownMs = STALE_VOTE_COOLDOWN_MS,
   } = options;
 
   /** Frozen at hub start — the anchor the /api/upgrade signals compare to. */
@@ -1881,39 +1895,35 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
         instances.delete(id);
         idleSince = null; // re-arm the idle clock on membership change
       }
-      // Self-upgrade: a bridge running DIFFERENT code than this hub just
-      // registered, so this process is stale. Reply first (the bridge
-      // re-spawns the hub from its own dist when it sees `restarting`), then
-      // exit. Fingerprints are compared when both sides have one — content
-      // cannot lie the way a version frozen from package.json can (a hub
-      // born between a release merge and the dist rebuild). The lexical
-      // tie-break (bridge fp must sort HIGHER) gives coexisting dists on one
-      // machine a stable winner, so two differently-built bridges can never
-      // ping-pong the hub. Bridges without a fingerprint fall back to the
-      // legacy strictly-newer version check.
-      const bridgeFingerprint =
-        typeof body.codeFingerprint === "string" && body.codeFingerprint
-          ? body.codeFingerprint
-          : null;
-      const fingerprintStale =
-        bridgeFingerprint !== null &&
-        hubFingerprint !== null &&
-        bridgeFingerprint !== hubFingerprint &&
-        bridgeFingerprint > hubFingerprint;
-      const versionStale =
-        bridgeFingerprint === null &&
-        hubFingerprint === null &&
-        typeof body.version === "string" &&
-        compareVersions(body.version, AGENT_INFO.version) > 0;
-      const stale = url.pathname === "/api/register" && (fingerprintStale || versionStale);
+      // Self-upgrade: a bridge with a strictly NEWER VERSION just registered,
+      // so this process is stale. Reply first (the bridge re-spawns the hub
+      // from its own dist when it sees `restarting`), then exit.
+      //
+      // Content fingerprints are deliberately NOT a vote signal: a hash has
+      // no ordering (a lexically-higher fingerprint can be OLDER code), and
+      // the hub's respawn source is not guaranteed to be the voting bridge's
+      // dist — differing fingerprints could only ever produce a
+      // non-converging restart loop (observed live: a coexisting dist voted
+      // every respawned hub stale, ~5s churn, all instances wiped).
+      // Fingerprint comparison belongs to /api/upgrade ONLY, where the
+      // comparison target is the DISK a respawn would load — self-negating
+      // by construction.
+      //
+      // Cooldown: a fresh hub ignores stale votes for the first minute. If
+      // the respawn race ever produces another same-age hub, this breaks the
+      // loop — at most one restart per STALE_VOTE_COOLDOWN_MS.
+      const newerVersion =
+        typeof body.version === "string" && compareVersions(body.version, AGENT_INFO.version) > 0;
+      const cooledDown = Date.now() - startedAt > staleVoteCooldownMs;
+      const stale = url.pathname === "/api/register" && newerVersion && cooledDown;
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify(stale ? { ok: true, restarting: true } : { ok: true }));
       if (stale) {
         restartSoon(
-          fingerprintStale
-            ? `hub: bridge fingerprint ${bridgeFingerprint!.slice(0, 12)} differs from hub ${hubFingerprint!.slice(0, 12)} — restarting to upgrade`
-            : `hub: bridge ${body.version} is newer than hub ${AGENT_INFO.version} — restarting to upgrade`,
+          `hub: bridge ${body.version} is newer than hub ${AGENT_INFO.version} — restarting to upgrade`,
         );
+      } else if (url.pathname === "/api/register" && newerVersion && !cooledDown) {
+        log("hub: newer-bridge vote ignored (restart cooldown after a recent restart)");
       }
       return;
     }

--- a/src/remote/session-close-endpoint.ts
+++ b/src/remote/session-close-endpoint.ts
@@ -85,13 +85,32 @@ function advertisedSessionCount(server: ZcodeAcpServer): number {
 }
 
 /**
+ * Pids to SIGTERM directly when tearing down an incubated TUI tree: the
+ * incubated CLI (ZCODE_ACP_TUI_CLI_PID — tui.ts forwards its SIGTERM to the
+ * martty child and exits clean) and this bridge's parent (the TUI host
+ * driving this bridge's stdio). Deduped; pid 1 excluded. Pure — for tests.
+ */
+export function tuiTeardownPids(tuiPgid: number, ppid: number): number[] {
+  const out: number[] = [];
+  for (const pid of [tuiPgid, ppid]) {
+    if (Number.isInteger(pid) && pid > 1 && !out.includes(pid)) out.push(pid);
+  }
+  return out;
+}
+
+/**
  * Tear the incubated CLI down AFTER the close response flushed (the phone
- * must get its 200 before the bridge dies). The group SIGTERM covers the
- * martty Rust host too — a bare kill of one pid orphans it; martty's client
- * converts the signal to an orderly exit and restores the TTY, the tree ends
- * with exit code 0, and each terminal's own close-on-exit pref takes the
- * window. The self-exit timer is the fallback for the headless serve bridge
- * and for a terminal whose launch path broke process-group membership.
+ * must get its 200 before the bridge dies). The group SIGTERM covers every
+ * descendant at once — but ONLY when the terminal made the script a session
+ * leader (Terminal.app, -e-style terminals). Ghostty's AppleScript tab and
+ * Warp's URI tab run the script inside the terminal app's own session: the
+ * group ESRCHs (verified live 2026-09-08 — kill(-pid) failed while the pid
+ * was alive), and without the direct pid signals only this bridge died,
+ * leaving the window on a dead-agent error page. martty converts SIGTERM to
+ * an orderly exit, restores the TTY, the tree ends with exit code 0, and each
+ * terminal's own close-on-exit pref takes the window. The self-exit timer is
+ * the fallback for the headless serve bridge and for launch paths where both
+ * signal forms miss.
  */
 function terminateAfterFlush(decision: ServeTerminateDecision, res: ServerResponse): void {
   const run = () => {
@@ -102,8 +121,18 @@ function terminateAfterFlush(decision: ServeTerminateDecision, res: ServerRespon
       } catch (e) {
         log(
           `remote: TUI group signal failed ` +
-            `(${e instanceof Error ? e.message : String(e)}) — exiting this bridge instead`,
+            `(${e instanceof Error ? e.message : String(e)}) — signalling the tree pids directly`,
         );
+      }
+      // Direct signals for terminals that run the script without a new
+      // session (see above); harmless duplicates when the group signal landed.
+      for (const pid of tuiTeardownPids(decision.tuiPgid, process.ppid)) {
+        try {
+          process.kill(pid, "SIGTERM");
+          log(`remote: last session closed — SIGTERM to TUI pid ${pid}`);
+        } catch {
+          // already gone — the self-exit below still ends this bridge
+        }
       }
     }
     setTimeout(() => process.exit(0), SELF_EXIT_MS);

--- a/tests/hub.test.ts
+++ b/tests/hub.test.ts
@@ -774,6 +774,7 @@ describe("hub version self-upgrade", () => {
   it("restarts when a newer bridge registers", async () => {
     let exited = false;
     const hub = await startTestHub({
+      staleVoteCooldownMs: 0,
       onIdleExit: () => {
         exited = true;
       },
@@ -838,15 +839,39 @@ describe("hub fingerprint self-upgrade", () => {
     });
   }
 
-  it("restarts when a bridge with a different (lexically higher) fingerprint registers", async () => {
+  it("NEVER restarts on a differing fingerprint (votes are version-only)", async () => {
+    // Regression (live incident 2026-09-08): a coexisting dist's fingerprint
+    // voted every respawned hub stale — a non-converging ~5s restart churn
+    // that wiped all instances ("sessions flash then disappear"). A hash has
+    // no ordering; it can never prove "newer". Fingerprint comparison lives
+    // in /api/upgrade only (hub vs DISK, self-negating by construction).
     let restarted = false;
     const hub = await startTestHub({
-      hubFingerprint: "aaaa",
+      hubFingerprint: "7d05",
+      staleVoteCooldownMs: 0,
       onRestart: () => {
         restarted = true;
       },
     });
-    const res = await register(hub, { codeFingerprint: "bbbb" });
+    for (const fp of ["bbbb", "aaaa", "fcf69ae4e10f"]) {
+      const res = await register(hub, { codeFingerprint: fp });
+      expect(await res.json()).toEqual({ ok: true });
+    }
+    await new Promise((r) => setTimeout(r, 800));
+    expect(restarted).toBe(false);
+    expect((await fetch(`http://127.0.0.1:${hub.port}/api/health`)).status).toBe(200);
+  });
+
+  it("restarts for a strictly newer VERSION even when both sides have fingerprints", async () => {
+    let restarted = false;
+    const hub = await startTestHub({
+      hubFingerprint: "aaaa",
+      staleVoteCooldownMs: 0,
+      onRestart: () => {
+        restarted = true;
+      },
+    });
+    const res = await register(hub, { version: "9999.0.0", codeFingerprint: "bbbb" });
     expect(await res.json()).toEqual({ ok: true, restarting: true });
     await withTimeout(
       new Promise<void>((resolve) => {
@@ -858,45 +883,16 @@ describe("hub fingerprint self-upgrade", () => {
         }, 50);
       }),
       5000,
-      "hub restart onto higher fingerprint",
+      "hub restart onto newer version",
     );
   });
 
-  it("does not ping-pong for a lexically LOWER fingerprint (stable winner)", async () => {
+  it("suppresses newer-bridge votes during the restart cooldown", async () => {
+    // Loop breaker: a hub that just (re)started ignores stale votes for the
+    // cooldown window — a same-age respawn can never be voted into a churn.
     let restarted = false;
     const hub = await startTestHub({
-      hubFingerprint: "bbbb",
-      onRestart: () => {
-        restarted = true;
-      },
-    });
-    const res = await register(hub, { codeFingerprint: "aaaa" });
-    expect(await res.json()).toEqual({ ok: true });
-    await new Promise((r) => setTimeout(r, 800));
-    expect(restarted).toBe(false);
-  });
-
-  it("does not restart for an identical fingerprint", async () => {
-    let restarted = false;
-    const hub = await startTestHub({
-      hubFingerprint: "aaaa",
-      onRestart: () => {
-        restarted = true;
-      },
-    });
-    const res = await register(hub, { codeFingerprint: "aaaa" });
-    expect(await res.json()).toEqual({ ok: true });
-    await new Promise((r) => setTimeout(r, 800));
-    expect(restarted).toBe(false);
-  });
-
-  it("ignores the version signal once this hub knows its fingerprint", async () => {
-    // A fingerprint-less bridge claiming a huge version must not restart a
-    // fingerprinted hub: the transition case (old bridge vs new hub) is the
-    // /api/upgrade postinstall poke's job, never the register path's.
-    let restarted = false;
-    const hub = await startTestHub({
-      hubFingerprint: "aaaa",
+      staleVoteCooldownMs: 60_000,
       onRestart: () => {
         restarted = true;
       },
@@ -905,6 +901,7 @@ describe("hub fingerprint self-upgrade", () => {
     expect(await res.json()).toEqual({ ok: true });
     await new Promise((r) => setTimeout(r, 800));
     expect(restarted).toBe(false);
+    expect((await fetch(`http://127.0.0.1:${hub.port}/api/health`)).status).toBe(200);
   });
 });
 
@@ -2206,7 +2203,7 @@ describe("hub instance shutdown", () => {
       5000,
       "dummy bridge exit",
     );
-  });
+  }, 15_000);
 
   it("refuses an editor-origin bridge without a nonce (403)", async () => {
     const hub = await startTestHub();

--- a/tests/hub.test.ts
+++ b/tests/hub.test.ts
@@ -1097,7 +1097,12 @@ describe("hub remote session-create (ADR-0014)", () => {
    * once(); the mutable exitCode/signalCode fields flip the death checks.
    */
   let fakeChild: EventEmitter & { pid: number; exitCode: number | null; signalCode: string | null };
-  let spawnCalls: Array<{ cwd: string; env: NodeJS.ProcessEnv; kind: "tui" | "serve" }>;
+  let spawnCalls: Array<{
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+    kind: "tui" | "serve";
+    launch?: unknown;
+  }>;
   let spawnCount: number;
 
   beforeEach(() => {
@@ -1115,7 +1120,12 @@ describe("hub remote session-create (ADR-0014)", () => {
   });
 
   function spawnServeSpy() {
-    return (opts: { cwd: string; env: NodeJS.ProcessEnv; kind: "tui" | "serve" }) => {
+    return (opts: {
+      cwd: string;
+      env: NodeJS.ProcessEnv;
+      kind: "tui" | "serve";
+      launch?: unknown;
+    }) => {
       spawnCount++;
       spawnCalls.push(opts);
       return fakeChild as unknown as import("node:child_process").ChildProcess;
@@ -1620,7 +1630,12 @@ describe("hub terminal-TUI session resume (ADR-0017)", () => {
     });
 
   let fakeChild: EventEmitter & { pid: number; exitCode: number | null; signalCode: string | null };
-  let spawnCalls: Array<{ cwd: string; env: NodeJS.ProcessEnv; kind: "tui" | "serve" }>;
+  let spawnCalls: Array<{
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+    kind: "tui" | "serve";
+    launch?: unknown;
+  }>;
 
   beforeEach(() => {
     listKnownWorkspacesMock.mockReset();
@@ -1638,7 +1653,8 @@ describe("hub terminal-TUI session resume (ADR-0017)", () => {
     cwd: string;
     env: NodeJS.ProcessEnv;
     kind: "tui" | "serve";
-  }) => import("node:child_process").ChildProcess {
+    launch?: unknown;
+  }) => import("node:child_process").ChildProcess | null {
     return (opts) => {
       spawnCalls.push(opts);
       return fakeChild as unknown as import("node:child_process").ChildProcess;
@@ -1822,7 +1838,12 @@ describe("hub terminal-TUI session create (session binding + slow-window fallbac
     });
 
   let fakeChild: EventEmitter & { pid: number; exitCode: number | null; signalCode: string | null };
-  let spawnCalls: Array<{ cwd: string; env: NodeJS.ProcessEnv; kind: "tui" | "serve" }>;
+  let spawnCalls: Array<{
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+    kind: "tui" | "serve";
+    launch?: unknown;
+  }>;
 
   beforeEach(() => {
     listKnownWorkspacesMock.mockReset();
@@ -1836,13 +1857,23 @@ describe("hub terminal-TUI session create (session binding + slow-window fallbac
     spawnCalls = [];
   });
 
-  function spawnServeSpy(): (opts: {
+  function spawnServeSpy(
+    /** When set, its return decides opened (child) vs failed launch (null). */
+    respond?: (opts: {
+      cwd: string;
+      env: NodeJS.ProcessEnv;
+      kind: "tui" | "serve";
+      launch?: unknown;
+    }) => import("node:child_process").ChildProcess | null,
+  ): (opts: {
     cwd: string;
     env: NodeJS.ProcessEnv;
     kind: "tui" | "serve";
-  }) => import("node:child_process").ChildProcess {
+    launch?: unknown;
+  }) => import("node:child_process").ChildProcess | null {
     return (opts) => {
       spawnCalls.push(opts);
+      if (respond) return respond(opts);
       return fakeChild as unknown as import("node:child_process").ChildProcess;
     };
   }
@@ -1907,6 +1938,82 @@ describe("hub terminal-TUI session create (session binding + slow-window fallbac
     const res = await post(hub, { workspacePath: PROJECT });
     expect(res.status).toBe(502);
     expect(await res.text()).toBe("serve bridge did not register in time");
+  });
+
+  it("walks down the terminal list at the registration timeout before going headless", async () => {
+    // Locked-screen Ghostty: the tab opens (launch succeeded) but its surface
+    // init died, so the TUI never registers. The NEXT preference gets a fresh
+    // budget; headless comes only after the list is exhausted (one rescue).
+    const launches = [
+      { kind: "openApp", app: "Ghostty" },
+      { kind: "openApp", app: "Warp" },
+    ];
+    const hub = await startTestHub({
+      spawnServe: spawnServeSpy(),
+      tuiRegisterTimeoutMs: 500,
+      terminalLaunches: launches as never,
+    });
+    const pending = post(hub, { workspacePath: PROJECT });
+    await new Promise((r) => setTimeout(r, 700)); // first budget burns out
+    expect(spawnCalls).toHaveLength(2);
+    expect(spawnCalls[0]!.kind).toBe("tui");
+    expect(spawnCalls[0]!.launch).toEqual(launches[0]);
+    expect(spawnCalls[1]!.kind).toBe("tui");
+    expect(spawnCalls[1]!.launch).toEqual(launches[1]);
+    // The second window registers: the SAME nonce satisfies the incubation.
+    await registerServeBridge(hub, "window-2", spawnCalls[1]!.env.ZCODE_ACP_SPAWN_NONCE);
+    const res = await pending;
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ id: "window-2", reused: false });
+  });
+
+  it("rescues headlessly only once after every terminal preference failed", async () => {
+    const launches = [{ kind: "openApp", app: "Ghostty" }];
+    const hub = await startTestHub({
+      spawnServe: spawnServeSpy(),
+      tuiRegisterTimeoutMs: 500,
+      terminalLaunches: launches as never,
+    });
+    const pending = post(hub, { workspacePath: PROJECT });
+    // First timeout: list exhausted → headless rescue (2nd spawn, kind serve).
+    await new Promise((r) => setTimeout(r, 700));
+    expect(spawnCalls).toHaveLength(2);
+    expect(spawnCalls[1]!.kind).toBe("serve");
+    // Rescue registers → answered; the incubation is settled, so no third
+    // spawn even though the rescue's own budget also expires unanswered.
+    await registerServeBridge(hub, "rescued", spawnCalls[1]!.env.ZCODE_ACP_SPAWN_NONCE);
+    const res = await pending;
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ id: "rescued", reused: false });
+    await new Promise((r) => setTimeout(r, 700));
+    expect(spawnCalls).toHaveLength(2);
+  });
+
+  it("skips a terminal whose launch fails and answers with a later preference", async () => {
+    const launches = [
+      { kind: "openApp", app: "Broken" },
+      { kind: "openApp", app: "Warp" },
+    ];
+    const hub = await startTestHub({
+      // First launch fails to open (null) — the walk continues at once,
+      // without waiting for any registration budget.
+      spawnServe: spawnServeSpy((opts) =>
+        opts.launch && (opts.launch as { app: string }).app === "Broken"
+          ? null
+          : (fakeChild as unknown as import("node:child_process").ChildProcess),
+      ),
+      tuiRegisterTimeoutMs: 5_000,
+      terminalLaunches: launches as never,
+    });
+    const pending = post(hub, { workspacePath: PROJECT });
+    await new Promise((r) => setTimeout(r, 400));
+    expect(spawnCalls).toHaveLength(2);
+    expect(spawnCalls[0]!.launch).toEqual(launches[0]);
+    expect(spawnCalls[1]!.launch).toEqual(launches[1]);
+    await registerServeBridge(hub, "warp-window", spawnCalls[1]!.env.ZCODE_ACP_SPAWN_NONCE);
+    const res = await pending;
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ id: "warp-window", reused: false });
   });
 });
 

--- a/tests/remote-session-close.test.ts
+++ b/tests/remote-session-close.test.ts
@@ -14,6 +14,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   createSessionCloseHandler,
   serveTerminateDecision,
+  tuiTeardownPids,
 } from "../src/remote/session-close-endpoint.js";
 import { collectStatus } from "../src/remote/status-endpoint.js";
 import { collectSessions } from "../src/remote/endpoint.js";
@@ -207,6 +208,19 @@ describe("serve-origin termination decision (remote close ends the CLI)", () => 
         ZCODE_ACP_TUI_CLI_PID: "not-a-pid",
       }),
     ).toEqual({ terminate: true });
+  });
+
+  it("teardown targets the CLI pid and the bridge's parent, deduped", () => {
+    // Ghostty's AppleScript tab and Warp's URI tab run the script WITHOUT a
+    // new session: the process group never exists and the direct pids are
+    // the only signal that lands (verified live 2026-09-08).
+    expect(tuiTeardownPids(100, 200)).toEqual([100, 200]);
+    // Same process hosting both roles (bridge spawned by the CLI itself).
+    expect(tuiTeardownPids(100, 100)).toEqual([100]);
+    // launchd (1) never gets signalled; malformed values drop out.
+    expect(tuiTeardownPids(1, 200)).toEqual([200]);
+    expect(tuiTeardownPids(100, 1)).toEqual([100]);
+    expect(tuiTeardownPids(Number.NaN, 200)).toEqual([200]);
   });
 
   it("remote-created empty placeholders count as advertised — close keeps the CLI alive", async () => {

--- a/tests/setup/hermetic-home.ts
+++ b/tests/setup/hermetic-home.ts
@@ -11,6 +11,12 @@
  * restores values recorded through stubEnv, so a test file calling it
  * mid-run cannot drop the suite back onto the real HOME. A per-test
  * vi.stubEnv("HOME", …) still overrides this default for that test.
+ *
+ * The serve-origin markers are DELETED the same way: a vitest run started
+ * from inside an incubated TUI inherits them, and the session-close handler
+ * reading them would treat the test worker as that TUI's bridge — signalling
+ * the REAL window's process tree (observed live 2026-09-08: the run killed
+ * its own host window). Tests that need them re-stub explicitly.
  */
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -20,6 +26,8 @@ import { afterAll } from "vitest";
 
 const home = mkdtempSync(path.join(tmpdir(), "zacp-test-home-"));
 process.env.HOME = home;
+delete process.env.ZCODE_ACP_REMOTE_ORIGIN;
+delete process.env.ZCODE_ACP_TUI_CLI_PID;
 
 afterAll(() => {
   // The dir is only used synchronously by store/config reads; by afterAll the


### PR DESCRIPTION
## Summary

Four conventional commits for 0.31.0:

- **feat(remote): ordered terminal preference list with chained fallback** — new `remote.terminal.terminals` config (env `ZCODE_ACP_HUB_TERMINAL_APPS`): the hub walks the ordered list on remote create/resume, moving down on launch failure or register timeout, headless spawn only after the list is exhausted. Verified live on a locked-screen Ghostty failure.
- **fix(remote): version-only hub stale votes with restart cooldown** — fingerprints are no longer a register-vote signal (no ordering → non-converging restart loop, observed live); 60s startup cooldown bounds vote-driven restarts. Fingerprint checks stay in `/api/upgrade`.
- **fix(remote): signal TUI tree pids directly when the process group is absent** — Ghostty/Warp tabs run the incubation script without a new session, so the group signal ESRCHs and only the bridge died, leaving the window on a dead-agent error page. Direct SIGTERMs to the CLI pid + bridge parent now tear the whole tree down (verified end-to-end: remote create → close → all 5 tree processes exit ≤2s). Test setup scrubs serve-origin env markers so vitest runs from inside an incubated TUI can never signal the host tree.
- **fix(handlers): broadcast config option updates to all attached clients** — model/thought/mode switches made from one client (e.g. the phone) now reach the CLI window too.

Full suite 1046/1046, typecheck, lint, prettier clean.