### PR TITLE
fix(acp): per-kind replay dedup so GLM thinking reaches the client

### DIFF
--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -2824,12 +2824,16 @@ export async function runEventTurn(
       const snapshot = await buildSnapshot(server, turn.zcodeSid);
       const completionEvents = differ.diff(snapshot);
       for (const iev of completionEvents) {
-        if (
-          (iev.kind === "TextDelta" || iev.kind === "ReasoningDelta") &&
-          iev.messageId &&
-          translator.deliveredMessageIds.has(iev.messageId)
-        ) {
-          continue;
+        // Per-kind dedup (see deliveredReasoningMessageIds): text and reasoning
+        // share one assistant message id, so the kind that streamed live must
+        // be suppressed while the other kind — typically GLM reasoning that
+        // only exists in the completion snapshot — must still go through.
+        if (iev.kind === "TextDelta" || iev.kind === "ReasoningDelta") {
+          const delivered =
+            iev.kind === "TextDelta"
+              ? translator.deliveredMessageIds
+              : translator.deliveredReasoningMessageIds;
+          if (iev.messageId && delivered.has(iev.messageId)) continue;
         }
         await dispatchEvent(server, cx, acpSid, iev, chunkMsgId);
       }

--- a/src/translators/event-translator.ts
+++ b/src/translators/event-translator.ts
@@ -64,14 +64,26 @@ export class EventTranslator {
   private activeTurnId: string | null = null;
   private skippingForeignTurn = false;
   /**
-   * Backend message ids (`assistantMessageId`) whose content reached this
+   * Backend message ids (`assistantMessageId`) whose TEXT reached this
    * translator via the live event stream. Used by the turn loop to dedup the
    * turn-completion fallback replay: a message already streamed live must not
    * be re-emitted by `ProjectionDiffer.diff()`, while messages produced while
    * no listener was attached (e.g. a backend turn resumed after compaction)
    * have no live deltas and must be replayed.
+   *
+   * TEXT-only by contract. Text and reasoning share one assistant message id
+   * (the differ tags both replays with `m.info.id`), and GLM-style backends
+   * stream the text live while the CoT reaches us only via the completion
+   * snapshot — a shared set would let the streamed text suppress the reasoning
+   * replay entirely.
    */
   readonly deliveredMessageIds = new Set<string>();
+  /**
+   * Same contract as `deliveredMessageIds`, for REASONING content. Kept
+   * separate so live-streamed reasoning never suppresses the differ's
+   * reasoning replay (and vice versa: streamed text must not).
+   */
+  readonly deliveredReasoningMessageIds = new Set<string>();
 
   /** Tool call ids we've already emitted a ToolCallNew for. */
   readonly seenToolIds = new Set<string>();
@@ -213,9 +225,15 @@ export class EventTranslator {
     const delta = (payload["delta"] as string) ?? "";
     // Record the owning assistant message so the turn loop can distinguish
     // "already streamed live" from "produced while no listener was attached"
-    // when replaying missing content at turn completion.
+    // when replaying missing content at turn completion. Per-content-kind:
+    // text and reasoning share one assistantMessageId, and the completion
+    // replay must stay able to deliver the kind that did NOT stream live
+    // (GLM: text streams, reasoning arrives only via the snapshot).
     const msgId = payload["assistantMessageId"];
-    if (typeof msgId === "string" && msgId) this.deliveredMessageIds.add(msgId);
+    if (typeof msgId === "string" && msgId) {
+      if (kind === "reasoning_delta") this.deliveredReasoningMessageIds.add(msgId);
+      else if (kind === "text_delta") this.deliveredMessageIds.add(msgId);
+    }
 
     if (kind === "text_delta") {
       if (delta) results.push({ kind: "TextDelta", text: delta });

--- a/tests/turn-attribution.test.ts
+++ b/tests/turn-attribution.test.ts
@@ -128,6 +128,16 @@ describe("turn-completion replay: re-emit text never streamed live, dedup by mes
     expect(t.deliveredMessageIds.has("msg_live_1")).toBe(true);
   });
 
+  it("translator records live reasoning per-kind, not into the text set", () => {
+    const t = new EventTranslator();
+    t.translate({
+      type: "model.streaming",
+      payload: { kind: "reasoning_delta", delta: "live reasoning", assistantMessageId: "msg_live_1" },
+    });
+    expect(t.deliveredReasoningMessageIds.has("msg_live_1")).toBe(true);
+    expect(t.deliveredMessageIds.has("msg_live_1")).toBe(false);
+  });
+
   it("streamed-then-replayed messages are skipped, missing ones are kept", () => {
     // Baseline: a message the differ has seen is never re-emitted.
     const differ = new ProjectionDiffer();
@@ -142,20 +152,48 @@ describe("turn-completion replay: re-emit text never streamed live, dedup by mes
     });
 
     // Turn-loop side of the dedup (mirrors runEventTurn): skip deltas whose
-    // message id was already delivered via the event stream.
+    // message id was already delivered via the event stream, per content kind.
     const translator = new EventTranslator();
     translator.deliveredMessageIds.add("msg_live_1");
-    const replayed = events.filter(
-      (e) =>
-        !(
-          (e.kind === "TextDelta" || e.kind === "ReasoningDelta") &&
-          e.messageId &&
-          translator.deliveredMessageIds.has(e.messageId)
-        ),
-    );
+    const replayed = events.filter((e) => {
+      if (e.kind !== "TextDelta" && e.kind !== "ReasoningDelta") return true;
+      const delivered =
+        e.kind === "TextDelta" ? translator.deliveredMessageIds : translator.deliveredReasoningMessageIds;
+      return !(e.messageId && delivered.has(e.messageId));
+    });
     const texts = replayed.filter((e) => e.kind === "TextDelta");
     expect(texts).toHaveLength(1);
     expect(texts[0]).toMatchObject({ kind: "TextDelta", messageId: "msg_missing_2" });
+  });
+
+  it("live-streamed text must not suppress the reasoning replay of the same message (GLM CoT)", () => {
+    // GLM-style backends stream the answer's text_delta live (assistantMessageId
+    // X) but deliver the CoT only via the completion snapshot as a reasoning
+    // part of the SAME message X. The old shared deliveredMessageIds dedup
+    // dropped that reasoning replay — thinking never reached the client.
+    const differ = new ProjectionDiffer();
+    const events = differ.diff({
+      projection: { status: "idle" },
+      messages: [assistantMsg("msg_x", "the answer", "the chain of thought")],
+    });
+
+    const translator = new EventTranslator();
+    translator.translate({
+      type: "model.streaming",
+      payload: { kind: "text_delta", delta: "the an", assistantMessageId: "msg_x" },
+    });
+
+    const replayed = events.filter((e) => {
+      if (e.kind !== "TextDelta" && e.kind !== "ReasoningDelta") return true;
+      const delivered =
+        e.kind === "TextDelta" ? translator.deliveredMessageIds : translator.deliveredReasoningMessageIds;
+      return !(e.messageId && delivered.has(e.messageId));
+    });
+
+    const reasoning = replayed.find((e) => e.kind === "ReasoningDelta");
+    expect(reasoning).toMatchObject({ kind: "ReasoningDelta", text: "the chain of thought", messageId: "msg_x" });
+    // And the already-streamed text must still be deduped.
+    expect(replayed.find((e) => e.kind === "TextDelta")).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Problem

When ZCode runs GLM-style models behind editors via ACP (found with Lody), the model's thinking never reaches the client — no `agent_thought_chunk` with real content is ever delivered, on any editor.

## Root cause

An assistant message carries **both** its reasoning part and its text part under **one** `assistantMessageId` (verified against the backend sqlite: `msg_x` owns both `reasoning` and `text`). Two facts combine into the bug:

1. For GLM-style backends the CoT is not streamed live (`model.streaming` stays silent during CoT — the reason the thinking-placeholder hint exists); the reasoning only exists in the completion snapshot as a message part.
2. `translateStreaming()` recorded the assistantMessageId in the shared `deliveredMessageIds` set for *any* streamed delta — so as soon as the answer's `text_delta`s flowed, the message was marked delivered. The turn-completion replay then emitted `ReasoningDelta(messageId=X)`, and the dedup filter dropped it because `X ∈ deliveredMessageIds`.

Net effect: reasoning is never streamed live *and* the replay that should have recovered it at turn completion is filtered out — thinking is silently discarded on every turn. (`registerFetchedReply`'s doc comment already promised "Reasoning is NOT registered … so the replay dispatching it is pure gain", but the shared set defeated exactly that.)

## Fix

Track delivered ids **per content kind**:

- `text_delta` / `fetchLastReply` → `deliveredMessageIds` (unchanged semantics)
- `reasoning_delta` → new `deliveredReasoningMessageIds`
- completion filter checks the set matching the replayed event kind

Streamed text still dedups as before; the reasoning replay now flows through and is dispatched as `agent_thought_chunk` (`thought_<chunkMsgId>`), which ACP editors already render (Zed/JetBrains/… and Lody both map it to their thinking block).

## Verification

- `tsc --noEmit` clean; full suite green: **77 files / 1066 tests**, including a new regression test reproducing the GLM scenario (live text stream on message X + completion snapshot reasoning on the same X → ReasoningDelta must survive, TextDelta must dedup).
- End-to-end against a real backend (GLM-5.3): thought chunks arrive at the ACP client — placeholder hint followed by the full reasoning text, byte-identical to the backend's stored reasoning part.