### PR TITLE
fix: attribute internal turns by turnId, filter unusable providers, shorten terminal fallback

### DIFF
--- a/src/config/options.ts
+++ b/src/config/options.ts
@@ -38,7 +38,7 @@ interface ProviderEntry {
   name?: string;
   kind?: string;
   enabled?: boolean;
-  options?: { baseURL?: string; apiKey?: string };
+  options?: { baseURL?: string; apiKey?: string; apiKeyRequired?: boolean };
   models?: ProviderModelsJson;
 }
 
@@ -63,33 +63,57 @@ export interface ModelRef {
 }
 
 /**
- * Collect models from config.json for the dropdown.
+ * Whether a provider entry is selectable in the dropdown — i.e. the desktop
+ * app itself would run it. The desktop marks a provider "未启用" when it has
+ * no usable credentials, and the IDE dropdown must not offer those models
+ * (issue #156): a keyless builtin (API-key mode picked but no key entered) or
+ * a keyless remote custom provider can never authenticate.
  *
- * Builtin providers (id prefix `builtin:`) must be `enabled: true` — they
- * reflect the plans the user activated in the ZCode desktop app. Custom
- * (third-party) providers are included UNLESS explicitly `enabled: false`:
- * the newer CLI leaves the flag unset on active third-party providers, so
- * treating "absent" as enabled keeps them in the dropdown while still
- * honoring an explicit disable.
+ *   - builtin: requires `enabled: true` AND a credential (plan token / key).
+ *   - custom: excluded on explicit `enabled: false`; otherwise must be
+ *     usable — has an apiKey, declares keys not required, or points at a
+ *     local baseURL (llama.cpp/ollama-style providers work keyless).
+ */
+function providerSelectable(pid: string, p: ProviderEntry | undefined): boolean {
+  if (!p) return false;
+  if (isBuiltinProvider(pid)) return p.enabled === true && Boolean(p.options?.apiKey);
+  if (p.enabled === false) return false;
+  if (p.options?.apiKey) return true;
+  if (p.options?.apiKeyRequired === false) return true;
+  return isLocalBaseURL(p.options?.baseURL);
+}
+
+/** localhost-style baseURL (llama.cpp / Ollama / LM Studio run keyless). */
+function isLocalBaseURL(url: string | undefined): boolean {
+  if (!url) return false;
+  try {
+    const host = new URL(url).hostname;
+    return host === "localhost" || host === "127.0.0.1" || host === "[::1]" || host === "::1";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Collect models from config.json for the dropdown.
  */
 export function loadAllModels(): ModelRef[] {
   try {
     const cfg = readConfig() as ConfigShape;
     const out: ModelRef[] = [];
     for (const [pid, p] of Object.entries(cfg.provider ?? {})) {
-      if (isBuiltinProvider(pid)) {
-        if (p?.enabled !== true) continue;
-      } else if (p?.enabled === false) {
-        continue;
-      }
+      if (!providerSelectable(pid, p)) continue;
       const providerName = p.name ?? pid;
       for (const modelId of Object.keys(p.models ?? {})) {
         out.push({ providerId: pid, providerName, modelId });
       }
     }
-    if (out.length === 0) {
-      // Fallback: config unreadable or no enabled provider — keep the legacy
-      // default so a freshly-installed editor still shows something.
+    // The default-provider fallback applies only to a MISSING/empty provider
+    // map (fresh install). When providers ARE configured but none is usable
+    // (all keyless/未启用, #156), returning [] is correct: the fallback would
+    // re-advertise exactly the unusable provider — or one absent from the
+    // user's config — and switching to it fails in applyModelSwitch.
+    if (out.length === 0 && Object.keys(cfg.provider ?? {}).length === 0) {
       return [
         {
           providerId: DEFAULT_PROVIDER_ID,

--- a/src/remote/hub-server.ts
+++ b/src/remote/hub-server.ts
@@ -282,9 +282,17 @@ function parseOrigin(raw: unknown): "editor" | "serve" {
 /**
  * The TUI-in-a-terminal incubation budget (ADR-0016): a visible terminal
  * adds a GUI round-trip (Terminal app launch, TUI boot, its bridge child)
- * ahead of the hub registration — double the headless budget.
+ * ahead of the hub registration. Terminals normally register in a couple of
+ * seconds; a cold GUI start still fits inside 10s.
  */
-const TUI_REGISTER_TIMEOUT_MS = 20_000;
+const TUI_REGISTER_TIMEOUT_MS = 10_000;
+/**
+ * Budget for fallback attempts AFTER the first terminal preference (next
+ * preference, headless rescue): half the first budget. A terminal that has
+ * already failed once is a fallback — making the user wait the full budget
+ * again per preference turned a broken first choice into a 3×20s stall.
+ */
+const TUI_RETRY_BUDGET_MS = TUI_REGISTER_TIMEOUT_MS / 2;
 /** `open -a <terminal>` must answer fast or the incubation falls back. */
 const TERMINAL_OPEN_TIMEOUT_MS = 3_000;
 /**
@@ -1195,7 +1203,7 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
           );
           const next = await openNextTerminal();
           if (next) {
-            deadline = Date.now() + budget;
+            deadline = Date.now() + Math.max(1_000, Math.min(budget, TUI_RETRY_BUDGET_MS));
             continue;
           }
         }
@@ -1224,7 +1232,7 @@ export function startHub(options: HubOptions & { onIdleExit?: () => void }): Pro
             );
             throw new Error("serve bridge did not register in time");
           }
-          deadline = Date.now() + budget;
+          deadline = Date.now() + Math.max(1_000, Math.min(budget, TUI_RETRY_BUDGET_MS));
           continue;
         }
         warn(`hub: serve bridge for ${workspacePath} never registered`);

--- a/src/translators/event-translator.ts
+++ b/src/translators/event-translator.ts
@@ -53,6 +53,17 @@ export class EventTranslator {
    */
   private skippingBackgroundTurn = false;
   /**
+   * turnId of the user turn this translator owns (from its `turn.started`).
+   * Backend-internal turns (`session/goal` set, `session/compact`) emit their
+   * own turn.started/turn.completed on the SAME session mid-turn: without
+   * attribution, their turn.completed flipped turnDone and the bridge ended
+   * the user's turn while the backend kept generating (the "ghost completed"
+   * remote-status bug). turnId-less backends keep the old behavior (both ids
+   * must be present for a mismatch to drop an event).
+   */
+  private activeTurnId: string | null = null;
+  private skippingForeignTurn = false;
+  /**
    * Backend message ids (`assistantMessageId`) whose content reached this
    * translator via the live event stream. Used by the turn loop to dedup the
    * turn-completion fallback replay: a message already streamed live must not
@@ -100,6 +111,18 @@ export class EventTranslator {
         return results;
       }
       this.skippingBackgroundTurn = false;
+      const turnId = (payload["turnId"] as string) ?? null;
+      if (!this.turnStarted) {
+        this.activeTurnId = turnId;
+        this.skippingForeignTurn = false;
+      } else if (turnId && this.activeTurnId && turnId !== this.activeTurnId) {
+        // A second, different turn started mid-turn: a backend-internal turn
+        // (goal set / compact). Its events belong to that turn — drop them
+        // until it completes and our own turn's events resume.
+        this.skippingForeignTurn = true;
+        log(`  [event] turn.started (foreign turn ${turnId.slice(-8)}) → skipping its events`);
+        return results;
+      }
       this.turnStarted = true;
       log("  [event] turn.started");
     } else if (this.skippingBackgroundTurn) {
@@ -107,15 +130,43 @@ export class EventTranslator {
       // listener handles it). turn.completed/turn.failed for the bg turn also
       // land here and are intentionally NOT used to set turnDone.
       return results;
+    } else if (etype === "turn.completed" || etype === "turn.failed") {
+      const evTurnId = (payload["turnId"] as string) ?? null;
+      if (this.skippingForeignTurn) {
+        // A turn ended while a foreign (internal) turn was in flight. When it
+        // provably belongs to the foreign turn, drop it and resume normal
+        // processing. When it names OUR turn (the user turn can complete
+        // before the internal one), fall through — swallowing it here would
+        // leave turnDone unset and the turn loop waiting out STALE_FREEZE_MS.
+        this.skippingForeignTurn = false;
+        if (!(evTurnId && this.activeTurnId && evTurnId === this.activeTurnId)) {
+          log(`  [event] ${etype} (foreign turn) → ignored`);
+          return results;
+        }
+      }
+      if (evTurnId && this.activeTurnId && evTurnId !== this.activeTurnId) {
+        log(`  [event] ${etype} (turnId mismatch) → ignored`);
+        return results;
+      }
+      if (etype === "turn.completed") {
+        this.turnDone = true;
+        this.turnResultType = (payload["resultType"] as string) ?? "success";
+        results.push(...this.translateTurnDone(payload));
+        log(`  [event] turn.completed (resultType=${this.turnResultType})`);
+      } else {
+        this.turnDone = true;
+        this.turnFailed = true;
+        this.turnError = (payload["error"] as Record<string, unknown>) ?? {};
+        this.turnResultType = (payload["resultType"] as string) ?? "error";
+        const err = this.turnError;
+        warn(`  [event] turn.failed (code=${err["code"] ?? err["type"] ?? "?"})`);
+      }
+    } else if (this.skippingForeignTurn) {
+      return results;
     } else if (etype === "model.streaming") {
       results.push(...this.translateStreaming(payload));
     } else if (etype === "tool.updated") {
       results.push(...this.translateTool(payload));
-    } else if (etype === "turn.completed") {
-      this.turnDone = true;
-      this.turnResultType = (payload["resultType"] as string) ?? "success";
-      results.push(...this.translateTurnDone(payload));
-      log(`  [event] turn.completed (resultType=${this.turnResultType})`);
     } else if (etype === "session.updated") {
       const usage = (payload["usage"] as Record<string, unknown>) ?? {};
       const used = usage["inputTokens"];
@@ -129,13 +180,6 @@ export class EventTranslator {
       // settings patch — forward the new values so the editor UI follows the
       // switch immediately instead of at the next turn's completion.
       results.push(...this.translateStateUpdated(payload));
-    } else if (etype === "turn.failed") {
-      this.turnDone = true;
-      this.turnFailed = true;
-      this.turnError = (payload["error"] as Record<string, unknown>) ?? {};
-      this.turnResultType = (payload["resultType"] as string) ?? "error";
-      const err = this.turnError;
-      warn(`  [event] turn.failed (code=${err["code"] ?? err["type"] ?? "?"})`);
     }
     return results;
   }
@@ -154,8 +198,7 @@ export class EventTranslator {
     const mode = (patch["mode"] as Record<string, unknown> | undefined)?.current;
     if (typeof mode === "string") ev.mode = mode;
     const model = (patch["model"] as Record<string, unknown> | undefined)?.current as
-      | Record<string, unknown>
-      | undefined;
+      Record<string, unknown> | undefined;
     if (model && typeof model["providerId"] === "string" && typeof model["modelId"] === "string") {
       ev.model = { providerId: model["providerId"], modelId: model["modelId"] };
     }

--- a/tests/event-translator.test.ts
+++ b/tests/event-translator.test.ts
@@ -370,3 +370,66 @@ describe("EventTranslator run_in_background flag threading", () => {
     expect(u.background).toBeUndefined();
   });
 });
+
+describe("EventTranslator foreign internal-turn attribution", () => {
+  it("ignores a goal/compact internal turn started mid-turn (ghost-completed bug)", () => {
+    const t = new EventTranslator();
+    t.translate(ev("turn.started", { turnId: "turn_user" }));
+    // session/goal(set) starts a backend-internal turn on the same session.
+    expect(t.translate(ev("turn.started", { turnId: "turn_goal" }))).toEqual([]);
+    // Its output and terminal event MUST NOT touch this translator's state.
+    expect(t.translate(ev("model.streaming", { kind: "text_delta", delta: "goal ack" }))).toEqual(
+      [],
+    );
+    expect(
+      t.translate(ev("turn.completed", { turnId: "turn_goal", resultType: "success" })),
+    ).toEqual([]);
+    expect(t.turnDone).toBe(false);
+    // The user's own turn completes normally afterwards.
+    t.translate(ev("turn.completed", { turnId: "turn_user", resultType: "success" }));
+    expect(t.turnDone).toBe(true);
+  });
+
+  it("drops a mismatched turn.completed even without a foreign turn.started", () => {
+    const t = new EventTranslator();
+    t.translate(ev("turn.started", { turnId: "turn_user" }));
+    t.translate(ev("turn.completed", { turnId: "turn_other", resultType: "success" }));
+    expect(t.turnDone).toBe(false);
+    t.translate(ev("turn.completed", { turnId: "turn_user", resultType: "success" }));
+    expect(t.turnDone).toBe(true);
+  });
+
+  it("drops a mismatched turn.failed too", () => {
+    const t = new EventTranslator();
+    t.translate(ev("turn.started", { turnId: "turn_user" }));
+    t.translate(ev("turn.failed", { turnId: "turn_goal", error: { code: "x" } }));
+    expect(t.turnFailed).toBe(false);
+    expect(t.turnDone).toBe(false);
+  });
+
+  it("keeps legacy behavior when turnId is absent (old backends)", () => {
+    const t = new EventTranslator();
+    t.translate(ev("turn.started", {}));
+    t.translate(ev("turn.completed", { resultType: "success" }));
+    expect(t.turnDone).toBe(true);
+  });
+
+  it("accepts a turn.completed matching the active turnId", () => {
+    const t = new EventTranslator();
+    t.translate(ev("turn.started", { turnId: "turn_user" }));
+    const out = t.translate(ev("turn.completed", { turnId: "turn_user", resultType: "success" }));
+    expect(t.turnDone).toBe(true);
+    expect(out).toEqual([{ kind: "UsageDelta", used: 0, size: 0 }]);
+  });
+
+  it("processes OUR turn.completed even while a foreign turn is still in flight", () => {
+    const t = new EventTranslator();
+    t.translate(ev("turn.started", { turnId: "turn_user" }));
+    t.translate(ev("turn.started", { turnId: "turn_goal" })); // foreign, skipping
+    // The user turn completes FIRST (goal turn still running) — its terminal
+    // event must NOT be swallowed as foreign, else the turn loop hangs until
+    // the STALE_FREEZE_MS backstop.
+    t.translate(ev("turn.completed", { turnId: "turn_user", resultType: "success" }));
+    expect(t.turnDone).toBe(true);
+  });
+});

--- a/tests/runtime-model.test.ts
+++ b/tests/runtime-model.test.ts
@@ -3,10 +3,11 @@
  *
  * History: loadProviderModels() hardcoded a single builtin provider id, so
  * custom providers configured in the ZCode desktop app never appeared in the
- * dropdown. These tests lock the new behaviour: loadAllModels() aggregates ALL
- * enabled builtin providers PLUS every custom provider (the newer CLI no
- * longer sets `enabled` on third-party providers, so filtering on it would
- * drop them), buildRuntimeModel() inlines apiKey as {source:"inline",value}
+ * dropdown. These tests lock the new behaviour: loadAllModels() aggregates
+ * enabled builtin providers (which must carry a credential — a keyless one is
+ * "未启用" in the desktop, #156) PLUS custom providers that are usable (not
+ * explicitly disabled, and either credentialed or local/keyless-optional),
+ * buildRuntimeModel() inlines apiKey as {source:"inline",value}
  * for third-party providers (the backend resolves model-call auth from the
  * overlay itself; omitting it yields HTTP 401) but omits it for builtins.
  * Builtin models encode as bare modelIds, and third-party models carry their
@@ -17,14 +18,18 @@ import { describe, expect, it, vi } from "vitest";
 
 import { ZCODE_CREDS_PATH } from "../src/utils.js";
 
-/** Fake config.json with one builtin (OAuth, no apiKey) + one custom (apiKey). */
+/**
+ * Fake config.json. Enabled builtins carry their plan token in options.apiKey
+ * (the desktop's own storage shape — a keyless builtin is "未启用" there and
+ * must not reach the IDE dropdown, issue #156).
+ */
 const FAKE_CONFIG = {
   provider: {
     "builtin:primary": {
       name: "Primary",
       kind: "anthropic",
       enabled: true,
-      options: { baseURL: "https://example.test/api" },
+      options: { baseURL: "https://example.test/api", apiKey: "plan-token" },
       models: {
         "model-a": { limit: { context: 1000000 } },
         "model-b": { limit: { context: 200000 } },
@@ -36,6 +41,13 @@ const FAKE_CONFIG = {
       enabled: false,
       options: { baseURL: "https://example.test/api2" },
       models: { "model-a": { limit: { context: 1000000 } } },
+    },
+    "builtin:bigmodel": {
+      name: "BigModel",
+      kind: "anthropic",
+      enabled: true,
+      options: { baseURL: "https://open.bigmodel.cn/api/anthropic" },
+      models: { "bg-1": { limit: { context: 128000 } } },
     },
     "custom-provider-alpha": {
       name: "Alpha",
@@ -65,15 +77,39 @@ const FAKE_CONFIG = {
       options: { apiKey: "test-key-gamma", baseURL: "http://127.0.0.1:8001/v1" },
       models: { "gamma-1": { limit: { context: 200000 } } },
     },
+    "custom-provider-remote-keyless": {
+      name: "RemoteKeyless",
+      kind: "anthropic",
+      source: "custom",
+      options: { baseURL: "https://api.example.test/v1" },
+      models: { "rk-1": { limit: { context: 200000 } } },
+    },
+    "custom-provider-required-keyless": {
+      name: "RequiredKeyless",
+      kind: "anthropic",
+      source: "custom",
+      options: { apiKeyRequired: true, baseURL: "https://api2.example.test/v1" },
+      models: { "req-1": { limit: { context: 200000 } } },
+    },
+    "custom-provider-local": {
+      name: "LocalLlama",
+      kind: "openai-compatible",
+      source: "custom",
+      options: { baseURL: "http://127.0.0.1:8080/v1" },
+      models: { "llama-x": { limit: { context: 32000 } } },
+    },
   },
 };
+
+/** Swapped by tests that need a different config.json (see #156 fallback). */
+let fakeConfig: unknown = FAKE_CONFIG;
 
 vi.mock("node:fs", async () => {
   const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
   return {
     ...actual,
     readFileSync: (p: string) => {
-      if (p === ZCODE_CREDS_PATH) return JSON.stringify(FAKE_CONFIG);
+      if (p === ZCODE_CREDS_PATH) return JSON.stringify(fakeConfig);
       return actual.readFileSync(p);
     },
   };
@@ -102,6 +138,44 @@ describe("loadAllModels", () => {
     expect(ids).toContain("beta-1");
     // gamma-1 (custom with an EXPLICIT enabled:false) is excluded.
     expect(ids).not.toContain("gamma-1");
+  });
+
+  it("excludes providers the desktop marks 未启用 for missing credentials (#156)", () => {
+    const ids = loadAllModels().map((m) => m.modelId);
+    // Keyless builtin (API-key mode picked, no key entered) — excluded even
+    // though enabled:true; it can never authenticate.
+    expect(ids).not.toContain("bg-1");
+    // Keyless REMOTE custom provider — no credentials, remote baseURL.
+    expect(ids).not.toContain("rk-1");
+    // apiKeyRequired:true without a key — explicitly unusable.
+    expect(ids).not.toContain("req-1");
+    // Keyless LOCAL provider (llama.cpp/ollama style) stays selectable.
+    expect(ids).toContain("llama-x");
+    // The credentialed builtin is still there.
+    expect(ids).toContain("model-a");
+  });
+
+  it("returns [] when every configured provider is unusable (no default leak, #156)", () => {
+    // Review finding: the old empty-list fallback re-advertised the very
+    // unusable provider (or one absent from the user's config). With
+    // providers configured, [] is the honest answer; the default fallback
+    // applies only to a fresh install with NO provider map.
+    fakeConfig = {
+      provider: {
+        "builtin:zai-coding-plan": {
+          name: "ZAI",
+          kind: "anthropic",
+          enabled: true,
+          options: { apiKeyRequired: true, baseURL: "https://api.z.ai/api" },
+          models: { "GLM-5.3": {} },
+        },
+      },
+    };
+    try {
+      expect(loadAllModels()).toEqual([]);
+    } finally {
+      fakeConfig = FAKE_CONFIG;
+    }
   });
 
   it("tracks provider identity for every custom provider", () => {

--- a/tests/set-mode-alias.test.ts
+++ b/tests/set-mode-alias.test.ts
@@ -23,7 +23,7 @@ const FAKE_CONFIG = {
       name: "GLM Coding Plan",
       kind: "anthropic",
       enabled: true,
-      options: { baseURL: "https://example.test/api" },
+      options: { baseURL: "https://example.test/api", apiKey: "plan-token" },
       models: {
         "GLM-5.3": { limit: { context: 1000000 }, reasoning: { variants: ["low", "high", "max"] } },
       },
@@ -114,7 +114,10 @@ describe("setMode param normalization", () => {
     const { cx, sent } = mockContext();
     await setMode(server, { sessionId: "sess_acp", modeId: "build" }, cx);
     const modeUpdate = sent.find((u) => u.sessionUpdate === "current_mode_update");
-    expect(modeUpdate).toMatchObject({ sessionUpdate: "current_mode_update", currentModeId: "build" });
+    expect(modeUpdate).toMatchObject({
+      sessionUpdate: "current_mode_update",
+      currentModeId: "build",
+    });
   });
 
   it("missing both mode and modeId is rejected", async () => {


### PR DESCRIPTION
Three fixes:

- **goal "ghost completed" bug**: `session/goal(set)` starts a backend-internal AI turn on the same session whose `turn.completed` flipped `turnDone` in the running turn loop — the bridge ended the user's turn early (remote clients saw the session "completed", live push dead) while the backend kept generating; new messages only appeared on replay. `EventTranslator` now attributes turn.started/completed by turnId and skips foreign (internal) turns entirely; turnId-less backends keep legacy behavior.
- **#156**: keyless / 未启用 providers (builtin API-key mode with no key, keyless remote custom providers) leaked into the ACP IDE model dropdown. `loadAllModels` now requires builtin providers to carry a credential and custom providers to be usable (key, `apiKeyRequired:false`, or local baseURL); the default fallback applies only to a fresh install so it cannot re-advertise the unusable provider.
- **remote session-create fallback stall**: per-terminal registration budget 20s → 10s, fallback preferences and headless rescue 5s.

Verified: typecheck, lint, full suite (1054 tests) green; review findings addressed (foreign-flag clear now turnId-aware; no default leak on all-unusable configs).